### PR TITLE
Add git switch, restore, rm, mv and tag verbs

### DIFF
--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -180,6 +180,26 @@ serve, and inventing a name would put an unreviewed one into history.
   the blob, and this build refuses and names the path instead. Same
   trade as the staged-change refusal above: no reflog here means a
   silent discard cannot be undone, and a refusal can be acted on.
+- **The same split applies to a directory standing on the name itself**,
+  not only above it. A directory holding untracked files is refused and
+  named (`Updating the following directories would lose untracked files
+  in them`); one holding nothing but ignored files is removed whole and
+  the target's file written in its place, since `--overwrite-ignore` is
+  git's default and the refusal is about untracked content rather than
+  about the directory.
+- **A tree entry's executable bit is restored with its content.** git
+  records exactly one permission bit and puts it back in both
+  directions, so `chmod -x` on a `100755` path and `chmod +x` on a
+  `100644` one are both modifications that `restore` and `switch` undo.
+  The mode is written unconditionally rather than probed first: deciding
+  costs the same op as setting, and the backends a repository is served
+  from apply it natively.
+- **An unborn branch is not a branch you can be on.** A fresh
+  repository's HEAD names one that has never been written, and
+  `switch <that name>` is `fatal: invalid reference: <name>` rather than
+  `Already on`, because there is no commit to be on; `switch -c <new>`
+  stays the one line an unborn HEAD accepts. `checkout` answers the same
+  line differently, as git does, through its pathspec fallback.
 - **A move never crosses a mount boundary**, at either end. The rename op
   binds to the backend serving the source, so a destination another mount
   serves would be written into the source's backend at a path it does not

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -116,14 +116,14 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
 | `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
-| `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}` and `HEAD:a.txt` included; `-d`, `-f`; a creation option needs a name |
+| `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included; `-d`, `-f`; a creation option needs a name |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -148,6 +148,14 @@ serve, and inventing a name would put an unreviewed one into history.
   path and refuse first. Creating a branch where HEAD already is
   (`switch -c topic`, no start point) moves nothing and is allowed, which
   is git's own reading of the line.
+- **A branch with no commit is a name and nothing else.** `switch -c topic`
+  before the first commit repoints HEAD and writes neither a ref nor a
+  reflog line, which is how git leaves an unborn branch too. Naming a
+  start point there is a different line and stays unresolvable.
+- **`^{tag}` stops above the commit.** Every other peel type sits at or
+  below it, so an annotated tag is unwrapped on the way; `v1^{tag}` is
+  the one spelling that names the tag object itself, and a lightweight
+  tag has none to stop at.
 - **A move never crosses a mount boundary**, at either end. The rename op
   binds to the backend serving the source, so a destination another mount
   serves would be written into the source's backend at a path it does not

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -118,7 +118,7 @@ git -C /repo tag -d v1.0
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
 | `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents |
 | `rm`       | refuses a path with uncommitted work unless `-f`, a path a symlinked ancestor now hides included; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
+| `mv`       | files and directories, `-f` over an existing file and over the conflict stages it was holding, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere as a source, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch; a name whose ref path another branch already holds is refused                             |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
@@ -293,12 +293,26 @@ serve, and inventing a name would put an unreviewed one into history.
   no branch ever recorded and then remove its root. The mount table is
   asked first and the verb refuses, naming the mount when the session
   may be told about it and saying only that one is there when it may
-  not. The same boundary stops the tidying pass that drops a directory
-  emptied by `rm`: it halts at the mount root rather than removing it,
-  since nothing the caller asked for has failed. This is the rule
-  `MountRootPolicy` already applies to `rm` and `mv` at the command
-  tier, which a git verb reaching the dispatcher directly has to ask for
-  itself.
+  not. **Every destination is asked before the first one is written**,
+  which is what the other collision checks already do and what keeps
+  the refusal from landing halfway: a `switch` that had written an
+  earlier path would leave the working tree on the target's content
+  with HEAD and the index still on the branch being left, and
+  `restore -SW` stages before it writes, so a refusal in the second
+  pass would move the index and nothing else. The same boundary stops
+  the tidying pass that drops a directory emptied by `rm`: it halts at
+  the mount root rather than removing it, since nothing the caller
+  asked for has failed. This is the rule `MountRootPolicy` already
+  applies to `rm` and `mv` at the command tier, which a git verb
+  reaching the dispatcher directly has to ask for itself.
+- **`mv -f` onto an unmerged path takes its stages with it.** `-f` is
+  the only way to reach a destination that already exists, and git's
+  answer there is one stage-0 entry holding the source: `ls-files -u` is
+  empty afterwards. Leaving the stages behind is the worse divergence
+  rather than the smaller one, since the index writer lays them back
+  over the entry and the blob that just moved is the copy that
+  disappears. An unmerged *source* still moves nowhere, and a plain `mv`
+  onto an occupied destination is still the ordinary refusal.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -118,12 +118,12 @@ git -C /repo tag -d v1.0
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
 | `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` names the tree, and a path it lacks is removed from the target        |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`                                      |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed                                                                              |
-| `switch`   | the same move for a branch only; `-c` creates, `--detach` is the only way onto a bare commit                                            |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; `-d`, `-f`                          |
+| `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; `-d`, `-f`; a creation option needs a name |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -139,7 +139,8 @@ serve, and inventing a name would put an unreviewed one into history.
   build writes but does not read back.
 - **`tag -a` needs `-m`**, for the reason `commit` does: there is no
   editor to open. `mv` prints only its two usage lines for a missing
-  operand, not git's option table.
+  operand, and `tag` prints only the synopsis lines for the options this
+  build has, neither of them git's full option table.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -116,14 +116,14 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` names the tree, and a path it lacks is removed from the target        |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, and a path it lacks is removed from the target   |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, and an unmerged path moves nowhere |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed                                                                              |
-| `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; `-d`, `-f`; a creation option needs a name |
+| `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target; `-d`, `-f`; a creation option needs a name |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -117,13 +117,13 @@ git -C /repo tag -d v1.0
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
 | `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents |
-| `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
+| `rm`       | refuses a path with uncommitted work unless `-f`, a path a symlinked ancestor now hides included; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
 | `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch; a name whose ref path another branch already holds is refused                             |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt`, `v1^{tag}` and `v1^{object}` included, and the type recorded is the one the target really is; a name whose ref path another tag already holds is refused; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`, where `-n-1` says nothing at all and any count below it is refused; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt`, `v1^{tag}` and `v1^{object}` included, and the type recorded is the one the target really is; a name whose ref path another tag already holds is refused; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -268,6 +268,37 @@ serve, and inventing a name would put an unreviewed one into history.
   the transaction at all. The one divergence is the wording of the
   `-l`/`-d` refusal: git names the two options in the order they were
   typed and in the spelling used, where this build has one fixed order.
+- **`tag -n-1` is not a `-n` at all.** git's option parser starts the
+  count at -1 to mean "never given", so the sentinel reaches the verb
+  looking like an absent flag: `tag -d -n-1 v` deletes and
+  `tag -n-1 -a v -m m` creates, where either line with a real `-n`
+  refuses. Anything below -1 is a count, and a count has to be positive:
+  the refusal names the format field git was building
+  (`positive value expected contents:lines=-2`) rather than the option,
+  because that is where git discovers it, which is also why it fires in
+  a repository holding no tags and why `-d -n-2` still dies on the
+  list-mode refusal first.
+- **A symlinked ancestor hides a tracked file from the walk, not from
+  `rm`.** git's own diff refuses to follow a link in a leading path and
+  reports the file deleted, which is why `status` shows `D` for it; `rm`
+  lstats instead, and that lstat resolves the link and finds whatever
+  lies at the other end. So a tracked `slot/child` behind
+  `slot -> /elsewhere` is a local modification and is refused without
+  `-f`, even when the file at the other end is byte for byte the same
+  one: two files agreeing is still two files. A link pointing past the
+  name entirely leaves nothing to lose, and the removal goes through.
+- **A nested mount stops a working-tree removal.** Replacing a directory
+  with a file takes the whole directory, and `readdir` merges a mount
+  nested inside it into the listing, so the walk would empty a backend
+  no branch ever recorded and then remove its root. The mount table is
+  asked first and the verb refuses, naming the mount when the session
+  may be told about it and saying only that one is there when it may
+  not. The same boundary stops the tidying pass that drops a directory
+  emptied by `rm`: it halts at the mount root rather than removing it,
+  since nothing the caller asked for has failed. This is the rule
+  `MountRootPolicy` already applies to `rm` and `mv` at the command
+  tier, which a git verb reaching the dispatcher directly has to ask for
+  itself.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -118,12 +118,12 @@ git -C /repo tag -d v1.0
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
 | `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
-| `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
+| `branch`   | `-d` deletes a merged branch, `-D` any branch; a name whose ref path another branch already holds is refused                             |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included, and the type recorded is the one the target really is; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt`, `v1^{tag}` and `v1^{object}` included, and the type recorded is the one the target really is; a name whose ref path another tag already holds is refused; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -156,6 +156,11 @@ serve, and inventing a name would put an unreviewed one into history.
   below it, so an annotated tag is unwrapped on the way; `v1^{tag}` is
   the one spelling that names the tag object itself, and a lightweight
   tag has none to stop at.
+- **`^{object}` peels nothing.** It is an existence check rather than a
+  type, so it hands back whatever the name resolved to and an annotated
+  tag stays a tag where `^{}` would unwrap it. Every object reports a
+  concrete type, so reading `object` as one refused every expression
+  that spelled it.
 - **A bare object id names that exact object.** Every other spelling of a
   revision is a commit-ish reading that unwraps an annotated tag, so
   `restore --source=v1` reads a tree; an id does not, which is how
@@ -180,6 +185,34 @@ serve, and inventing a name would put an unreviewed one into history.
   the blob, and this build refuses and names the path instead. Same
   trade as the staged-change refusal above: no reflog here means a
   silent discard cannot be undone, and a refusal can be acted on.
+- **The divergence runs both ways round the same collision.** A staged
+  path *inside* a directory the target replaces with a file is refused
+  and named too. git succeeds there as well, removing the directory and
+  dropping the staged entry, which would otherwise leave an index
+  holding both `slot` and `slot/child`: a shape git's own index has no
+  room for. The two halves are one decision, so neither is quietly
+  more permissive than the other.
+- **A directory is replaced without following a link out of it.** A
+  listing dereferences, so a link to a directory lists that directory's
+  contents; walking them would delete a tree no branch named. The name
+  plane is asked for each child, and a link is unlinked where a
+  directory is descended into, which is what `rm -r` does too.
+- **Two refs cannot hold one path.** A ref is a file below `.git`, so
+  `foo` and `foo/bar` cannot both exist, in `refs/tags/` or in
+  `refs/heads/`. Creating either over the other is refused with git's
+  own lock wording and exit 128, before the working tree moves, and
+  `-f` does not help because the obstacle is the path rather than the
+  value. Left to the mount, a disk backend raised its host's error and
+  a prefix store took both keys and left a ref the loose-ref walk could
+  not find.
+- **`mv` refuses a directory and something inside it**, whatever order
+  the line puts them in and whether or not `-k` is given. The check
+  reads the whole line once every source has passed its own, so a
+  source with a fault of its own and a same-target collision are both
+  reported first, and a source `-k` already skipped is out of the
+  comparison. `-k` cannot apply here: moving the directory is what
+  makes the other source disappear, so skipping the second move would
+  leave the first one applied and unstaged.
 - **The same split applies to a directory standing on the name itself**,
   not only above it. A directory holding untracked files is refused and
   named (`Updating the following directories would lose untracked files

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -116,7 +116,7 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents, and a gitlink keeps whatever working tree it has |
 | `rm`       | refuses a path with uncommitted work unless `-f`, a path a symlinked ancestor now hides included; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
 | `mv`       | files and directories, `-f` over an existing file and over the conflict stages it was holding, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere as a source, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
@@ -313,6 +313,29 @@ serve, and inventing a name would put an unreviewed one into history.
   over the entry and the blob that just moved is the copy that
   disappears. An unmerged *source* still moves nowhere, and a plain `mv`
   onto an occupied destination is still the ordinary refusal.
+- **An ancestry suffix is only `~` and `^`.** Every other character
+  used to count as another first-parent hop, so `HEAD^x` resolved to
+  `HEAD^^` and `git tag release HEAD^x` wrote the tag at a commit
+  nobody named. The whole expression is refused now, which is git's own
+  answer, and `main~٣` goes with it: the count scans ASCII digits, so
+  what a unicode digit leaves behind is not a step either. The wording
+  follows the verb, since git's does: `tag` says
+  `Failed to resolve '<rev>' as a valid ref.` and `log` and `show` say
+  `ambiguous argument '<rev>'`. `HEAD^0`, `HEAD^~` and `HEAD~2^2~1` are
+  steps git takes and still parse.
+- **A gitlink is a directory placeholder, not a blob.** A `160000`
+  entry names a commit in another repository, which this one does not
+  hold, so reading it as content is either a miss or, when the id does
+  happen to resolve here, an empty string written over the whole
+  directory. git checks out no submodule content at all without
+  `--recurse-submodules`; all the entry asks of the working tree is
+  that a directory stand at the name, so an existing one is left
+  exactly as it is with its untracked work, a regular file or a link is
+  replaced by an empty directory, and a missing one is created. Nothing
+  else about a submodule is supported: `status` still reads the
+  directory as an ordinary untracked one, which is why a branch switch
+  onto a gitlink the current branch also carries is refused before it
+  gets this far.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -98,15 +98,32 @@ git -C /repo branch topic
 git -C /repo branch -d topic
 git -C /repo branch -D topic
 git -C /repo checkout topic
+git -C /repo switch topic
+git -C /repo switch -c feature HEAD~1
+git -C /repo switch --detach HEAD~1
+git -C /repo restore src/main.py
+git -C /repo restore --staged src/main.py
+git -C /repo restore --source HEAD~1 -SW src/main.py
+git -C /repo rm old.py
+git -C /repo rm -r --cached build
+git -C /repo mv src/old.py src/new.py
+git -C /repo tag v1.0
+git -C /repo tag -a v1.1 -m "release"
+git -C /repo tag -d v1.0
 ```
 
-| Verb       | Notes                                                            |
-| ---------- | ---------------------------------------------------------------- |
-| `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path |
-| `reset`    | mixed only, from HEAD; a pathspec limits it to those paths        |
-| `commit`   | `-m` required, `--author "Name <email>"` optional                 |
-| `branch`   | `-d` deletes a merged branch, `-D` any branch                     |
-| `checkout` | refuses rather than overwrite work you have not committed         |
+| Verb       | Notes                                                                                                                                  |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
+| `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` names the tree, and a path it lacks is removed from the target        |
+| `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`                                      |
+| `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
+| `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
+| `checkout` | refuses rather than overwrite work you have not committed                                                                              |
+| `switch`   | the same move for a branch only; `-c` creates, `--detach` is the only way onto a bare commit                                            |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; `-d`, `-f`                          |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -116,7 +133,13 @@ serve, and inventing a name would put an unreviewed one into history.
 
 - **No network verbs.** `clone`, `fetch`, `pull` and `push` are absent.
 - **No `reset --hard`.** It destroys uncommitted work with no reflog here
-  to recover it from.
+  to recover it from. `rm` and `restore` are the way to discard a file's
+  changes on purpose, and `rm` refuses unless `-f` says so.
+- **No `switch -`.** The previous branch lives in the reflog, which this
+  build writes but does not read back.
+- **`tag -a` needs `-m`**, for the reason `commit` does: there is no
+  editor to open. `mv` prints only its two usage lines for a missing
+  operand, not git's option table.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -121,7 +121,7 @@ git -C /repo tag -d v1.0
 | `mv`       | files and directories, `-f` over an existing file and over the conflict stages it was holding, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere as a source, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch; a name whose ref path another branch already holds is refused                             |
-| `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
+| `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too, the branch HEAD already names included, since moving nothing is not the same as having nothing to check |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
 | `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`, where `-n-1` says nothing at all and any count below it is refused; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt`, `v1^{tag}` and `v1^{object}` included, and the type recorded is the one the target really is; a name whose ref path another tag already holds is refused; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
 
@@ -331,11 +331,15 @@ serve, and inventing a name would put an unreviewed one into history.
   `--recurse-submodules`; all the entry asks of the working tree is
   that a directory stand at the name, so an existing one is left
   exactly as it is with its untracked work, a regular file or a link is
-  replaced by an empty directory, and a missing one is created. Nothing
-  else about a submodule is supported: `status` still reads the
-  directory as an ordinary untracked one, which is why a branch switch
-  onto a gitlink the current branch also carries is refused before it
-  gets this far.
+  replaced by an empty directory, and a missing one is created. What is
+  under the name is never touched either: a tracked child the restored
+  source drops loses its index entry and keeps its working-tree copy,
+  and a directory full of untracked files is what the entry asked for
+  rather than a collision, where an untracked *file* at the name still
+  refuses. Nothing else about a submodule is supported: `status` still
+  reads the directory as an ordinary untracked one, which is why a
+  branch switch onto a gitlink the current branch also carries is
+  refused before it gets this far.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -152,6 +152,13 @@ serve, and inventing a name would put an unreviewed one into history.
   before the first commit repoints HEAD and writes neither a ref nor a
   reflog line, which is how git leaves an unborn branch too. Naming a
   start point there is a different line and stays unresolvable.
+- **A revision is read left to right.** `~n`, `^n` and `^{<type>}` are
+  operators applied in the order they are written, so `HEAD^{commit}~1`
+  is HEAD's parent, `HEAD~1^{tree}` is that parent's tree, and the two
+  chain further (`HEAD^{commit}~1^{tree}`). A peel was read as a
+  trailing thing until this round, so every chain that went on after one
+  was refused although git takes it. A step off something with no
+  parents is still refused, which is what `HEAD^{tree}~1` is.
 - **`^{tag}` stops above the commit.** Every other peel type sits at or
   below it, so an annotated tag is unwrapped on the way; `v1^{tag}` is
   the one spelling that names the tag object itself, and a lightweight
@@ -336,10 +343,18 @@ serve, and inventing a name would put an unreviewed one into history.
   source drops loses its index entry and keeps its working-tree copy,
   and a directory full of untracked files is what the entry asked for
   rather than a collision, where an untracked *file* at the name still
-  refuses. Nothing else about a submodule is supported: `status` still
-  reads the directory as an ordinary untracked one, which is why a
-  branch switch onto a gitlink the current branch also carries is
-  refused before it gets this far.
+  refuses. Taking the entry away is an `rmdir` rather than an unlink,
+  and it warns rather than failing: an empty directory goes, one that
+  still holds anything stays with
+  `warning: unable to rmdir '<name>': Directory not empty`, a file or a
+  link at the name is the `Not a directory` wording of the same line,
+  and the switch or restore succeeds either way. A gitlink is also
+  invisible to the unstaged comparison, because the submodule's own HEAD
+  is what git compares and this build cannot read it: reporting the
+  directory as a deleted file is worse than saying nothing, and it
+  refused every branch switch away from a submodule. What is left of the
+  divergence is the untracked side: files inside a submodule's directory
+  are still listed as untracked, where git says nothing about them.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -116,9 +116,9 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, a path it lacks is removed from the target, and a path still in conflict is named rather than half-restored |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a directory holding a mount is refused rather than half-moved |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
@@ -148,6 +148,17 @@ serve, and inventing a name would put an unreviewed one into history.
   path and refuse first. Creating a branch where HEAD already is
   (`switch -c topic`, no start point) moves nothing and is allowed, which
   is git's own reading of the line.
+- **A move never crosses a mount boundary**, at either end. The rename op
+  binds to the backend serving the source, so a destination another mount
+  serves would be written into the source's backend at a path it does not
+  own: the file lands hidden behind that mount while the index names the
+  new path. A source that is a mount root, or holds one, is refused for
+  the same reason one level up.
+- **A rename onto a directory the namespace has filled is `ENOTEMPTY`.**
+  A symlink is namespace state no backend can see, so a destination the
+  backend reads as empty can still hold one, and replacing it would
+  delete the link with it. The merged view decides, which is what POSIX
+  promises.
 - **`tag -a` needs `-m`**, for the reason `commit` does: there is no
   editor to open. `mv` prints only its two usage lines for a missing
   operand, and `tag` prints only the synopsis lines for the options this

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -116,14 +116,14 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, and a path it lacks is removed from the target   |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, a path it lacks is removed from the target, and a path still in conflict is named rather than half-restored |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
 | `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a directory holding a mount is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
-| `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included                     |
+| `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target; `-d`, `-f`; a creation option needs a name |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}` and `HEAD:a.txt` included; `-d`, `-f`; a creation option needs a name |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -142,6 +142,12 @@ serve, and inventing a name would put an unreviewed one into history.
   changes on purpose, and `rm` refuses unless `-f` says so.
 - **No `switch -`.** The previous branch lives in the reflog, which this
   build writes but does not read back.
+- **An unmerged index stops a branch move.** Every collision check reads
+  stage 0, so a path held only as conflict stages would be carried past
+  all of them and then cleared. `switch` and `checkout` name each such
+  path and refuse first. Creating a branch where HEAD already is
+  (`switch -c topic`, no start point) moves nothing and is allowed, which
+  is git's own reading of the line.
 - **`tag -a` needs `-m`**, for the reason `commit` does: there is no
   editor to open. `mv` prints only its two usage lines for a missing
   operand, and `tag` prints only the synopsis lines for the options this

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -161,12 +161,25 @@ serve, and inventing a name would put an unreviewed one into history.
   `restore --source=v1` reads a tree; an id does not, which is how
   `git tag nested <tag-id>` records the nested tag git itself warns
   about rather than quietly flattening it.
-- **A path is only a way through while every parent is a directory.** A
-  symlink standing on one is not: `restore` replaces it with the
-  directory the entry needs rather than writing through it, and removes
-  nothing through it in the other direction, so the tree the link
-  pointed at is never touched by a path that only looked like it led
-  there.
+- **A path is only a way through while every parent is a directory.**
+  Anything else standing on one is not, whatever kind it is: a symlink,
+  a regular file, tracked or not. The two directions differ and both are
+  git's. Writing an entry *replaces* what stands above it with the
+  directory the entry needs, so `restore` and `switch` both land the
+  blob where the branch says and leave a link's target tree, a path no
+  branch named, untouched. Removing an entry does nothing at all,
+  because the path never led there. The checks are one helper, so a
+  third caller inherits both halves rather than re-deriving one.
+- **A switch replaces an ignored parent and refuses an uncommitted
+  one.** The untracked case git refuses by name, and that is unchanged.
+  An *ignored* file or link is in neither tree and on no collision list,
+  so it reaches the write and is replaced in silence, which is git's own
+  split. The deliberate divergence is the third: where an index entry
+  stands in the way of a directory the target records, git allows the
+  switch and discards the staged addition with nothing left pointing at
+  the blob, and this build refuses and names the path instead. Same
+  trade as the staged-change refusal above: no reflog here means a
+  silent discard cannot be undone, and a refusal can be acted on.
 - **A move never crosses a mount boundary**, at either end. The rename op
   binds to the backend serving the source, so a destination another mount
   serves would be written into the source's backend at a path it does not

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -123,7 +123,7 @@ git -C /repo tag -d v1.0
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included, and the type recorded is the one the target really is; `-d`, `-f`; a creation option needs a name |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included, and the type recorded is the one the target really is; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -173,6 +173,14 @@ serve, and inventing a name would put an unreviewed one into history.
   own: the file lands hidden behind that mount while the index names the
   new path. A source that is a mount root, or holds one, is refused for
   the same reason one level up.
+- **A rename moves what the node table holds at the path, not just below
+  it.** A symlink and an attr overlay live above every backend, addressed
+  by absolute path, so a move has to re-anchor the source's own entry and
+  its whole subtree or the link is destroyed and the mode is inherited by
+  whatever is written at the old name next. `git mv` renames through the
+  dispatcher, which does this for every caller that reaches it; a
+  single-mount shell `mv` renames through the backend op directly and so
+  repeats it, for a two-operand line only.
 - **A rename onto a directory the namespace has filled is `ENOTEMPTY`.**
   A symlink is namespace state no backend can see, so a destination the
   backend reads as empty can still hold one, and replacing it would
@@ -182,6 +190,18 @@ serve, and inventing a name would put an unreviewed one into history.
   editor to open. `mv` prints only its two usage lines for a missing
   operand, and `tag` prints only the synopsis lines for the options this
   build has, neither of them git's full option table.
+- **`tag -n` asks for a listing, so `-d` cannot also be on the line.**
+  With nothing else there `-n` *makes* the line a listing, which is why
+  `tag -n1 nosuch` is a pattern matching nothing at exit 0; once `-d`
+  has chosen the mode there is nothing left to imply, and the line dies
+  with every tag still standing.
+- **`tag -d` deletes every name or none of them.** One ref transaction
+  carries the whole line, and a name given twice is two updates for one
+  ref, which the transaction refuses before applying any of them. A name
+  no ref answers is reported and skipped instead, since it never reaches
+  the transaction at all. The one divergence is the wording of the
+  `-l`/`-d` refusal: git names the two options in the order they were
+  typed and in the spelling used, where this build has one fixed order.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -118,10 +118,10 @@ git -C /repo tag -d v1.0
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
 | `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, and a path it lacks is removed from the target   |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, and an unmerged path moves nowhere |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a directory holding a mount is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
-| `checkout` | refuses rather than overwrite work you have not committed                                                                              |
+| `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included                     |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named |
 | `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target; `-d`, `-f`; a creation option needs a name |
 
@@ -132,6 +132,11 @@ serve, and inventing a name would put an unreviewed one into history.
 ## Deliberate limits
 
 - **No network verbs.** `clone`, `fetch`, `pull` and `push` are absent.
+- **A pathspec that begins with a dash needs `--`.** `git rm -draft` is a
+  refused switch and `git rm -- -draft` removes the file, which is what
+  every synopsis ending `[--] [<pathspec>...]` promises. The marker
+  itself is consumed by the parser, so a verb reading a *revision* still
+  resolves an escaped word as one rather than narrowing by it.
 - **No `reset --hard`.** It destroys uncommitted work with no reflog here
   to recover it from. `rm` and `restore` are the way to discard a file's
   changes on purpose, and `rm` refuses unless `-f` says so.

--- a/docs/python/cli/git.mdx
+++ b/docs/python/cli/git.mdx
@@ -116,14 +116,14 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place |
-| `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents |
+| `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
 | `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included; `-d`, `-f`; a creation option needs a name |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included, and the type recorded is the one the target really is; `-d`, `-f`; a creation option needs a name |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -156,6 +156,17 @@ serve, and inventing a name would put an unreviewed one into history.
   below it, so an annotated tag is unwrapped on the way; `v1^{tag}` is
   the one spelling that names the tag object itself, and a lightweight
   tag has none to stop at.
+- **A bare object id names that exact object.** Every other spelling of a
+  revision is a commit-ish reading that unwraps an annotated tag, so
+  `restore --source=v1` reads a tree; an id does not, which is how
+  `git tag nested <tag-id>` records the nested tag git itself warns
+  about rather than quietly flattening it.
+- **A path is only a way through while every parent is a directory.** A
+  symlink standing on one is not: `restore` replaces it with the
+  directory the entry needs rather than writing through it, and removes
+  nothing through it in the other direction, so the tree the link
+  pointed at is never touched by a path that only looked like it led
+  there.
 - **A move never crosses a mount boundary**, at either end. The rename op
   binds to the backend serving the source, so a destination another mount
   serves would be written into the source's backend at a path it does not

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -117,12 +117,12 @@ git -C /repo tag -d v1.0
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
 | `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
-| `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
+| `branch`   | `-d` deletes a merged branch, `-D` any branch; a name whose ref path another branch already holds is refused                             |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included, and the type recorded is the one the target really is; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt`, `v1^{tag}` and `v1^{object}` included, and the type recorded is the one the target really is; a name whose ref path another tag already holds is refused; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -155,6 +155,11 @@ serve, and inventing a name would put an unreviewed one into history.
   below it, so an annotated tag is unwrapped on the way; `v1^{tag}` is
   the one spelling that names the tag object itself, and a lightweight
   tag has none to stop at.
+- **`^{object}` peels nothing.** It is an existence check rather than a
+  type, so it hands back whatever the name resolved to and an annotated
+  tag stays a tag where `^{}` would unwrap it. Every object reports a
+  concrete type, so reading `object` as one refused every expression
+  that spelled it.
 - **A bare object id names that exact object.** Every other spelling of a
   revision is a commit-ish reading that unwraps an annotated tag, so
   `restore --source=v1` reads a tree; an id does not, which is how
@@ -179,6 +184,34 @@ serve, and inventing a name would put an unreviewed one into history.
   the blob, and this build refuses and names the path instead. Same
   trade as the staged-change refusal above: no reflog here means a
   silent discard cannot be undone, and a refusal can be acted on.
+- **The divergence runs both ways round the same collision.** A staged
+  path *inside* a directory the target replaces with a file is refused
+  and named too. git succeeds there as well, removing the directory and
+  dropping the staged entry, which would otherwise leave an index
+  holding both `slot` and `slot/child`: a shape git's own index has no
+  room for. The two halves are one decision, so neither is quietly
+  more permissive than the other.
+- **A directory is replaced without following a link out of it.** A
+  listing dereferences, so a link to a directory lists that directory's
+  contents; walking them would delete a tree no branch named. The name
+  plane is asked for each child, and a link is unlinked where a
+  directory is descended into, which is what `rm -r` does too.
+- **Two refs cannot hold one path.** A ref is a file below `.git`, so
+  `foo` and `foo/bar` cannot both exist, in `refs/tags/` or in
+  `refs/heads/`. Creating either over the other is refused with git's
+  own lock wording and exit 128, before the working tree moves, and
+  `-f` does not help because the obstacle is the path rather than the
+  value. Left to the mount, a disk backend raised its host's error and
+  a prefix store took both keys and left a ref the loose-ref walk could
+  not find.
+- **`mv` refuses a directory and something inside it**, whatever order
+  the line puts them in and whether or not `-k` is given. The check
+  reads the whole line once every source has passed its own, so a
+  source with a fault of its own and a same-target collision are both
+  reported first, and a source `-k` already skipped is out of the
+  comparison. `-k` cannot apply here: moving the directory is what
+  makes the other source disappear, so skipping the second move would
+  leave the first one applied and unstaged.
 - **The same split applies to a directory standing on the name itself**,
   not only above it. A directory holding untracked files is refused and
   named (`Updating the following directories would lose untracked files

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -97,15 +97,32 @@ git -C /repo branch topic
 git -C /repo branch -d topic
 git -C /repo branch -D topic
 git -C /repo checkout topic
+git -C /repo switch topic
+git -C /repo switch -c feature HEAD~1
+git -C /repo switch --detach HEAD~1
+git -C /repo restore src/main.ts
+git -C /repo restore --staged src/main.ts
+git -C /repo restore --source HEAD~1 -SW src/main.ts
+git -C /repo rm old.ts
+git -C /repo rm -r --cached build
+git -C /repo mv src/old.ts src/new.ts
+git -C /repo tag v1.0
+git -C /repo tag -a v1.1 -m "release"
+git -C /repo tag -d v1.0
 ```
 
-| Verb       | Notes                                                            |
-| ---------- | ---------------------------------------------------------------- |
-| `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path |
-| `reset`    | mixed only, from HEAD; a pathspec limits it to those paths        |
-| `commit`   | `-m` required, `--author "Name <email>"` optional                 |
-| `branch`   | `-d` deletes a merged branch, `-D` any branch                     |
-| `checkout` | refuses rather than overwrite work you have not committed         |
+| Verb       | Notes                                                                                                                                  |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
+| `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` names the tree, and a path it lacks is removed from the target        |
+| `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`                                      |
+| `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
+| `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
+| `checkout` | refuses rather than overwrite work you have not committed                                                                              |
+| `switch`   | the same move for a branch only; `-c` creates, `--detach` is the only way onto a bare commit                                            |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; `-d`, `-f`                          |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -115,7 +132,13 @@ serve, and inventing a name would put an unreviewed one into history.
 
 - **No network verbs.** `clone`, `fetch`, `pull` and `push` are absent.
 - **No `reset --hard`.** It destroys uncommitted work with no reflog here
-  to recover it from.
+  to recover it from. `rm` and `restore` are the way to discard a file's
+  changes on purpose, and `rm` refuses unless `-f` says so.
+- **No `switch -`.** The previous branch lives in the reflog, which this
+  build writes but does not read back.
+- **`tag -a` needs `-m`**, for the reason `commit` does: there is no
+  editor to open. `mv` prints only its two usage lines for a missing
+  operand, not git's option table.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -115,14 +115,14 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place |
-| `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents |
+| `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
 | `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included; `-d`, `-f`; a creation option needs a name |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included, and the type recorded is the one the target really is; `-d`, `-f`; a creation option needs a name |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -155,6 +155,17 @@ serve, and inventing a name would put an unreviewed one into history.
   below it, so an annotated tag is unwrapped on the way; `v1^{tag}` is
   the one spelling that names the tag object itself, and a lightweight
   tag has none to stop at.
+- **A bare object id names that exact object.** Every other spelling of a
+  revision is a commit-ish reading that unwraps an annotated tag, so
+  `restore --source=v1` reads a tree; an id does not, which is how
+  `git tag nested <tag-id>` records the nested tag git itself warns
+  about rather than quietly flattening it.
+- **A path is only a way through while every parent is a directory.** A
+  symlink standing on one is not: `restore` replaces it with the
+  directory the entry needs rather than writing through it, and removes
+  nothing through it in the other direction, so the tree the link
+  pointed at is never touched by a path that only looked like it led
+  there.
 - **A move never crosses a mount boundary**, at either end. The rename op
   binds to the backend serving the source, so a destination another mount
   serves would be written into the source's backend at a path it does not

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -115,9 +115,9 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, a path it lacks is removed from the target, and a path still in conflict is named rather than half-restored |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a directory holding a mount is refused rather than half-moved |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
@@ -147,6 +147,17 @@ serve, and inventing a name would put an unreviewed one into history.
   path and refuse first. Creating a branch where HEAD already is
   (`switch -c topic`, no start point) moves nothing and is allowed, which
   is git's own reading of the line.
+- **A move never crosses a mount boundary**, at either end. The rename op
+  binds to the backend serving the source, so a destination another mount
+  serves would be written into the source's backend at a path it does not
+  own: the file lands hidden behind that mount while the index names the
+  new path. A source that is a mount root, or holds one, is refused for
+  the same reason one level up.
+- **A rename onto a directory the namespace has filled is `ENOTEMPTY`.**
+  A symlink is namespace state no backend can see, so a destination the
+  backend reads as empty can still hold one, and replacing it would
+  delete the link with it. The merged view decides, which is what POSIX
+  promises.
 - **`tag -a` needs `-m`**, for the reason `commit` does: there is no
   editor to open. `mv` prints only its two usage lines for a missing
   operand, and `tag` prints only the synopsis lines for the options this

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -122,7 +122,7 @@ git -C /repo tag -d v1.0
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included, and the type recorded is the one the target really is; `-d`, `-f`; a creation option needs a name |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included, and the type recorded is the one the target really is; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -172,6 +172,14 @@ serve, and inventing a name would put an unreviewed one into history.
   own: the file lands hidden behind that mount while the index names the
   new path. A source that is a mount root, or holds one, is refused for
   the same reason one level up.
+- **A rename moves what the node table holds at the path, not just below
+  it.** A symlink and an attr overlay live above every backend, addressed
+  by absolute path, so a move has to re-anchor the source's own entry and
+  its whole subtree or the link is destroyed and the mode is inherited by
+  whatever is written at the old name next. `git mv` renames through the
+  dispatcher, which does this for every caller that reaches it; a
+  single-mount shell `mv` renames through the backend op directly and so
+  repeats it, for a two-operand line only.
 - **A rename onto a directory the namespace has filled is `ENOTEMPTY`.**
   A symlink is namespace state no backend can see, so a destination the
   backend reads as empty can still hold one, and replacing it would
@@ -181,6 +189,18 @@ serve, and inventing a name would put an unreviewed one into history.
   editor to open. `mv` prints only its two usage lines for a missing
   operand, and `tag` prints only the synopsis lines for the options this
   build has, neither of them git's full option table.
+- **`tag -n` asks for a listing, so `-d` cannot also be on the line.**
+  With nothing else there `-n` *makes* the line a listing, which is why
+  `tag -n1 nosuch` is a pattern matching nothing at exit 0; once `-d`
+  has chosen the mode there is nothing left to imply, and the line dies
+  with every tag still standing.
+- **`tag -d` deletes every name or none of them.** One ref transaction
+  carries the whole line, and a name given twice is two updates for one
+  ref, which the transaction refuses before applying any of them. A name
+  no ref answers is reported and skipped instead, since it never reaches
+  the transaction at all. The one divergence is the wording of the
+  `-l`/`-d` refusal: git names the two options in the order they were
+  typed and in the spelling used, where this build has one fixed order.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -115,7 +115,7 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents, and a gitlink keeps whatever working tree it has |
 | `rm`       | refuses a path with uncommitted work unless `-f`, a path a symlinked ancestor now hides included; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
 | `mv`       | files and directories, `-f` over an existing file and over the conflict stages it was holding, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere as a source, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
@@ -312,6 +312,29 @@ serve, and inventing a name would put an unreviewed one into history.
   over the entry and the blob that just moved is the copy that
   disappears. An unmerged *source* still moves nowhere, and a plain `mv`
   onto an occupied destination is still the ordinary refusal.
+- **An ancestry suffix is only `~` and `^`.** Every other character
+  used to count as another first-parent hop, so `HEAD^x` resolved to
+  `HEAD^^` and `git tag release HEAD^x` wrote the tag at a commit
+  nobody named. The whole expression is refused now, which is git's own
+  answer, and `main~٣` goes with it: the count scans ASCII digits, so
+  what a unicode digit leaves behind is not a step either. The wording
+  follows the verb, since git's does: `tag` says
+  `Failed to resolve '<rev>' as a valid ref.` and `log` and `show` say
+  `ambiguous argument '<rev>'`. `HEAD^0`, `HEAD^~` and `HEAD~2^2~1` are
+  steps git takes and still parse.
+- **A gitlink is a directory placeholder, not a blob.** A `160000`
+  entry names a commit in another repository, which this one does not
+  hold, so reading it as content is either a miss or, when the id does
+  happen to resolve here, an empty string written over the whole
+  directory. git checks out no submodule content at all without
+  `--recurse-submodules`; all the entry asks of the working tree is
+  that a directory stand at the name, so an existing one is left
+  exactly as it is with its untracked work, a regular file or a link is
+  replaced by an empty directory, and a missing one is created. Nothing
+  else about a submodule is supported: `status` still reads the
+  directory as an ordinary untracked one, which is why a branch switch
+  onto a gitlink the current branch also carries is refused before it
+  gets this far.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -117,10 +117,10 @@ git -C /repo tag -d v1.0
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
 | `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, and a path it lacks is removed from the target   |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, and an unmerged path moves nowhere |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a directory holding a mount is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
-| `checkout` | refuses rather than overwrite work you have not committed                                                                              |
+| `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included                     |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named |
 | `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target; `-d`, `-f`; a creation option needs a name |
 
@@ -131,6 +131,11 @@ serve, and inventing a name would put an unreviewed one into history.
 ## Deliberate limits
 
 - **No network verbs.** `clone`, `fetch`, `pull` and `push` are absent.
+- **A pathspec that begins with a dash needs `--`.** `git rm -draft` is a
+  refused switch and `git rm -- -draft` removes the file, which is what
+  every synopsis ending `[--] [<pathspec>...]` promises. The marker
+  itself is consumed by the parser, so a verb reading a *revision* still
+  resolves an escaped word as one rather than narrowing by it.
 - **No `reset --hard`.** It destroys uncommitted work with no reflog here
   to recover it from. `rm` and `restore` are the way to discard a file's
   changes on purpose, and `rm` refuses unless `-f` says so.

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -117,12 +117,12 @@ git -C /repo tag -d v1.0
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
 | `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` names the tree, and a path it lacks is removed from the target        |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`                                      |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed                                                                              |
-| `switch`   | the same move for a branch only; `-c` creates, `--detach` is the only way onto a bare commit                                            |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; `-d`, `-f`                          |
+| `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; `-d`, `-f`; a creation option needs a name |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -138,7 +138,8 @@ serve, and inventing a name would put an unreviewed one into history.
   build writes but does not read back.
 - **`tag -a` needs `-m`**, for the reason `commit` does: there is no
   editor to open. `mv` prints only its two usage lines for a missing
-  operand, not git's option table.
+  operand, and `tag` prints only the synopsis lines for the options this
+  build has, neither of them git's full option table.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -115,14 +115,14 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` names the tree, and a path it lacks is removed from the target        |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, and a path it lacks is removed from the target   |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name |
+| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, and an unmerged path moves nowhere |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed                                                                              |
-| `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; `-d`, `-f`; a creation option needs a name |
+| `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target; `-d`, `-f`; a creation option needs a name |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -115,14 +115,14 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
 | `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
-| `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}` and `HEAD:a.txt` included; `-d`, `-f`; a creation option needs a name |
+| `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt` and `v1^{tag}` included; `-d`, `-f`; a creation option needs a name |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -147,6 +147,14 @@ serve, and inventing a name would put an unreviewed one into history.
   path and refuse first. Creating a branch where HEAD already is
   (`switch -c topic`, no start point) moves nothing and is allowed, which
   is git's own reading of the line.
+- **A branch with no commit is a name and nothing else.** `switch -c topic`
+  before the first commit repoints HEAD and writes neither a ref nor a
+  reflog line, which is how git leaves an unborn branch too. Naming a
+  start point there is a different line and stays unresolvable.
+- **`^{tag}` stops above the commit.** Every other peel type sits at or
+  below it, so an annotated tag is unwrapped on the way; `v1^{tag}` is
+  the one spelling that names the tag object itself, and a lightweight
+  tag has none to stop at.
 - **A move never crosses a mount boundary**, at either end. The rename op
   binds to the backend serving the source, so a destination another mount
   serves would be written into the source's backend at a path it does not

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -179,6 +179,26 @@ serve, and inventing a name would put an unreviewed one into history.
   the blob, and this build refuses and names the path instead. Same
   trade as the staged-change refusal above: no reflog here means a
   silent discard cannot be undone, and a refusal can be acted on.
+- **The same split applies to a directory standing on the name itself**,
+  not only above it. A directory holding untracked files is refused and
+  named (`Updating the following directories would lose untracked files
+  in them`); one holding nothing but ignored files is removed whole and
+  the target's file written in its place, since `--overwrite-ignore` is
+  git's default and the refusal is about untracked content rather than
+  about the directory.
+- **A tree entry's executable bit is restored with its content.** git
+  records exactly one permission bit and puts it back in both
+  directions, so `chmod -x` on a `100755` path and `chmod +x` on a
+  `100644` one are both modifications that `restore` and `switch` undo.
+  The mode is written unconditionally rather than probed first: deciding
+  costs the same op as setting, and the backends a repository is served
+  from apply it natively.
+- **An unborn branch is not a branch you can be on.** A fresh
+  repository's HEAD names one that has never been written, and
+  `switch <that name>` is `fatal: invalid reference: <name>` rather than
+  `Already on`, because there is no commit to be on; `switch -c <new>`
+  stays the one line an unborn HEAD accepts. `checkout` answers the same
+  line differently, as git does, through its pathspec fallback.
 - **A move never crosses a mount boundary**, at either end. The rename op
   binds to the backend serving the source, so a destination another mount
   serves would be written into the source's backend at a path it does not

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -116,13 +116,13 @@ git -C /repo tag -d v1.0
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
 | `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents |
-| `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
+| `rm`       | refuses a path with uncommitted work unless `-f`, a path a symlinked ancestor now hides included; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
 | `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch; a name whose ref path another branch already holds is refused                             |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt`, `v1^{tag}` and `v1^{object}` included, and the type recorded is the one the target really is; a name whose ref path another tag already holds is refused; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`, where `-n-1` says nothing at all and any count below it is refused; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt`, `v1^{tag}` and `v1^{object}` included, and the type recorded is the one the target really is; a name whose ref path another tag already holds is refused; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -267,6 +267,37 @@ serve, and inventing a name would put an unreviewed one into history.
   the transaction at all. The one divergence is the wording of the
   `-l`/`-d` refusal: git names the two options in the order they were
   typed and in the spelling used, where this build has one fixed order.
+- **`tag -n-1` is not a `-n` at all.** git's option parser starts the
+  count at -1 to mean "never given", so the sentinel reaches the verb
+  looking like an absent flag: `tag -d -n-1 v` deletes and
+  `tag -n-1 -a v -m m` creates, where either line with a real `-n`
+  refuses. Anything below -1 is a count, and a count has to be positive:
+  the refusal names the format field git was building
+  (`positive value expected contents:lines=-2`) rather than the option,
+  because that is where git discovers it, which is also why it fires in
+  a repository holding no tags and why `-d -n-2` still dies on the
+  list-mode refusal first.
+- **A symlinked ancestor hides a tracked file from the walk, not from
+  `rm`.** git's own diff refuses to follow a link in a leading path and
+  reports the file deleted, which is why `status` shows `D` for it; `rm`
+  lstats instead, and that lstat resolves the link and finds whatever
+  lies at the other end. So a tracked `slot/child` behind
+  `slot -> /elsewhere` is a local modification and is refused without
+  `-f`, even when the file at the other end is byte for byte the same
+  one: two files agreeing is still two files. A link pointing past the
+  name entirely leaves nothing to lose, and the removal goes through.
+- **A nested mount stops a working-tree removal.** Replacing a directory
+  with a file takes the whole directory, and `readdir` merges a mount
+  nested inside it into the listing, so the walk would empty a backend
+  no branch ever recorded and then remove its root. The mount table is
+  asked first and the verb refuses, naming the mount when the session
+  may be told about it and saying only that one is there when it may
+  not. The same boundary stops the tidying pass that drops a directory
+  emptied by `rm`: it halts at the mount root rather than removing it,
+  since nothing the caller asked for has failed. This is the rule
+  `MountRootPolicy` already applies to `rm` and `mv` at the command
+  tier, which a git verb reaching the dispatcher directly has to ask for
+  itself.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -115,14 +115,14 @@ git -C /repo tag -d v1.0
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `add`      | `-A` everything, `-u` tracked only, `-f` to stage an ignored path                                                                       |
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
-| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, and a path it lacks is removed from the target   |
+| `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, a path it lacks is removed from the target, and a path still in conflict is named rather than half-restored |
 | `rm`       | refuses a path with uncommitted work unless `-f`; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`             |
 | `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, an unmerged path moves nowhere, and a directory holding a mount is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch                                                                                           |
-| `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included                     |
+| `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named |
-| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target; `-d`, `-f`; a creation option needs a name |
+| `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}` and `HEAD:a.txt` included; `-d`, `-f`; a creation option needs a name |
 
 `commit` records `mirage <mirage@localhost>` unless `--author` says
 otherwise: git reads `user.name` from config files that a mount does not
@@ -141,6 +141,12 @@ serve, and inventing a name would put an unreviewed one into history.
   changes on purpose, and `rm` refuses unless `-f` says so.
 - **No `switch -`.** The previous branch lives in the reflog, which this
   build writes but does not read back.
+- **An unmerged index stops a branch move.** Every collision check reads
+  stage 0, so a path held only as conflict stages would be carried past
+  all of them and then cleared. `switch` and `checkout` name each such
+  path and refuse first. Creating a branch where HEAD already is
+  (`switch -c topic`, no start point) moves nothing and is allowed, which
+  is git's own reading of the line.
 - **`tag -a` needs `-m`**, for the reason `commit` does: there is no
   editor to open. `mv` prints only its two usage lines for a missing
   operand, and `tag` prints only the synopsis lines for the options this

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -160,12 +160,25 @@ serve, and inventing a name would put an unreviewed one into history.
   `restore --source=v1` reads a tree; an id does not, which is how
   `git tag nested <tag-id>` records the nested tag git itself warns
   about rather than quietly flattening it.
-- **A path is only a way through while every parent is a directory.** A
-  symlink standing on one is not: `restore` replaces it with the
-  directory the entry needs rather than writing through it, and removes
-  nothing through it in the other direction, so the tree the link
-  pointed at is never touched by a path that only looked like it led
-  there.
+- **A path is only a way through while every parent is a directory.**
+  Anything else standing on one is not, whatever kind it is: a symlink,
+  a regular file, tracked or not. The two directions differ and both are
+  git's. Writing an entry *replaces* what stands above it with the
+  directory the entry needs, so `restore` and `switch` both land the
+  blob where the branch says and leave a link's target tree, a path no
+  branch named, untouched. Removing an entry does nothing at all,
+  because the path never led there. The checks are one helper, so a
+  third caller inherits both halves rather than re-deriving one.
+- **A switch replaces an ignored parent and refuses an uncommitted
+  one.** The untracked case git refuses by name, and that is unchanged.
+  An *ignored* file or link is in neither tree and on no collision list,
+  so it reaches the write and is replaced in silence, which is git's own
+  split. The deliberate divergence is the third: where an index entry
+  stands in the way of a directory the target records, git allows the
+  switch and discards the staged addition with nothing left pointing at
+  the blob, and this build refuses and names the path instead. Same
+  trade as the staged-change refusal above: no reflog here means a
+  silent discard cannot be undone, and a refusal can be acted on.
 - **A move never crosses a mount boundary**, at either end. The rename op
   binds to the backend serving the source, so a destination another mount
   serves would be written into the source's backend at a path it does not

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -151,6 +151,13 @@ serve, and inventing a name would put an unreviewed one into history.
   before the first commit repoints HEAD and writes neither a ref nor a
   reflog line, which is how git leaves an unborn branch too. Naming a
   start point there is a different line and stays unresolvable.
+- **A revision is read left to right.** `~n`, `^n` and `^{<type>}` are
+  operators applied in the order they are written, so `HEAD^{commit}~1`
+  is HEAD's parent, `HEAD~1^{tree}` is that parent's tree, and the two
+  chain further (`HEAD^{commit}~1^{tree}`). A peel was read as a
+  trailing thing until this round, so every chain that went on after one
+  was refused although git takes it. A step off something with no
+  parents is still refused, which is what `HEAD^{tree}~1` is.
 - **`^{tag}` stops above the commit.** Every other peel type sits at or
   below it, so an annotated tag is unwrapped on the way; `v1^{tag}` is
   the one spelling that names the tag object itself, and a lightweight
@@ -335,10 +342,18 @@ serve, and inventing a name would put an unreviewed one into history.
   source drops loses its index entry and keeps its working-tree copy,
   and a directory full of untracked files is what the entry asked for
   rather than a collision, where an untracked *file* at the name still
-  refuses. Nothing else about a submodule is supported: `status` still
-  reads the directory as an ordinary untracked one, which is why a
-  branch switch onto a gitlink the current branch also carries is
-  refused before it gets this far.
+  refuses. Taking the entry away is an `rmdir` rather than an unlink,
+  and it warns rather than failing: an empty directory goes, one that
+  still holds anything stays with
+  `warning: unable to rmdir '<name>': Directory not empty`, a file or a
+  link at the name is the `Not a directory` wording of the same line,
+  and the switch or restore succeeds either way. A gitlink is also
+  invisible to the unstaged comparison, because the submodule's own HEAD
+  is what git compares and this build cannot read it: reporting the
+  directory as a deleted file is worse than saying nothing, and it
+  refused every branch switch away from a submodule. What is left of the
+  divergence is the untracked side: files inside a submodule's directory
+  are still listed as untracked, where git says nothing about them.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -120,7 +120,7 @@ git -C /repo tag -d v1.0
 | `mv`       | files and directories, `-f` over an existing file and over the conflict stages it was holding, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere as a source, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch; a name whose ref path another branch already holds is refused                             |
-| `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
+| `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too, the branch HEAD already names included, since moving nothing is not the same as having nothing to check |
 | `switch`   | the same move for a branch only; `-c` creates and checks the name against git's ref rules and works before the first commit, `--detach` is the only way onto a bare commit and takes HEAD when nothing is named; a staged addition, deletion or edit both branches agree about is carried across and reported with its status letter |
 | `tag`      | lists sorted, `-l <pattern>`, `-n[<num>]`, where `-n-1` says nothing at all and any count below it is refused; a name is a lightweight tag, `-a`/`-m` an annotated one; any object is a legal target, `HEAD^{tree}`, `HEAD:a.txt`, `v1^{tag}` and `v1^{object}` included, and the type recorded is the one the target really is; a name whose ref path another tag already holds is refused; `-d` deletes atomically, `-f`; a creation option needs a name, and `-n` needs a listing |
 
@@ -330,11 +330,15 @@ serve, and inventing a name would put an unreviewed one into history.
   `--recurse-submodules`; all the entry asks of the working tree is
   that a directory stand at the name, so an existing one is left
   exactly as it is with its untracked work, a regular file or a link is
-  replaced by an empty directory, and a missing one is created. Nothing
-  else about a submodule is supported: `status` still reads the
-  directory as an ordinary untracked one, which is why a branch switch
-  onto a gitlink the current branch also carries is refused before it
-  gets this far.
+  replaced by an empty directory, and a missing one is created. What is
+  under the name is never touched either: a tracked child the restored
+  source drops loses its index entry and keeps its working-tree copy,
+  and a directory full of untracked files is what the entry asked for
+  rather than a collision, where an untracked *file* at the name still
+  refuses. Nothing else about a submodule is supported: `status` still
+  reads the directory as an ordinary untracked one, which is why a
+  branch switch onto a gitlink the current branch also carries is
+  refused before it gets this far.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/docs/typescript/cli/git.mdx
+++ b/docs/typescript/cli/git.mdx
@@ -117,7 +117,7 @@ git -C /repo tag -d v1.0
 | `reset`    | mixed only, from HEAD; a pathspec limits it to those paths                                                                              |
 | `restore`  | worktree by default, `--staged` the index, `-SW` both; `--source` takes any tree-ish, spelled as a peel (`HEAD^{tree}`), a subtree (`HEAD:sub`) or a raw id, and is required before the first commit since the implicit HEAD source has nothing to read; a path it lacks is removed from the target, a path still in conflict is named rather than half-restored, and a file replaces a directory standing in its place, as it replaces a symlink standing on one of its parents |
 | `rm`       | refuses a path with uncommitted work unless `-f`, a path a symlinked ancestor now hides included; `--cached` keeps the file; `-r` for a directory; `-q`, `--ignore-unmatch`; the index is written only once the working tree is done with, so a deletion the mount refuses leaves the entry staged as it stood |
-| `mv`       | files and directories, `-f` over an existing file, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere, and a move that would cross a mount boundary at either end is refused rather than half-moved |
+| `mv`       | files and directories, `-f` over an existing file and over the conflict stages it was holding, `-k` skips what cannot move, `-n` dry run, `-v`; two sources cannot land on one name, a directory and something inside it cannot both move, an unmerged path moves nowhere as a source, and a move that would cross a mount boundary at either end is refused rather than half-moved |
 | `commit`   | `-m` required, `--author "Name <email>"` optional                                                                                       |
 | `branch`   | `-d` deletes a merged branch, `-D` any branch; a name whose ref path another branch already holds is refused                             |
 | `checkout` | refuses rather than overwrite work you have not committed, an untracked file the target needs the room for included and an index still holding conflict stages too |
@@ -292,12 +292,26 @@ serve, and inventing a name would put an unreviewed one into history.
   no branch ever recorded and then remove its root. The mount table is
   asked first and the verb refuses, naming the mount when the session
   may be told about it and saying only that one is there when it may
-  not. The same boundary stops the tidying pass that drops a directory
-  emptied by `rm`: it halts at the mount root rather than removing it,
-  since nothing the caller asked for has failed. This is the rule
-  `MountRootPolicy` already applies to `rm` and `mv` at the command
-  tier, which a git verb reaching the dispatcher directly has to ask for
-  itself.
+  not. **Every destination is asked before the first one is written**,
+  which is what the other collision checks already do and what keeps
+  the refusal from landing halfway: a `switch` that had written an
+  earlier path would leave the working tree on the target's content
+  with HEAD and the index still on the branch being left, and
+  `restore -SW` stages before it writes, so a refusal in the second
+  pass would move the index and nothing else. The same boundary stops
+  the tidying pass that drops a directory emptied by `rm`: it halts at
+  the mount root rather than removing it, since nothing the caller
+  asked for has failed. This is the rule `MountRootPolicy` already
+  applies to `rm` and `mv` at the command tier, which a git verb
+  reaching the dispatcher directly has to ask for itself.
+- **`mv -f` onto an unmerged path takes its stages with it.** `-f` is
+  the only way to reach a destination that already exists, and git's
+  answer there is one stage-0 entry holding the source: `ls-files -u` is
+  empty afterwards. Leaving the stages behind is the worse divergence
+  rather than the smaller one, since the index writer lays them back
+  over the entry and the blob that just moved is the copy that
+  disappears. An unmerged *source* still moves nowhere, and a plain `mv`
+  onto an occupied destination is still the ordinary refusal.
 - **`reset` takes no revision.** Real git resets the index to any commit
   named as an operand; this build resets it from HEAD only and refuses a
   revision by name rather than doing nothing quietly.

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2771,6 +2771,48 @@
         "stdout": "exit=128\ntannn\n",
         "stderr": "fatal: the '-n' option is only allowed in list mode\n"
       }
+    },
+    {
+      "id": "git_tag_refuses_an_ancestry_suffix_that_is_not_a_step",
+      "seq": 568357,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag zrelease 'HEAD^x'; echo exit=$?; git -C /repo tag -l zrelease",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=128\n",
+        "stderr": "fatal: Failed to resolve 'HEAD^x' as a valid ref.\n"
+      }
+    },
+    {
+      "id": "git_tag_counts_ascii_digits_only_in_an_ancestry_step",
+      "seq": 568358,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag zunicode 'HEAD~\u0663'; echo exit=$?; git -C /repo tag -l zunicode",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=128\n",
+        "stderr": "fatal: Failed to resolve 'HEAD~\u0663' as a valid ref.\n"
+      }
+    },
+    {
+      "id": "git_tag_still_takes_the_ancestry_steps_git_takes",
+      "seq": 568359,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag zfirst 'HEAD^' && git -C /repo tag zhere 'HEAD^0' && git -C /repo tag zmixed 'HEAD^~'; echo exit=$?; git -C /repo tag -l 'z*'",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=0\nzfirst\nzhere\nzmixed\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2337,6 +2337,62 @@
         "stdout": "notes\nold\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "git_mv_carries_the_mode_overlay",
+      "seq": 568326,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "echo m > /repo/mvmode.txt && git -C /repo add mvmode.txt && git -C /repo commit -m mvmode > /dev/null && chmod 400 /repo/mvmode.txt && git -C /repo mv mvmode.txt mvmoved.txt && stat -c '%A' /repo/mvmoved.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "-r--------\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_mv_carries_a_link_below_a_directory",
+      "seq": 568327,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "mkdir /repo/notes && echo t > /repo/tgt.txt && ln -s /repo/tgt.txt /repo/notes/link && git -C /repo add notes && git -C /repo mv notes moved && readlink /repo/moved/link; readlink /repo/notes/link; echo exit=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "/repo/tgt.txt\nexit=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_refuses_n_when_deleting",
+      "seq": 568328,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag ndel && git -C /repo tag -d -n1 ndel; echo exit=$?; git -C /repo tag -l 'ndel'",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=128\nndel\n",
+        "stderr": "fatal: the '-n' option is only allowed in list mode\n"
+      }
+    },
+    {
+      "id": "git_tag_refuses_a_repeated_deletion",
+      "seq": 568329,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag dupa && git -C /repo tag dupb && git -C /repo tag -d dupa dupb dupa; echo exit=$?; git -C /repo tag -l 'dup*'",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=1\ndupa\ndupb\n",
+        "stderr": "error: could not delete references: multiple updates for ref 'refs/tags/dupa' not allowed\n"
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2477,6 +2477,62 @@
         "stdout": "kid\nexit=1\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "git_restore_puts_the_executable_bit_back",
+      "seq": 568336,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf '#!/bin/sh\\n' > /repo/xs.sh && chmod 755 /repo/xs.sh && git -C /repo add xs.sh && git -C /repo commit -m xs > /dev/null && chmod 644 /repo/xs.sh && git -C /repo status --short | grep xs.sh && git -C /repo restore xs.sh && ls -l /repo/xs.sh | cut -c1-10 && git -C /repo status --short | grep -c xs.sh",
+      "expect": {
+        "exit": 1,
+        "stdout": " M xs.sh\n-rwxr-xr-x\n0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_restore_clears_the_executable_bit_too",
+      "seq": 568337,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'plain\\n' > /repo/xp.txt && git -C /repo add xp.txt && git -C /repo commit -m xp > /dev/null && chmod 755 /repo/xp.txt && git -C /repo restore xp.txt && ls -l /repo/xp.txt | cut -c1-10",
+      "expect": {
+        "exit": 0,
+        "stdout": "-rw-r--r--\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_switch_replaces_an_ignored_directory",
+      "seq": 568338,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'dslot/\\n' >> /repo/.gitignore && git -C /repo add .gitignore && git -C /repo commit -m ign3 > /dev/null && git -C /repo switch -c dbase > /dev/null 2>&1 && git -C /repo switch -c dfile > /dev/null 2>&1 && echo asfile > /repo/dslot && git -C /repo add -f dslot && git -C /repo commit -m dfile > /dev/null && git -C /repo switch dbase > /dev/null 2>&1 && mkdir -p /repo/dslot && echo keep > /repo/dslot/keep && git -C /repo switch dfile > /dev/null 2>&1 && cat /repo/dslot",
+      "expect": {
+        "exit": 0,
+        "stdout": "asfile\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_switch_still_refuses_a_directory_holding_untracked_files",
+      "seq": 568339,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch -c nbase > /dev/null 2>&1 && git -C /repo switch -c nfile > /dev/null 2>&1 && echo asfile > /repo/nslot && git -C /repo add nslot && git -C /repo commit -m nfile > /dev/null && git -C /repo switch nbase > /dev/null 2>&1 && rm -f /repo/nslot && mkdir -p /repo/nslot && echo keep > /repo/nslot/keep && git -C /repo switch nfile; echo exit=$?; cat /repo/nslot/keep",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=1\nkeep\n",
+        "stderr": "error: Updating the following directories would lose untracked files in them:\n\tnslot\n\nAborting\n"
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -1301,6 +1301,818 @@
         "stdout": "",
         "stderr": ""
       }
+    },
+    {
+      "id": "git_rm_stages_a_deletion",
+      "seq": 568252,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo rm letters.txt && git -C /repo status --porcelain && git -C /repo restore --staged letters.txt && git -C /repo restore letters.txt && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "rm 'letters.txt'\nD  letters.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_rm_refuses_a_directory_without_r",
+      "seq": 568253,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo rm docs",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: not removing 'docs' recursively without -r\n"
+      }
+    },
+    {
+      "id": "git_rm_r_removes_a_directory_and_its_empty_parent",
+      "seq": 568254,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo rm -r docs && test -e /repo/docs || echo gone; git -C /repo restore --staged docs && git -C /repo restore docs && cat /repo/docs/readme.md",
+      "expect": {
+        "exit": 0,
+        "stdout": "rm 'docs/readme.md'\ngone\nnotes\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_rm_refuses_an_unknown_path",
+      "seq": 568255,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo rm nosuch",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: pathspec 'nosuch' did not match any files\n"
+      }
+    },
+    {
+      "id": "git_rm_refuses_a_local_modification",
+      "seq": 568256,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'x\\n' >> /repo/letters.txt && git -C /repo rm letters.txt; git -C /repo restore letters.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": "error: the following file has local modifications:\n    letters.txt\n(use --cached to keep the file, or -f to force removal)\n"
+      }
+    },
+    {
+      "id": "git_rm_refuses_a_staged_change",
+      "seq": 568257,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'x\\n' >> /repo/letters.txt && git -C /repo add letters.txt && git -C /repo rm letters.txt; git -C /repo restore -SW letters.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": "error: the following file has changes staged in the index:\n    letters.txt\n(use --cached to keep the file, or -f to force removal)\n"
+      }
+    },
+    {
+      "id": "git_rm_refuses_staged_content_different_from_both",
+      "seq": 568258,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'x\\n' >> /repo/letters.txt && git -C /repo add letters.txt && printf 'y\\n' >> /repo/letters.txt && git -C /repo rm --cached letters.txt; git -C /repo restore -SW letters.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": "error: the following file has staged content different from both the\nfile and the HEAD:\n    letters.txt\n(use -f to force removal)\n"
+      }
+    },
+    {
+      "id": "git_rm_cached_keeps_the_file",
+      "seq": 568259,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo rm --cached numbers.txt && git -C /repo status --porcelain && git -C /repo add numbers.txt && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "rm 'numbers.txt'\nD  numbers.txt\n?? numbers.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_rm_force_removes_a_modified_file",
+      "seq": 568260,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'x\\n' >> /repo/letters.txt && git -C /repo rm -f letters.txt && git -C /repo status --porcelain && git -C /repo restore -SW letters.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "rm 'letters.txt'\nD  letters.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_rm_quiet_and_two_operands_with_one_missing",
+      "seq": 568261,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo rm -q letters.txt nosuch; git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": "fatal: pathspec 'nosuch' did not match any files\n"
+      }
+    },
+    {
+      "id": "git_rm_with_no_pathspec",
+      "seq": 568262,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo rm",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: No pathspec was given. Which files should I remove?\n"
+      }
+    },
+    {
+      "id": "git_mv_renames_a_file",
+      "seq": 568263,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv letters.txt moved.txt && git -C /repo status --porcelain && git -C /repo mv moved.txt letters.txt && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "R  letters.txt -> moved.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_mv_verbose",
+      "seq": 568264,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv -v letters.txt moved.txt && git -C /repo mv -v moved.txt letters.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "Renaming letters.txt to moved.txt\nRenaming moved.txt to letters.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_mv_refuses_a_bad_source",
+      "seq": 568265,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv nosuch dest",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: bad source, source=nosuch, destination=dest\n"
+      }
+    },
+    {
+      "id": "git_mv_refuses_an_untracked_source",
+      "seq": 568266,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'u\\n' > /repo/u.txt && git -C /repo mv u.txt dest; rm /repo/u.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": "fatal: not under version control, source=u.txt, destination=dest\n"
+      }
+    },
+    {
+      "id": "git_mv_refuses_an_existing_destination",
+      "seq": 568267,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv letters.txt numbers.txt",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: destination exists, source=letters.txt, destination=numbers.txt\n"
+      }
+    },
+    {
+      "id": "git_mv_force_overwrites",
+      "seq": 568268,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv -f letters.txt numbers.txt && git -C /repo status --porcelain && git -C /repo restore -SW letters.txt numbers.txt && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "D  letters.txt\nM  numbers.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_mv_into_a_directory",
+      "seq": 568269,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv letters.txt docs && git -C /repo status --porcelain && git -C /repo mv docs/letters.txt letters.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "R  letters.txt -> docs/letters.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_mv_a_directory",
+      "seq": 568270,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv docs moved && git -C /repo status --porcelain && ls /repo/moved && git -C /repo mv moved docs && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "R  docs/readme.md -> moved/readme.md\nreadme.md\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_mv_several_need_a_directory",
+      "seq": 568271,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv letters.txt numbers.txt nowhere",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: destination 'nowhere' is not a directory\n"
+      }
+    },
+    {
+      "id": "git_mv_with_one_operand",
+      "seq": 568272,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv letters.txt",
+      "expect": {
+        "exit": 129,
+        "stdout": "",
+        "stderr": "usage: git mv [-v] [-f] [-n] [-k] <source> <destination>\n   or: git mv [-v] [-f] [-n] [-k] <source>... <destination-directory>\n"
+      }
+    },
+    {
+      "id": "git_mv_keeps_an_edit",
+      "seq": 568273,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'x\\n' >> /repo/letters.txt && git -C /repo mv letters.txt moved.txt && git -C /repo status --porcelain && git -C /repo mv moved.txt letters.txt && git -C /repo restore letters.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "RM letters.txt -> moved.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_mv_dry_run",
+      "seq": 568274,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv -n letters.txt moved.txt && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "Checking rename of 'letters.txt' to 'moved.txt'\nRenaming letters.txt to moved.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_mv_into_a_missing_directory",
+      "seq": 568275,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv letters.txt nodir/moved.txt; git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": "fatal: renaming 'letters.txt' failed: No such file or directory\n"
+      }
+    },
+    {
+      "id": "git_mv_a_directory_carries_untracked_files",
+      "seq": 568276,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'u\\n' > /repo/docs/u.txt && git -C /repo mv docs moved && git -C /repo status --porcelain && ls /repo/moved && git -C /repo mv moved docs && rm /repo/docs/u.txt && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "R  docs/readme.md -> moved/readme.md\n?? moved/u.txt\nreadme.md\nu.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_restore_a_worktree_edit",
+      "seq": 568277,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'x\\n' >> /repo/letters.txt && git -C /repo status --porcelain && git -C /repo restore letters.txt && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": " M letters.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_restore_staged",
+      "seq": 568278,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'x\\n' >> /repo/letters.txt && git -C /repo add letters.txt && git -C /repo restore --staged letters.txt && git -C /repo status --porcelain && git -C /repo restore letters.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": " M letters.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_restore_both",
+      "seq": 568279,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'x\\n' >> /repo/letters.txt && git -C /repo add letters.txt && printf 'y\\n' >> /repo/letters.txt && git -C /repo restore -SW letters.txt && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_restore_refuses_an_unknown_path",
+      "seq": 568280,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo restore nosuch",
+      "expect": {
+        "exit": 1,
+        "stdout": "",
+        "stderr": "error: pathspec 'nosuch' did not match any file(s) known to git\n"
+      }
+    },
+    {
+      "id": "git_restore_needs_a_pathspec",
+      "seq": 568281,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo restore",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: you must specify path(s) to restore\n"
+      }
+    },
+    {
+      "id": "git_restore_from_a_source",
+      "seq": 568282,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo restore --source 98b4ffe numbers.txt && git -C /repo status --porcelain && cat /repo/numbers.txt && git -C /repo restore numbers.txt && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": " M numbers.txt\none\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_restore_refuses_a_bad_source",
+      "seq": 568283,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo restore -s nosuch numbers.txt",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: could not resolve nosuch\n"
+      }
+    },
+    {
+      "id": "git_restore_staged_turns_an_add_back_into_untracked",
+      "seq": 568284,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'n\\n' > /repo/new.txt && git -C /repo add new.txt && git -C /repo restore --staged new.txt && git -C /repo status --porcelain && rm /repo/new.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "?? new.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_restore_a_deleted_file",
+      "seq": 568285,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "rm /repo/numbers.txt && git -C /repo restore numbers.txt && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_restore_source_lacking_the_path_removes_it",
+      "seq": 568286,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo restore -s 265ec3a -SW docs/readme.md && git -C /repo status --porcelain && test -e /repo/docs || echo gone; git -C /repo restore -SW docs/readme.md && git -C /repo status --porcelain",
+      "expect": {
+        "exit": 0,
+        "stdout": "D  docs/readme.md\ngone\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_switch_moves_the_working_tree",
+      "seq": 568287,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch topic && cat /repo/numbers.txt && git -C /repo switch main",
+      "expect": {
+        "exit": 0,
+        "stdout": "one\n",
+        "stderr": "Switched to branch 'topic'\nSwitched to branch 'main'\n"
+      }
+    },
+    {
+      "id": "git_switch_already_on",
+      "seq": 568288,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch main",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": "Already on 'main'\n"
+      }
+    },
+    {
+      "id": "git_switch_creates",
+      "seq": 568289,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch -c fresh && git -C /repo branch && git -C /repo switch main > /dev/null 2>&1 && git -C /repo branch -d fresh | cut -d' ' -f1-3",
+      "expect": {
+        "exit": 0,
+        "stdout": "* fresh\n  main\n  topic\nDeleted branch fresh\n",
+        "stderr": "Switched to a new branch 'fresh'\n"
+      }
+    },
+    {
+      "id": "git_switch_creates_at_a_start_point",
+      "seq": 568290,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch -c older 225f39c && git -C /repo log --oneline -n 1 && git -C /repo switch main > /dev/null 2>&1 && git -C /repo branch -d older",
+      "expect": {
+        "exit": 0,
+        "stdout": "225f39c add docs\nDeleted branch older (was 225f39c).\n",
+        "stderr": "Switched to a new branch 'older'\n"
+      }
+    },
+    {
+      "id": "git_switch_refuses_an_unknown_branch",
+      "seq": 568291,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch nosuchbranch",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: invalid reference: nosuchbranch\n"
+      }
+    },
+    {
+      "id": "git_switch_refuses_a_commit_without_detach",
+      "seq": 568292,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch 265ec3a",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: a branch is expected, got commit '265ec3a'\nhint: If you want to detach HEAD at the commit, try again with the --detach option.\n"
+      }
+    },
+    {
+      "id": "git_switch_detaches",
+      "seq": 568293,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch --detach 225f39c && git -C /repo status -b --porcelain && git -C /repo switch main",
+      "expect": {
+        "exit": 0,
+        "stdout": "## HEAD (no branch)\n",
+        "stderr": "HEAD is now at 225f39c add docs\nPrevious HEAD position was 225f39c add docs\nSwitched to branch 'main'\n"
+      }
+    },
+    {
+      "id": "git_switch_from_detached_names_the_previous_position",
+      "seq": 568294,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch --detach 265ec3a > /dev/null 2>&1 && git -C /repo switch -d 98b4ffe && git -C /repo switch main",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": "Previous HEAD position was 265ec3a add delta\nHEAD is now at 98b4ffe first commit\nPrevious HEAD position was 98b4ffe first commit\nSwitched to branch 'main'\n"
+      }
+    },
+    {
+      "id": "git_switch_refuses_to_lose_an_edit",
+      "seq": 568295,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'precious\\n' > /repo/numbers.txt && git -C /repo switch topic; git -C /repo restore numbers.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": "error: Your local changes to the following files would be overwritten by checkout:\n\tnumbers.txt\nPlease commit your changes or stash them before you switch branches.\nAborting\n"
+      }
+    },
+    {
+      "id": "git_switch_needs_an_operand",
+      "seq": 568296,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: missing branch or commit argument\n"
+      }
+    },
+    {
+      "id": "git_tag_lists_nothing",
+      "seq": 568297,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_creates_and_lists",
+      "seq": 568298,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag v1.0 225f39c && git -C /repo tag v0.9 265ec3a && git -C /repo tag && git -C /repo log --oneline -n 1 v0.9",
+      "expect": {
+        "exit": 0,
+        "stdout": "v0.9\nv1.0\n265ec3a add delta\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_list_pattern",
+      "seq": 568299,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -l 'v1*'",
+      "expect": {
+        "exit": 0,
+        "stdout": "v1.0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_refuses_a_name_that_exists",
+      "seq": 568300,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag v1.0",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: tag 'v1.0' already exists\n"
+      }
+    },
+    {
+      "id": "git_tag_refuses_a_bad_object",
+      "seq": 568301,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag v2 nosuchrev",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: Failed to resolve 'nosuchrev' as a valid ref.\n"
+      }
+    },
+    {
+      "id": "git_tag_annotated_with_message",
+      "seq": 568302,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -a v1.1 -m 'release one point one' && git -C /repo tag -n",
+      "expect": {
+        "exit": 0,
+        "stdout": "v0.9            add delta\nv1.0            add docs\nv1.1            release one point one\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_annotated_needs_a_message",
+      "seq": 568303,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -a v1.2",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: no tag message supplied (mirage has no editor to open; pass -m)\n"
+      }
+    },
+    {
+      "id": "git_tag_refuses_an_invalid_name",
+      "seq": 568304,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag 'bad name'",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: 'bad name' is not a valid tag name.\n"
+      }
+    },
+    {
+      "id": "git_tag_force_moves_a_tag",
+      "seq": 568305,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -f v0.9 225f39c | cut -d' ' -f1-3 && git -C /repo log --oneline -n 1 v0.9",
+      "expect": {
+        "exit": 0,
+        "stdout": "Updated tag 'v0.9'\n225f39c add docs\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_decorates_the_log",
+      "seq": 568306,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo log --format='%h%d' -n 1 225f39c",
+      "expect": {
+        "exit": 0,
+        "stdout": "225f39c (tag: v1.0, tag: v0.9, topic)\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_delete",
+      "seq": 568307,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -d v0.9 && git -C /repo tag -d nosuch; git -C /repo tag -d v1.0 v1.1 | cut -d' ' -f1-3 && git -C /repo tag",
+      "expect": {
+        "exit": 0,
+        "stdout": "Deleted tag 'v0.9' (was 225f39c)\nDeleted tag 'v1.0'\nDeleted tag 'v1.1'\n",
+        "stderr": "error: tag 'nosuch' not found.\n"
+      }
+    },
+    {
+      "id": "git_tag_sort_order",
+      "seq": 568308,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag a10 && git -C /repo tag a9 && git -C /repo tag B && git -C /repo tag && git -C /repo tag -d a10 a9 B > /dev/null && git -C /repo tag",
+      "expect": {
+        "exit": 0,
+        "stdout": "B\na10\na9\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_new_verbs_leave_the_tree_clean",
+      "seq": 568309,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo status --porcelain && git -C /repo branch",
+      "expect": {
+        "exit": 0,
+        "stdout": "* main\n  topic\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2393,6 +2393,62 @@
         "stdout": "exit=1\ndupa\ndupb\n",
         "stderr": "error: could not delete references: multiple updates for ref 'refs/tags/dupa' not allowed\n"
       }
+    },
+    {
+      "id": "git_restore_replaces_a_file_standing_where_a_directory_belongs",
+      "seq": 568330,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "mkdir -p /repo/rslot && echo c > /repo/rslot/child && git -C /repo add rslot/child && git -C /repo commit -m rslot > /dev/null && rm -rf /repo/rslot && echo untracked > /repo/rslot && git -C /repo restore rslot/child && cat /repo/rslot/child",
+      "expect": {
+        "exit": 0,
+        "stdout": "c\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_restore_removes_nothing_through_a_file",
+      "seq": 568331,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "rm -rf /repo/rslot && echo untracked > /repo/rslot && git -C /repo restore --source=HEAD~1 rslot/child; echo exit=$?; cat /repo/rslot",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=0\nuntracked\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_switch_replaces_an_ignored_link_ancestor",
+      "seq": 568332,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'islot\\n' > /repo/.gitignore && git -C /repo add .gitignore && git -C /repo commit -m ign > /dev/null && git -C /repo switch -c ibase > /dev/null 2>&1 && git -C /repo switch -c ilink > /dev/null 2>&1 && mkdir -p /repo/islot && echo kid > /repo/islot/child && git -C /repo add -f islot/child && git -C /repo commit -m ikid > /dev/null && git -C /repo switch ibase > /dev/null 2>&1 && mkdir -p /repo/iaway && echo outside > /repo/iaway/child && ln -s /repo/iaway /repo/islot && git -C /repo switch ilink > /dev/null 2>&1 && cat /repo/islot/child && cat /repo/iaway/child; readlink /repo/islot; echo exit=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "kid\noutside\nexit=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_switch_refuses_a_staged_file_in_the_way",
+      "seq": 568333,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch -c sbase > /dev/null 2>&1 && git -C /repo switch -c sstage > /dev/null 2>&1 && mkdir -p /repo/sslot && echo kid > /repo/sslot/child && git -C /repo add sslot/child && git -C /repo commit -m skid > /dev/null && git -C /repo switch sbase > /dev/null 2>&1 && echo staged > /repo/sslot && git -C /repo add sslot && git -C /repo switch sstage; echo exit=$?; git -C /repo status --short | grep sslot",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=1\nA  sslot\n",
+        "stderr": "error: Your local changes to the following files would be overwritten by checkout:\n\tsslot\nPlease commit your changes or stash them before you switch branches.\nAborting\n"
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2113,6 +2113,48 @@
         "stdout": "* main\n  topic\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "git_switch_c_refuses_an_invalid_branch_name",
+      "seq": 568310,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch -c ../../config",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: '../../config' is not a valid branch name\nhint: See `man git check-ref-format`\nhint: Disable this message with \"git config set advice.refSyntax false\"\n"
+      }
+    },
+    {
+      "id": "git_mv_refuses_two_sources_for_one_target",
+      "seq": 568311,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv letters.txt letters.txt docs",
+      "expect": {
+        "exit": 128,
+        "stdout": "",
+        "stderr": "fatal: multiple sources for the same target, source=letters.txt, destination=docs/letters.txt\n"
+      }
+    },
+    {
+      "id": "git_tag_creation_option_needs_a_name",
+      "seq": 568312,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -a",
+      "expect": {
+        "exit": 129,
+        "stdout": "",
+        "stderr": "usage: git tag [-a] [-f] [-m <msg>] <tagname> [<commit> | <object>]\n   or: git tag -d <tagname>...\n   or: git tag [-n[<num>]] -l [<pattern>...]\n"
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2813,6 +2813,34 @@
         "stdout": "exit=0\nzfirst\nzhere\nzmixed\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "git_log_takes_a_peel_before_an_ancestry_step",
+      "seq": 568360,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "step=$(git -C /repo log --oneline -n 1 'HEAD~1'); for rev in 'HEAD^{commit}~1' 'HEAD~1^{commit}' 'HEAD^{}~1'; do if [ \"$(git -C /repo log --oneline -n 1 \"$rev\")\" = \"$step\" ]; then echo same; else echo \"$rev differs\"; fi; done",
+      "expect": {
+        "exit": 0,
+        "stdout": "same\nsame\nsame\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_writes_at_a_chained_peel",
+      "seq": 568361,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag zchain 'HEAD^{commit}~1' && [ \"$(git -C /repo log --oneline -n 1 zchain)\" = \"$(git -C /repo log --oneline -n 1 'HEAD~1')\" ] && echo written; git -C /repo tag zwrong 'HEAD^{tree}~1'; echo exit=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "written\nexit=128\n",
+        "stderr": "fatal: Failed to resolve 'HEAD^{tree}~1' as a valid ref.\n"
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2155,6 +2155,34 @@
         "stdout": "",
         "stderr": "usage: git tag [-a] [-f] [-m <msg>] <tagname> [<commit> | <object>]\n   or: git tag -d <tagname>...\n   or: git tag [-n[<num>]] -l [<pattern>...]\n"
       }
+    },
+    {
+      "id": "git_switch_detach_defaults_to_head",
+      "seq": 568313,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch --detach > /dev/null 2>&1 && git -C /repo status -b --porcelain && git -C /repo switch main > /dev/null 2>&1",
+      "expect": {
+        "exit": 0,
+        "stdout": "## HEAD (no branch)\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_n0_prints_bare_names",
+      "seq": 568314,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -a n0tag -m 'has a message' && git -C /repo tag -n0 -l n0tag && git -C /repo tag -n1 -l n0tag && git -C /repo tag -d n0tag > /dev/null",
+      "expect": {
+        "exit": 0,
+        "stdout": "n0tag\nn0tag           has a message\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2211,6 +2211,34 @@
         "stdout": "",
         "stderr": "error: unknown switch `draft'\n"
       }
+    },
+    {
+      "id": "git_tag_takes_a_path_expression",
+      "seq": 568317,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag blobtag HEAD:letters.txt && git -C /repo tag -l blobtag && git -C /repo tag -d blobtag > /dev/null",
+      "expect": {
+        "exit": 0,
+        "stdout": "blobtag\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_switch_swaps_a_file_and_a_directory",
+      "seq": 568318,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "mkdir /repo/slot && echo deep > /repo/slot/child && git -C /repo add slot && git -C /repo commit -m deep > /dev/null && git -C /repo switch -c other 2> /dev/null && git -C /repo rm -r slot > /dev/null && echo flat > /repo/slot && git -C /repo add slot && git -C /repo commit -m flat > /dev/null && git -C /repo switch main 2> /dev/null && cat /repo/slot/child && git -C /repo switch other 2> /dev/null && cat /repo/slot",
+      "expect": {
+        "exit": 0,
+        "stdout": "deep\nflat\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2309,6 +2309,34 @@
         "stdout": "peelnested\npeelv1\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "git_rm_refuses_a_directory_and_keeps_the_index",
+      "seq": 568324,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "echo x > /repo/rmdir.txt && git -C /repo add rmdir.txt && git -C /repo commit -m rmdir > /dev/null && rm /repo/rmdir.txt && mkdir /repo/rmdir.txt && echo k > /repo/rmdir.txt/keep && git -C /repo rm rmdir.txt; echo exit=$?; git -C /repo status --short | grep rmdir",
+      "expect": {
+        "exit": 0,
+        "stdout": "rm 'rmdir.txt'\nexit=128\n D rmdir.txt\n?? rmdir.txt/\n",
+        "stderr": "fatal: git rm: 'rmdir.txt': Is a directory\n"
+      }
+    },
+    {
+      "id": "git_restore_replaces_a_linked_ancestor",
+      "seq": 568325,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "mkdir /repo/away && echo old > /repo/away/readme.md && rm -r /repo/docs && ln -s away /repo/docs && git -C /repo restore docs/readme.md && cat /repo/docs/readme.md && cat /repo/away/readme.md",
+      "expect": {
+        "exit": 0,
+        "stdout": "notes\nold\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2183,6 +2183,34 @@
         "stdout": "n0tag\nn0tag           has a message\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "git_rm_takes_a_dashed_pathspec_after_the_marker",
+      "seq": 568315,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "echo x > /repo/-draft && git -C /repo add -- -draft && git -C /repo rm -f -- -draft",
+      "expect": {
+        "exit": 0,
+        "stdout": "rm '-draft'\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_rm_refuses_a_dashed_operand_without_the_marker",
+      "seq": 568316,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo rm -draft",
+      "expect": {
+        "exit": 129,
+        "stdout": "",
+        "stderr": "error: unknown switch `draft'\n"
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2659,6 +2659,118 @@
         "stdout": "z\no\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "git_rm_refuses_a_tracked_path_a_link_now_hides",
+      "seq": 568349,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "mkdir -p /repo/zslot /repo/zaway && echo t > /repo/zslot/child && echo o > /repo/zaway/child && git -C /repo add zslot/child && git -C /repo commit -m zslot > /dev/null && rm -rf /repo/zslot && ln -s /repo/zaway /repo/zslot && git -C /repo rm zslot/child; echo exit=$?; cat /repo/zaway/child",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=1\no\n",
+        "stderr": "error: the following file has local modifications:\n    zslot/child\n(use --cached to keep the file, or -f to force removal)\n"
+      }
+    },
+    {
+      "id": "git_rm_cached_unstages_the_path_a_link_hides",
+      "seq": 568350,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo rm --cached zslot/child; echo exit=$?; cat /repo/zaway/child",
+      "expect": {
+        "exit": 0,
+        "stdout": "rm 'zslot/child'\nexit=0\no\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_rm_takes_a_path_whose_link_points_past_it",
+      "seq": 568351,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "mkdir -p /repo/znull /repo/zvoid && echo t > /repo/znull/child && git -C /repo add znull/child && git -C /repo commit -m znull > /dev/null && rm -rf /repo/znull && ln -s /repo/zvoid /repo/znull && git -C /repo rm znull/child; echo exit=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "rm 'znull/child'\nexit=0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_refuses_a_message_count_below_minus_one",
+      "seq": 568352,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -n-2; echo exit=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=128\n",
+        "stderr": "fatal: positive value expected contents:lines=-2\n"
+      }
+    },
+    {
+      "id": "git_tag_reads_the_count_before_it_reads_a_tag",
+      "seq": 568353,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -n-5 nosuchtag; echo exit=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=128\n",
+        "stderr": "fatal: positive value expected contents:lines=-5\n"
+      }
+    },
+    {
+      "id": "git_tag_minus_n_one_is_not_a_listing_flag",
+      "seq": 568354,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag tnone && git -C /repo tag -d -n-1 tnone > /dev/null; echo exit=$?; git -C /repo tag -l tnone",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=0\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_minus_n_one_leaves_a_creation_alone",
+      "seq": 568355,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -n-1 -a tannn -m body; echo exit=$?; git -C /repo tag -n1 tannn",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=0\ntannn           body\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_list_mode_outranks_the_message_count",
+      "seq": 568356,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -d -n-2 tannn; echo exit=$?; git -C /repo tag -l tannn",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=128\ntannn\n",
+        "stderr": "fatal: the '-n' option is only allowed in list mode\n"
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2267,6 +2267,48 @@
         "stdout": "flat\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "git_switch_carries_a_staged_addition",
+      "seq": 568321,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo branch carryadd && echo new > /repo/carryadd.txt && git -C /repo add carryadd.txt && git -C /repo switch carryadd 2>/dev/null | grep carryadd && git -C /repo status --short | grep carryadd",
+      "expect": {
+        "exit": 0,
+        "stdout": "A\tcarryadd.txt\nA  carryadd.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_switch_carries_a_staged_deletion",
+      "seq": 568322,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "echo gone > /repo/carrydel.txt && git -C /repo add carrydel.txt && git -C /repo commit -m carrydel > /dev/null && git -C /repo branch carrydel && git -C /repo rm --cached carrydel.txt > /dev/null && git -C /repo switch carrydel 2>/dev/null | grep carrydel && git -C /repo status --short | grep carrydel",
+      "expect": {
+        "exit": 0,
+        "stdout": "D\tcarrydel.txt\nD  carrydel.txt\n?? carrydel.txt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_takes_a_typed_tag_peel",
+      "seq": 568323,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -a peelv1 -m annotated && git -C /repo tag peelnested 'peelv1^{tag}' && git -C /repo tag -l 'peel*'",
+      "expect": {
+        "exit": 0,
+        "stdout": "peelnested\npeelv1\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2239,6 +2239,34 @@
         "stdout": "deep\nflat\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "git_restore_takes_a_tree_peel_as_a_source",
+      "seq": 568319,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "echo one > /repo/peel.txt && git -C /repo add peel.txt && git -C /repo commit -m peel > /dev/null && echo two > /repo/peel.txt && git -C /repo restore --source=HEAD^{tree} peel.txt && cat /repo/peel.txt",
+      "expect": {
+        "exit": 0,
+        "stdout": "one\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_restore_replaces_a_directory_an_untracked_file_holds",
+      "seq": 568320,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "echo flat > /repo/slot2 && git -C /repo add slot2 && git -C /repo commit -m slot2 > /dev/null && git -C /repo rm --cached slot2 > /dev/null && rm /repo/slot2 && mkdir /repo/slot2 && echo inner > /repo/slot2/child && git -C /repo add slot2/child && echo untracked > /repo/slot2/keep && git -C /repo restore --source=HEAD -SW slot2 && cat /repo/slot2",
+      "expect": {
+        "exit": 0,
+        "stdout": "flat\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2449,6 +2449,34 @@
         "stdout": "exit=1\nA  sslot\n",
         "stderr": "error: Your local changes to the following files would be overwritten by checkout:\n\tsslot\nPlease commit your changes or stash them before you switch branches.\nAborting\n"
       }
+    },
+    {
+      "id": "git_switch_still_refuses_an_untracked_file_in_the_way",
+      "seq": 568334,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo restore --staged sslot && git -C /repo switch -c ubase > /dev/null 2>&1 && git -C /repo switch -c ufile > /dev/null 2>&1 && mkdir -p /repo/uslot && echo kid > /repo/uslot/child && git -C /repo add uslot/child && git -C /repo commit -m ukid > /dev/null && git -C /repo switch ubase > /dev/null 2>&1 && echo untracked > /repo/uslot && git -C /repo switch ufile; echo exit=$?; cat /repo/uslot",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=1\nuntracked\n",
+        "stderr": "error: The following untracked working tree files would be overwritten by checkout:\n\tuslot\nPlease move or remove them before you switch branches.\nAborting\n"
+      }
+    },
+    {
+      "id": "git_switch_replaces_an_ignored_file_ancestor",
+      "seq": 568335,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'fslot\\n' >> /repo/.gitignore && git -C /repo add .gitignore && git -C /repo commit -m ign2 > /dev/null && git -C /repo switch -c fbase > /dev/null 2>&1 && git -C /repo switch -c ffile > /dev/null 2>&1 && mkdir -p /repo/fslot && echo kid > /repo/fslot/child && git -C /repo add -f fslot/child && git -C /repo commit -m fkid > /dev/null && git -C /repo switch fbase > /dev/null 2>&1 && echo ignored > /repo/fslot && git -C /repo switch ffile > /dev/null 2>&1 && cat /repo/fslot/child; git -C /repo status --short | grep fslot; echo exit=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "kid\nexit=1\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/cli/git.json
+++ b/integ/cli/git.json
@@ -2533,6 +2533,132 @@
         "stdout": "exit=1\nkeep\n",
         "stderr": "error: Updating the following directories would lose untracked files in them:\n\tnslot\n\nAborting\n"
       }
+    },
+    {
+      "id": "git_switch_refuses_a_staged_path_inside_a_replaced_directory",
+      "seq": 568340,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo switch -c gbase > /dev/null 2>&1 && git -C /repo switch -c gfile > /dev/null 2>&1 && echo asfile > /repo/gslot && git -C /repo add gslot && git -C /repo commit -m gfile > /dev/null && git -C /repo switch gbase > /dev/null 2>&1 && mkdir -p /repo/gslot && echo kid > /repo/gslot/child && git -C /repo add gslot/child && git -C /repo switch gfile; echo exit=$?; cat /repo/gslot/child",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=1\nkid\n",
+        "stderr": "error: Your local changes to the following files would be overwritten by checkout:\n\tgslot/child\nPlease commit your changes or stash them before you switch branches.\nAborting\n"
+      }
+    },
+    {
+      "id": "git_switch_replaces_a_directory_without_following_a_link_out_of_it",
+      "seq": 568341,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "printf 'llink\\n' >> /repo/.gitignore && git -C /repo add .gitignore && git -C /repo commit -m ign4 > /dev/null && git -C /repo switch -c lbase > /dev/null 2>&1 && git -C /repo switch -c lfile > /dev/null 2>&1 && echo asfile > /repo/lslot && git -C /repo add lslot && git -C /repo commit -m lfile > /dev/null && git -C /repo switch lbase > /dev/null 2>&1 && mkdir -p /repo/laway && echo outside > /repo/laway/keep && mkdir -p /repo/lslot && ln -s /repo/laway /repo/lslot/llink && git -C /repo switch lfile > /dev/null 2>&1 && cat /repo/lslot && cat /repo/laway/keep",
+      "expect": {
+        "exit": 0,
+        "stdout": "asfile\noutside\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_tag_refuses_a_ref_path_a_tag_above_it_holds",
+      "seq": 568342,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag tfoo && git -C /repo tag tfoo/bar; echo exit=$?; git -C /repo tag -l | grep tfoo",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=128\ntfoo\n",
+        "stderr": "fatal: cannot lock ref 'refs/tags/tfoo/bar': 'refs/tags/tfoo' exists; cannot create 'refs/tags/tfoo/bar'\n"
+      }
+    },
+    {
+      "id": "git_tag_refuses_a_ref_path_a_tag_below_it_holds",
+      "seq": 568343,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag tbaz/qux && git -C /repo tag tbaz; echo exit=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=128\n",
+        "stderr": "fatal: cannot lock ref 'refs/tags/tbaz': 'refs/tags/tbaz/qux' exists; cannot create 'refs/tags/tbaz'\n"
+      }
+    },
+    {
+      "id": "git_branch_refuses_a_ref_path_another_branch_holds",
+      "seq": 568344,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo branch tbb && git -C /repo branch tbb/cc; echo exit=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=128\n",
+        "stderr": "fatal: cannot lock ref 'refs/heads/tbb/cc': 'refs/heads/tbb' exists; cannot create 'refs/heads/tbb/cc'\n"
+      }
+    },
+    {
+      "id": "git_tag_reads_an_object_peel",
+      "seq": 568345,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo tag -a tv1 -m ann && git -C /repo tag ocopy 'HEAD^{object}' && git -C /repo tag owrap 'tv1^{object}' && git -C /repo tag -l | grep -E 'ocopy|owrap'",
+      "expect": {
+        "exit": 0,
+        "stdout": "ocopy\nowrap\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "git_mv_refuses_a_directory_and_something_inside_it",
+      "seq": 568346,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "mkdir -p /repo/mvdir /repo/mvdest && echo z > /repo/mvdir/file && git -C /repo add mvdir && git -C /repo commit -m mvdir > /dev/null && git -C /repo mv mvdir mvdir/file mvdest; echo exit=$?; cat /repo/mvdir/file",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=128\nz\n",
+        "stderr": "fatal: cannot move both 'mvdir/file' and its parent directory 'mvdir'\n"
+      }
+    },
+    {
+      "id": "git_mv_k_does_not_skip_an_overlapping_source",
+      "seq": 568347,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "git -C /repo mv -k mvdir/file mvdir mvdest; echo exit=$?; cat /repo/mvdir/file",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=128\nz\n",
+        "stderr": "fatal: cannot move both 'mvdir/file' and its parent directory 'mvdir'\n"
+      }
+    },
+    {
+      "id": "git_mv_k_taking_a_source_out_takes_it_out_of_the_overlap",
+      "seq": 568348,
+      "targets": [
+        "git-disk",
+        "git-ram"
+      ],
+      "command": "echo o > /repo/mvdir/other && git -C /repo mv -k mvdir mvdir/other mvdest && cat /repo/mvdest/mvdir/file && cat /repo/mvdest/mvdir/other",
+      "expect": {
+        "exit": 0,
+        "stdout": "z\no\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/unix/mv/dir_rename.json
+++ b/integ/unix/mv/dir_rename.json
@@ -159,6 +159,102 @@
         "stdout": "",
         "stderr": "mv: cannot stat '/data/mvdirn/nosuch': No such file or directory\n"
       }
+    },
+    {
+      "id": "mv_dir_rename_link_prep",
+      "seq": 613215,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mkdir -p /data/mvdirl/d && echo t > /data/mvdirl/t.txt && ln -s /data/mvdirl/t.txt /data/mvdirl/d/link",
+      "expect": {
+        "exit": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "mv_dir_rename_link_travels",
+      "seq": 613216,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "mv /data/mvdirl/d /data/mvdirl/e && readlink /data/mvdirl/e/link && cat /data/mvdirl/e/link",
+      "expect": {
+        "exit": 0,
+        "stdout": "/data/mvdirl/t.txt\nt\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "mv_dir_rename_link_left_the_old_name",
+      "seq": 613217,
+      "targets": [
+        "ram",
+        "disk",
+        "redis",
+        "opfs",
+        "s3",
+        "databricks",
+        "gridfs",
+        "s3-prefix",
+        "databricks-prefix",
+        "gridfs-prefix",
+        "dropbox",
+        "dropbox-root",
+        "onedrive",
+        "sharepoint",
+        "sharepoint-prefix",
+        "ssh",
+        "nextcloud",
+        "gdrive",
+        "gdrive-folder",
+        "box"
+      ],
+      "command": "readlink /data/mvdirl/d/link; echo exit=$?",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=1\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/python/mirage/commands/cli/builtin/git/__init__.py
+++ b/python/mirage/commands/cli/builtin/git/__init__.py
@@ -18,9 +18,14 @@ from mirage.commands.cli.builtin.git.checkout import checkout
 from mirage.commands.cli.builtin.git.commit import commit
 from mirage.commands.cli.builtin.git.diff import diff
 from mirage.commands.cli.builtin.git.log import log
+from mirage.commands.cli.builtin.git.mv import mv
 from mirage.commands.cli.builtin.git.reset import reset
+from mirage.commands.cli.builtin.git.restore import restore
+from mirage.commands.cli.builtin.git.rm import rm
 from mirage.commands.cli.builtin.git.show import show
 from mirage.commands.cli.builtin.git.status import status
+from mirage.commands.cli.builtin.git.switch import switch
+from mirage.commands.cli.builtin.git.tag import tag
 from mirage.commands.cli.types import CLISpec, UsageStyle
 from mirage.commands.spec.types import Operand, Option
 
@@ -127,6 +132,71 @@ COMMIT_OPTIONS = (
 CHECKOUT_OPTIONS = (Option(short="-b",
                            description="Create the branch and switch to it"), )
 
+SWITCH_OPTIONS = (
+    Option(short="-c",
+           long="--create",
+           type="str",
+           description="Create the branch and switch to it"),
+    Option(short="-d",
+           long="--detach",
+           description="Detach HEAD at the named commit"),
+)
+
+RESTORE_OPTIONS = (
+    Option(short="-S", long="--staged", description="Restore the index"),
+    Option(short="-W",
+           long="--worktree",
+           description="Restore the working tree (default)"),
+    Option(short="-s",
+           long="--source",
+           type="str",
+           description="Which tree-ish to restore from"),
+)
+
+RM_OPTIONS = (
+    Option(short="-r", description="Allow recursive removal"),
+    Option(long="--cached",
+           description="Only remove from the index, keeping the file"),
+    Option(short="-f",
+           long="--force",
+           description="Override the up-to-date check"),
+    Option(short="-q", long="--quiet",
+           description="Do not list removed files"),
+    Option(long="--ignore-unmatch",
+           description="Exit with a zero status even if nothing matched"),
+)
+
+MV_OPTIONS = (
+    Option(short="-f",
+           long="--force",
+           description="Force move/rename even if target exists"),
+    Option(short="-k", description="Skip move/rename errors"),
+    Option(short="-n", long="--dry-run", description="Dry run"),
+    Option(short="-v", long="--verbose", description="Be verbose"),
+)
+
+TAG_OPTIONS = (
+    Option(short="-l", long="--list", description="List tag names"),
+    # git spells the count attached (`-n2`) or not at all, never as a
+    # separate token, which is what value_optional says: a bare -n means
+    # one line and the next word is left alone to be a pattern.
+    Option(short="-n",
+           type="int",
+           value_optional=True,
+           description="Print <n> lines of each tag message"),
+    Option(short="-d", long="--delete", description="Delete tags"),
+    Option(short="-a",
+           long="--annotate",
+           description="Annotated tag, needs a message"),
+    Option(short="-m",
+           long="--message",
+           type="str",
+           multiple=True,
+           description="Tag message (repeatable, one paragraph each)"),
+    Option(short="-f", long="--force",
+           description="Replace the tag if exists"),
+)
+
 STATUS_OPTIONS = (
     Option(long="--porcelain",
            description="Machine-readable output, stable across versions"),
@@ -218,6 +288,46 @@ GIT = CLISpec(
             fn=checkout,
             options=CHECKOUT_OPTIONS,
             rest=REVISION,
+            write=True,
+        ),
+        CLISpec(
+            name="switch",
+            description="Switch branches",
+            fn=switch,
+            options=SWITCH_OPTIONS,
+            rest=REVISION,
+            write=True,
+        ),
+        CLISpec(
+            name="restore",
+            description="Restore working tree files",
+            fn=restore,
+            options=RESTORE_OPTIONS,
+            rest=PATHSPEC,
+            write=True,
+        ),
+        CLISpec(
+            name="rm",
+            description="Remove files from the working tree and the index",
+            fn=rm,
+            options=RM_OPTIONS,
+            rest=PATHSPEC,
+            write=True,
+        ),
+        CLISpec(
+            name="mv",
+            description="Move or rename a file, a directory, or a symlink",
+            fn=mv,
+            options=MV_OPTIONS,
+            rest=PATHSPEC,
+            write=True,
+        ),
+        CLISpec(
+            name="tag",
+            description="Create, list or delete a tag",
+            fn=tag,
+            options=TAG_OPTIONS,
+            rest=Operand(type="str"),
             write=True,
         ),
     ),

--- a/python/mirage/commands/cli/builtin/git/add.py
+++ b/python/mirage/commands/cli/builtin/git/add.py
@@ -32,8 +32,8 @@ from mirage.commands.cli.builtin.git.objects import store_blob
 from mirage.commands.cli.builtin.git.pathspec import matched, repo_relative
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.types import RepoLocation, WorkTree
-from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
-                                                  links_of, start_point)
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal, links_of, start_point)
 from mirage.commands.cli.builtin.git.worktree import UNTRACKED_ALL, scan
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
@@ -231,7 +231,7 @@ async def add(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
     try:
         if dispatch is None or stat_path is None:
             raise NoWorkspaceError()
-        check_operands(texts, UnknownSwitchError)
+        check_operands(texts, UnknownSwitchError, escaped(inv.argv))
         parsed = parse_flags(fl)
         if not texts and not parsed.every and not parsed.update:
             raise NothingSpecifiedError()

--- a/python/mirage/commands/cli/builtin/git/branch.py
+++ b/python/mirage/commands/cli/builtin/git/branch.py
@@ -23,11 +23,12 @@ from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     BranchExistsError, BranchNameRequiredError, CheckedOutBranchError,
     GitError, InvalidBranchNameError, NoBranchError, NoWorkspaceError,
-    UnknownSwitchError, UnmergedBranchError)
+    RefLockError, UnknownSwitchError, UnmergedBranchError)
 from mirage.commands.cli.builtin.git.format import short
 from mirage.commands.cli.builtin.git.objects import abbrev_for
-from mirage.commands.cli.builtin.git.refs import (delete_ref, read_head,
-                                                  valid_ref_name, write_ref)
+from mirage.commands.cli.builtin.git.refs import (blocking_ref, delete_ref,
+                                                  read_head, valid_ref_name,
+                                                  write_ref)
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.types import HeadRef, RepoLocation
@@ -87,6 +88,12 @@ async def _create(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
     if Ref(ref.encode()) in repo.refs.allkeys():
         raise BranchExistsError(name)
     commit = resolve_commit(repo, start or HEAD)
+    # Last, as it is for git: a ref whose path another ref already
+    # holds fails when the lock is taken, so a bad start point is
+    # reported first.
+    held = blocking_ref(repo.refs.allkeys(), ref)
+    if held is not None:
+        raise RefLockError(ref, held)
     await write_ref(dispatch, location.commondir, ref, commit.id)
 
 

--- a/python/mirage/commands/cli/builtin/git/branch.py
+++ b/python/mirage/commands/cli/builtin/git/branch.py
@@ -84,7 +84,7 @@ async def _create(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
     await write_ref(dispatch, location.commondir, ref, commit.id)
 
 
-def _head_commit(repo: BaseRepo, head: HeadRef) -> bytes | None:
+def head_commit(repo: BaseRepo, head: HeadRef) -> bytes | None:
     """The commit HEAD resolves to, None on an unborn branch.
 
     HEAD carries an object id only when detached; attached it names a
@@ -156,7 +156,7 @@ async def _delete(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
         raise CheckedOutBranchError(name, location.worktree)
     sha = repo.refs[ref]
     if not force and not await asyncio.to_thread(_merged, repo, sha,
-                                                 _head_commit(repo, head)):
+                                                 head_commit(repo, head)):
         raise UnmergedBranchError(name)
     await delete_ref(dispatch, location.commondir, ref.decode())
     return (f"Deleted branch {name} "

--- a/python/mirage/commands/cli/builtin/git/branch.py
+++ b/python/mirage/commands/cli/builtin/git/branch.py
@@ -22,12 +22,12 @@ from dulwich.walk import Walker
 from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     BranchExistsError, BranchNameRequiredError, CheckedOutBranchError,
-    GitError, NoBranchError, NoWorkspaceError, UnknownSwitchError,
-    UnmergedBranchError)
+    GitError, InvalidBranchNameError, NoBranchError, NoWorkspaceError,
+    UnknownSwitchError, UnmergedBranchError)
 from mirage.commands.cli.builtin.git.format import short
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.refs import (delete_ref, read_head,
-                                                  write_ref)
+                                                  valid_ref_name, write_ref)
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.types import HeadRef, RepoLocation
@@ -77,6 +77,11 @@ async def _create(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
         name (str): the branch name.
         start (str | None): the revision to start it at, HEAD when None.
     """
+    # Before the start point resolves, which is git's order here and
+    # the opposite of switch's. A ref is a path below .git, so an
+    # unchecked name reaches write_ref as one.
+    if not valid_ref_name(name):
+        raise InvalidBranchNameError(name)
     ref = f"{HEADS_PREFIX.decode()}{name}"
     if Ref(ref.encode()) in repo.refs.allkeys():
         raise BranchExistsError(name)

--- a/python/mirage/commands/cli/builtin/git/branch.py
+++ b/python/mirage/commands/cli/builtin/git/branch.py
@@ -31,7 +31,8 @@ from mirage.commands.cli.builtin.git.refs import (delete_ref, read_head,
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.types import HeadRef, RepoLocation
-from mirage.commands.cli.builtin.git.util import check_operands, fatal
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
@@ -196,7 +197,7 @@ async def branch(
     try:
         if dispatch is None:
             raise NoWorkspaceError()
-        check_operands(texts, UnknownSwitchError)
+        check_operands(texts, UnknownSwitchError, escaped(inv.argv))
         repo, location = await opened(fl, doors)
         head = await read_head(dispatch, location.gitdir)
         force = fl.as_bool("D")

--- a/python/mirage/commands/cli/builtin/git/changes.py
+++ b/python/mirage/commands/cli/builtin/git/changes.py
@@ -23,7 +23,7 @@ from dulwich.objects import Blob, ObjectID
 from dulwich.objectspec import parse_commit
 from dulwich.repo import BaseRepo
 
-from mirage.commands.cli.builtin.git.constants import HEAD_REF
+from mirage.commands.cli.builtin.git.constants import GITLINK, HEAD_REF
 from mirage.commands.cli.builtin.git.index import read_index
 from mirage.commands.cli.builtin.git.io import entry_bytes
 from mirage.commands.cli.builtin.git.types import (IndexState, RepoLocation,
@@ -351,6 +351,16 @@ async def work_changes(dispatch: DispatchFn, worktree: str,
     changes: dict[str, str] = {}
     for path, entry in entries.items():
         name = path.decode("utf-8", errors="replace")
+        # A 160000 entry records another repository's HEAD, and what
+        # stands at the name is a directory, so the walk never finds a
+        # file there and every submodule read as deleted. git compares
+        # the submodule's own HEAD, which is unreadable from here, and
+        # says nothing at all when there is none; saying nothing is both
+        # the closest this can get and what keeps a branch switch away
+        # from a submodule from being refused over a file that was never
+        # missing.
+        if entry.mode == GITLINK:
+            continue
         if name not in found.files:
             changes[name] = DELETED
         elif await _differs(dispatch, worktree, name, entry,

--- a/python/mirage/commands/cli/builtin/git/changes.py
+++ b/python/mirage/commands/cli/builtin/git/changes.py
@@ -89,26 +89,30 @@ def head_entries(repo: BaseRepo) -> dict[bytes, tuple[int, bytes]] | None:
     }
 
 
-def _exact_renames(adds: list[str], deletes: list[str],
-                   shas: dict[str, bytes]) -> list[tuple[str, str]]:
+def _exact_renames(adds: list[str], deletes: list[str], shas: dict[str, bytes],
+                   kinds: dict[str, int]) -> list[tuple[str, str]]:
     """Pair an add with a delete holding byte-identical content.
 
     Costs a dictionary rather than a read, so it runs first and takes
-    every pair it can before anything is fetched.
+    every pair it can before anything is fetched. Keyed by kind as well
+    as content, because a symlink and a regular file that happen to
+    share bytes are not a rename of each other, while a moved symlink
+    is exactly one.
 
     Args:
         adds (list[str]): paths the index has and HEAD does not.
         deletes (list[str]): paths HEAD has and the index does not.
         shas (dict[str, bytes]): blob id of each, on whichever side it
             exists.
+        kinds (dict[str, int]): the file-type bits of each.
     """
-    sources: dict[bytes, str] = {}
+    sources: dict[tuple[int, bytes], str] = {}
     for path in deletes:
-        sources.setdefault(shas[path], path)
+        sources.setdefault((kinds[path], shas[path]), path)
     taken: set[str] = set()
     pairs = []
     for path in adds:
-        origin = sources.get(shas[path])
+        origin = sources.get((kinds[path], shas[path]))
         if origin is not None and origin not in taken:
             taken.add(origin)
             pairs.append((path, origin))
@@ -165,31 +169,33 @@ def _content_renames(store: BaseObjectStore, adds: list[str],
 
 def _pair_renames(store: BaseObjectStore, staged: dict[str, str],
                   shas: dict[str, bytes],
-                  regular: set[str]) -> dict[str, tuple[str, str | None]]:
+                  kinds: dict[str, int]) -> dict[str, tuple[str, str | None]]:
     """Fold an add and a delete of the same file into one rename.
 
     Two passes, git's own order: identical content first, then what is
-    merely similar enough. Only regular files are candidates, because a
-    symlink and a file that happen to share bytes are not a rename of
-    each other.
+    merely similar enough. Both pair within one kind, and only the
+    second is limited to regular files: a moved symlink is a rename git
+    reports as one, but scoring a link against a file would pair two
+    unrelated things by the bytes of a path.
 
     Args:
         store (BaseObjectStore): the object database, read for blobs.
         staged (dict[str, str]): path to its one-letter staged status.
         shas (dict[str, bytes]): blob id on whichever side exists, for
             the added and deleted paths only.
-        regular (set[str]): of those, the ones that are regular files.
+        kinds (dict[str, int]): the file-type bits of each.
     """
     adds = sorted(path for path, letter in staged.items()
-                  if letter == ADDED and path in regular)
+                  if letter == ADDED and path in kinds)
     deletes = sorted(path for path, letter in staged.items()
-                     if letter == DELETED and path in regular)
-    pairs = _exact_renames(adds, deletes, shas)
+                     if letter == DELETED and path in kinds)
+    pairs = _exact_renames(adds, deletes, shas, kinds)
     matched_new = {new for new, _old in pairs}
     matched_old = {old for _new, old in pairs}
-    pairs.extend(
-        _content_renames(store, [p for p in adds if p not in matched_new],
-                         [p for p in deletes if p not in matched_old], shas))
+    scored = [[p for p in side if kinds[p] == S_IFREG]
+              for side in ([p for p in adds if p not in matched_new],
+                           [p for p in deletes if p not in matched_old])]
+    pairs.extend(_content_renames(store, scored[0], scored[1], shas))
     paired = {new: (RENAMED, old) for new, old in pairs}
     consumed = {old for _new, old in pairs}
     return {
@@ -219,15 +225,14 @@ def stage_changes(store: BaseObjectStore,
     tree = head or {}
     staged: dict[str, str] = {}
     shas: dict[str, bytes] = {}
-    regular: set[str] = set()
+    kinds: dict[str, int] = {}
     for path, entry in entries.items():
         name = path.decode("utf-8", errors="replace")
         recorded = tree.get(path)
         if recorded is None:
             staged[name] = ADDED
             shas[name] = entry.sha
-            if S_IFMT(entry.mode) == S_IFREG:
-                regular.add(name)
+            kinds[name] = S_IFMT(entry.mode)
         elif recorded[1] != entry.sha or recorded[0] != entry.mode:
             staged[name] = MODIFIED
     for path, (mode, sha) in tree.items():
@@ -235,9 +240,8 @@ def stage_changes(store: BaseObjectStore,
             name = path.decode("utf-8", errors="replace")
             staged[name] = DELETED
             shas[name] = sha
-            if S_IFMT(mode) == S_IFREG:
-                regular.add(name)
-    return _pair_renames(store, staged, shas, regular)
+            kinds[name] = S_IFMT(mode)
+    return _pair_renames(store, staged, shas, kinds)
 
 
 def staged_state(

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -35,6 +35,7 @@ from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
 from mirage.commands.cli.builtin.git.format import short, subject
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import (blocking_ancestor,
+                                                refuse_replaced_mounts,
                                                 remove_empty_parents,
                                                 remove_file, remove_tree,
                                                 restore_entry)
@@ -312,6 +313,15 @@ async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
     state = await read_index(dispatch, location.gitdir)
     state.conflicts.clear()
     changed = sorted(_written(before, after))
+    # Before the first removal, not at the entry that meets it: a
+    # refusal halfway through leaves the entries already written
+    # holding the target's content while HEAD and the index still name
+    # the branch being left, which is the half-switch every other check
+    # above exists to prevent.
+    await refuse_replaced_mounts(
+        stat_path, location.worktree,
+        [path.decode("utf-8", errors="replace")
+         for path in changed], links, mounts)
     blobs = await asyncio.to_thread(contents, repo,
                                     [after[path][1] for path in changed])
     # Removals first, and the emptied directories with them, because

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -30,7 +30,7 @@ from mirage.commands.cli.builtin.git.changes import (ADDED, DELETED, MODIFIED,
 from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     BadStartPointError, BranchExistsError, CheckoutConflictError, GitError,
-    NoWorkspaceError, ResolveIndexError, UnknownPathspecError,
+    NoWorkspaceError, RefLockError, ResolveIndexError, UnknownPathspecError,
     UnknownSwitchError)
 from mirage.commands.cli.builtin.git.format import short, subject
 from mirage.commands.cli.builtin.git.index import read_index, write_index
@@ -41,9 +41,9 @@ from mirage.commands.cli.builtin.git.io import (blocking_ancestor,
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.pathspec import under
 from mirage.commands.cli.builtin.git.reflog import record
-from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, detach_head,
-                                                  read_head, set_head,
-                                                  write_ref)
+from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, blocking_ref,
+                                                  detach_head, read_head,
+                                                  set_head, write_ref)
 from mirage.commands.cli.builtin.git.reset import restored
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
@@ -237,6 +237,33 @@ def _blocked_ancestors(writing: Tree, dirty: set[str]) -> list[str]:
         under(name, path) for name in names))
 
 
+def _blocked_descendants(writing: Tree, dirty: set[str]) -> list[str]:
+    """Which uncommitted paths a written file's directory would take with it.
+
+    The other half of the check above, over the same set. A staged
+    ``slot/child`` is in the way of a target recording the *file*
+    ``slot``, because the file cannot be written without removing the
+    directory, and the index entry for the child would survive the
+    switch as one half of a shape git's index has no room for. The
+    exact-key comparison misses it for the same reason as the ancestor
+    case: ``slot/child`` is in neither tree.
+
+    The same deliberate divergence, and named the same way. git allows
+    it: switching onto a branch recording the file ``slot`` with
+    ``slot/child`` staged succeeds, removes the directory, and drops
+    the staged entry with nothing left pointing at its blob. mirage
+    refuses and names the path instead. Pinned against git 2.50.1.
+
+    Args:
+        writing (Tree): the entries the switch writes, from ``_written``.
+        dirty (set[str]): paths whose working tree or index differs from
+            HEAD.
+    """
+    names = _tree_names(writing)
+    return sorted(path for path in dirty if any(
+        under(path, name) for name in names))
+
+
 def _lost_directories(writing: Tree, untracked: list[str]) -> list[str]:
     """Which directories the switch would empty of untracked files.
 
@@ -320,7 +347,7 @@ async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
         if links is None or links.stat_at(where) is None:
             info = await stat_path(where)
             if info is not None and info.type is FileType.DIRECTORY:
-                await remove_tree(dispatch, where)
+                await remove_tree(dispatch, where, links)
         await restore_entry(dispatch, where, mode, blobs[sha], links)
     # The index is git's two-way merge, not a copy of the target tree:
     # only a path the two trees disagree about is decided by the
@@ -509,7 +536,8 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
     writing = _written(before, after)
     blocked = sorted(
         set(_conflicts(before, after, dirty))
-        | set(_blocked_ancestors(writing, dirty)))
+        | set(_blocked_ancestors(writing, dirty))
+        | set(_blocked_descendants(writing, dirty)))
     overwritten = _overwritten(writing, found.untracked)
     lost = _lost_directories(writing, found.untracked)
     if blocked or overwritten or lost:
@@ -573,6 +601,12 @@ async def checkout(
                 raise BadStartPointError(start, target) from exc
         else:
             commit = resolve_commit(repo, target if not creating else HEAD)
+        # Before the working tree moves, which is where git refuses it
+        # too: the ref is locked first and nothing is checked out when
+        # the lock cannot be taken.
+        held = blocking_ref(known, ref.decode()) if creating else None
+        if held is not None:
+            raise RefLockError(ref.decode(), held)
         attached = creating or ref in known
         moved = await move_head(dispatch, stat_path, links_of(doors), repo,
                                 location, head, commit, target,

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -36,7 +36,8 @@ from mirage.commands.cli.builtin.git.format import short, subject
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import (blocking_ancestor,
                                                 remove_empty_parents,
-                                                remove_file, restore_entry)
+                                                remove_file, remove_tree,
+                                                restore_entry)
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.pathspec import under
 from mirage.commands.cli.builtin.git.reflog import record
@@ -56,6 +57,7 @@ from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
 from mirage.ops.types import LinkView, StatPath
 from mirage.runtime.types import DispatchFn
+from mirage.types import FileType
 
 Tree = dict[bytes, tuple[int, bytes]]
 
@@ -307,8 +309,19 @@ async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
                                         links)
         if above is not None:
             await remove_file(dispatch, above)
-        await restore_entry(dispatch, posixpath.join(location.worktree, name),
-                            mode, blobs[sha], links)
+        where = posixpath.join(location.worktree, name)
+        # And the same thing standing on the name itself rather than
+        # above it: a directory holding only ignored files is in no
+        # collision list either, since the check that refuses one is
+        # about the untracked files it would lose. git updates ignored
+        # files by default and takes the whole directory with it. A
+        # link is left to restore_entry, which retargets it; following
+        # one to a directory here would delete a tree no branch named.
+        if links is None or links.stat_at(where) is None:
+            info = await stat_path(where)
+            if info is not None and info.type is FileType.DIRECTORY:
+                await remove_tree(dispatch, where)
+        await restore_entry(dispatch, where, mode, blobs[sha], links)
     # The index is git's two-way merge, not a copy of the target tree:
     # only a path the two trees disagree about is decided by the
     # target, and where they agree the entry is left exactly as it

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -49,13 +49,13 @@ from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.types import HeadRef, RepoLocation
 from mirage.commands.cli.builtin.git.util import (  # yapf: disable
-    check_operands, escaped, fatal, links_of)
+    check_operands, escaped, fatal, links_of, mounts_of)
 from mirage.commands.cli.builtin.git.worktree import UNTRACKED_ALL, scan
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
-from mirage.ops.types import LinkView, StatPath
+from mirage.ops.types import LinkView, MountView, StatPath
 from mirage.runtime.types import DispatchFn
 from mirage.types import FileType
 
@@ -284,7 +284,7 @@ def _lost_directories(writing: Tree, untracked: list[str]) -> list[str]:
 
 async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
                   location: RepoLocation, before: Tree, after: Tree,
-                  links: LinkView | None) -> None:
+                  links: LinkView | None, mounts: MountView | None) -> None:
     """Make the working tree and index match the tree being switched to.
 
     Only paths the two trees disagree about are touched, so a file that
@@ -305,6 +305,9 @@ async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
         links (LinkView | None): the name plane's link facts, so an
             entry that changes between a link and a file replaces what
             is there rather than writing through it.
+        mounts (MountView | None): the name plane's mount boundaries,
+            so a directory holding a nested mount is refused rather
+            than emptied of a backend no branch recorded.
     """
     state = await read_index(dispatch, location.gitdir)
     state.conflicts.clear()
@@ -322,7 +325,7 @@ async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
         name = path.decode("utf-8", errors="replace")
         where = posixpath.join(location.worktree, name)
         await remove_file(dispatch, where)
-        await remove_empty_parents(dispatch, where, location.worktree)
+        await remove_empty_parents(dispatch, where, location.worktree, mounts)
     for path in changed:
         name = path.decode("utf-8", errors="replace")
         mode, sha = after[path]
@@ -347,7 +350,7 @@ async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
         if links is None or links.stat_at(where) is None:
             info = await stat_path(where)
             if info is not None and info.type is FileType.DIRECTORY:
-                await remove_tree(dispatch, where, links)
+                await remove_tree(dispatch, where, links, mounts)
         await restore_entry(dispatch, where, mode, blobs[sha], links)
     # The index is git's two-way merge, not a copy of the target tree:
     # only a path the two trees disagree about is decided by the
@@ -453,10 +456,10 @@ def _stage_letters(before: Tree, entries: dict[bytes,
 
 
 async def move_head(dispatch: DispatchFn, stat_path: StatPath,
-                    links: LinkView | None, repo: BaseRepo,
-                    location: RepoLocation, head: HeadRef, commit: Commit,
-                    target: str, ref: Ref | None, creating: bool,
-                    in_place: bool) -> dict[str, str]:
+                    links: LinkView | None, mounts: MountView | None,
+                    repo: BaseRepo, location: RepoLocation, head: HeadRef,
+                    commit: Commit, target: str, ref: Ref | None,
+                    creating: bool, in_place: bool) -> dict[str, str]:
     """Move HEAD, the index and the working tree to a commit.
 
     The one procedure ``checkout`` and ``switch`` share, since the two
@@ -474,6 +477,8 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
         stat_path (StatPath): dispatcher-backed stat, both channels.
         links (LinkView | None): the name plane's link facts, None
             outside a workspace.
+        mounts (MountView | None): the name plane's mount boundaries,
+            None outside a workspace.
         repo (BaseRepo): the opened repository.
         location (RepoLocation): the discovered repository.
         head (HeadRef): what HEAD pointed at before the move.
@@ -542,7 +547,8 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
     lost = _lost_directories(writing, found.untracked)
     if blocked or overwritten or lost:
         raise CheckoutConflictError(blocked, overwritten, lost)
-    await _switch(dispatch, stat_path, repo, location, before, after, links)
+    await _switch(dispatch, stat_path, repo, location, before, after, links,
+                  mounts)
     await _attach(dispatch, repo, location, head, commit, target, ref,
                   creating)
     return carried
@@ -608,10 +614,10 @@ async def checkout(
         if held is not None:
             raise RefLockError(ref.decode(), held)
         attached = creating or ref in known
-        moved = await move_head(dispatch, stat_path, links_of(doors), repo,
-                                location, head, commit, target,
-                                ref if attached else None, creating, creating
-                                and start is None)
+        moved = await move_head(dispatch, stat_path, links_of(doors),
+                                mounts_of(doors), repo, location, head, commit,
+                                target, ref if attached else None, creating,
+                                creating and start is None)
     except GitError as exc:
         return fatal(exc)
     carried = "".join(f"{letter}\t{path}\n"

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -27,7 +27,7 @@ from mirage.commands.cli.builtin.git.branch import head_commit
 from mirage.commands.cli.builtin.git.changes import (ADDED, DELETED, MODIFIED,
                                                      head_entries,
                                                      work_changes)
-from mirage.commands.cli.builtin.git.constants import HEAD
+from mirage.commands.cli.builtin.git.constants import GITLINK, HEAD
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     BadStartPointError, BranchExistsError, CheckoutConflictError, GitError,
     NoWorkspaceError, RefLockError, ResolveIndexError, UnknownPathspecError,
@@ -35,6 +35,7 @@ from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
 from mirage.commands.cli.builtin.git.format import short, subject
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import (blocking_ancestor,
+                                                keep_gitlink,
                                                 refuse_replaced_mounts,
                                                 remove_empty_parents,
                                                 remove_file, remove_tree,
@@ -313,6 +314,10 @@ async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
     state = await read_index(dispatch, location.gitdir)
     state.conflicts.clear()
     changed = sorted(_written(before, after))
+    # A gitlink is not written into the working tree at all, so it is
+    # neither read as a blob nor allowed to clear what stands at the
+    # name; keep_gitlink is the whole of what the entry asks for.
+    replacing = [path for path in changed if after[path][0] != GITLINK]
     # Before the first removal, not at the entry that meets it: a
     # refusal halfway through leaves the entries already written
     # holding the target's content while HEAD and the index still name
@@ -321,9 +326,9 @@ async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
     await refuse_replaced_mounts(
         stat_path, location.worktree,
         [path.decode("utf-8", errors="replace")
-         for path in changed], links, mounts)
+         for path in replacing], links, mounts)
     blobs = await asyncio.to_thread(contents, repo,
-                                    [after[path][1] for path in changed])
+                                    [after[path][1] for path in replacing])
     # Removals first, and the emptied directories with them, because
     # the two sets name the same place whenever a branch records a file
     # where the other records a directory: writing ``slot/child`` while
@@ -339,6 +344,10 @@ async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
     for path in changed:
         name = path.decode("utf-8", errors="replace")
         mode, sha = after[path]
+        if mode == GITLINK:
+            await keep_gitlink(dispatch, stat_path,
+                               posixpath.join(location.worktree, name), links)
+            continue
         # Whatever the removals above did not take, a component above
         # the entry may still not be a directory: an ignored file or
         # link is in neither tree and in no collision list, so it

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -28,10 +28,12 @@ from mirage.commands.cli.builtin.git.changes import head_entries, work_changes
 from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     BadStartPointError, BranchExistsError, CheckoutConflictError, GitError,
-    NoWorkspaceError, UnknownPathspecError, UnknownSwitchError)
+    NoWorkspaceError, ResolveIndexError, UnknownPathspecError,
+    UnknownSwitchError)
 from mirage.commands.cli.builtin.git.format import short, subject
 from mirage.commands.cli.builtin.git.index import read_index, write_index
-from mirage.commands.cli.builtin.git.io import remove_file, restore_entry
+from mirage.commands.cli.builtin.git.io import (remove_empty_parents,
+                                                remove_file, restore_entry)
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.pathspec import under
 from mirage.commands.cli.builtin.git.reflog import record
@@ -224,20 +226,27 @@ async def _switch(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
     state = await read_index(dispatch, location.gitdir)
     state.entries.clear()
     state.conflicts.clear()
-    changed = [
-        path for path in after if before.get(path) != after[path]
-        and path.decode("utf-8", errors="replace") not in keep
-    ]
+    changed = sorted(path for path in after if before.get(path) != after[path]
+                     and path.decode("utf-8", errors="replace") not in keep)
     blobs = await asyncio.to_thread(contents, repo,
                                     [after[path][1] for path in changed])
+    # Removals first, and the emptied directories with them, because
+    # the two sets name the same place whenever a branch records a file
+    # where the other records a directory: writing ``slot/child`` while
+    # the file ``slot`` is still there fails, and so does writing the
+    # file while the directory is. Nothing is read back from the
+    # working tree, so emptying it first is free. ``restore`` orders
+    # its own pass the same way, for the same reason.
+    for path in sorted(set(before) - set(after)):
+        name = path.decode("utf-8", errors="replace")
+        where = posixpath.join(location.worktree, name)
+        await remove_file(dispatch, where)
+        await remove_empty_parents(dispatch, where, location.worktree)
     for path in changed:
         name = path.decode("utf-8", errors="replace")
         mode, sha = after[path]
         await restore_entry(dispatch, posixpath.join(location.worktree, name),
                             mode, blobs[sha], links)
-    for path in set(before) - set(after):
-        name = path.decode("utf-8", errors="replace")
-        await remove_file(dispatch, posixpath.join(location.worktree, name))
     for path, (mode, sha) in after.items():
         name = path.decode("utf-8", errors="replace")
         held = staged.get(path)
@@ -268,20 +277,57 @@ def previous_position(repo: BaseRepo, head: HeadRef) -> str:
             f"{short(commit.id, abbrev_for(repo))} {subject(commit)}\n")
 
 
+async def _attach(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
+                  head: HeadRef, commit: Commit, target: str, ref: Ref | None,
+                  creating: bool) -> None:
+    """Point HEAD at a commit and write the reflog line for the move.
+
+    The half of a checkout that happens whatever the working tree
+    holds: a branch created where HEAD already is does only this.
+
+    Args:
+        dispatch (DispatchFn): workspace op dispatcher.
+        repo (BaseRepo): the opened repository.
+        location (RepoLocation): the discovered repository.
+        head (HeadRef): what HEAD pointed at before the move.
+        commit (Commit): the commit HEAD is moving to.
+        target (str): the operand as the user spelled it, for the
+            reflog.
+        ref (Ref | None): the branch to attach HEAD to, None to detach
+            it at the commit.
+        creating (bool): whether ``ref`` is a new branch to write first.
+    """
+    if creating and ref is not None:
+        await write_ref(dispatch, location.commondir, ref.decode(), commit.id)
+    if ref is not None:
+        await set_head(dispatch, location.gitdir, ref.decode())
+    else:
+        await detach_head(dispatch, location.gitdir, commit.id)
+    where = head.branch if head.branch is not None else short(
+        (head.commit or "").encode(), abbrev_for(repo))
+    await record(dispatch, location.gitdir,
+                 ref.decode() if ref is not None else None,
+                 head_commit(repo,
+                             head), commit.id, IDENTITY, int(time.time()),
+                 f"checkout: moving from {where} to {target}")
+
+
 async def move_head(dispatch: DispatchFn, stat_path: StatPath,
                     links: LinkView | None, repo: BaseRepo,
                     location: RepoLocation, head: HeadRef, commit: Commit,
-                    target: str, ref: Ref | None, creating: bool) -> set[str]:
+                    target: str, ref: Ref | None, creating: bool,
+                    in_place: bool) -> set[str]:
     """Move HEAD, the index and the working tree to a commit.
 
     The one procedure ``checkout`` and ``switch`` share, since the two
     differ only in what they accept and how they word a miss. Refuses
     rather than overwriting when the move would destroy work that is
-    not committed, whether that is an edit to a tracked file or an
-    untracked file the target holds. That check is the whole reason
-    either verb is safe to offer: without it a branch switch silently
-    throws away whatever was changed and not staged, and there is no
-    reflog here to get it back from.
+    not committed, whether that is an edit to a tracked file, an
+    untracked file the target holds, or a conflict still being
+    resolved. Those checks are the whole reason either verb is safe to
+    offer: without them a branch switch silently throws away whatever
+    was changed and not staged, and there is no reflog here to get it
+    back from.
 
     Args:
         dispatch (DispatchFn): workspace op dispatcher.
@@ -297,13 +343,35 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
         ref (Ref | None): the branch to attach HEAD to, None to detach
             it at the commit.
         creating (bool): whether ``ref`` is a new branch to write first.
+        in_place (bool): whether the line named no start point, so the
+            new branch is being created where HEAD already is.
 
     Returns:
         set[str]: paths whose uncommitted changes were carried across.
     """
+    # A branch created where HEAD already is moves nothing: git writes
+    # the ref, points HEAD at it, and never touches the working tree or
+    # the index, so an unmerged index survives ``git switch -c topic``
+    # and is refused by ``git switch -c topic HEAD`` a word later. The
+    # shape of the line is what decides it, which is git's own reading
+    # rather than a comparison of the two trees. Pinned against git
+    # 2.50.1.
+    if in_place:
+        await _attach(dispatch, repo, location, head, commit, target, ref,
+                      creating)
+        return set()
     before = await asyncio.to_thread(head_entries, repo) or {}
     after = await asyncio.to_thread(tree_of, repo, commit.id)
     state = await read_index(dispatch, location.gitdir)
+    # First, before either tree is compared and before the working tree
+    # is walked, which is where git refuses it too. Every check below
+    # reads stage 0, so a path held only as conflict stages is invisible
+    # to all of them and the move would clear the stages and delete the
+    # file, throwing away a resolution in progress.
+    if state.conflicts:
+        raise ResolveIndexError([
+            path.decode("utf-8", errors="replace") for path in state.conflicts
+        ])
     tracked = {
         path.decode("utf-8", errors="replace")
         for path in state.entries
@@ -332,19 +400,8 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
         raise CheckoutConflictError(blocked, overwritten, lost)
     await _switch(dispatch, repo, location, before, after, dirty,
                   state.entries, links)
-    if creating and ref is not None:
-        await write_ref(dispatch, location.commondir, ref.decode(), commit.id)
-    if ref is not None:
-        await set_head(dispatch, location.gitdir, ref.decode())
-    else:
-        await detach_head(dispatch, location.gitdir, commit.id)
-    where = head.branch if head.branch is not None else short(
-        (head.commit or "").encode(), abbrev_for(repo))
-    await record(dispatch, location.gitdir,
-                 ref.decode() if ref is not None else None,
-                 head_commit(repo,
-                             head), commit.id, IDENTITY, int(time.time()),
-                 f"checkout: moving from {where} to {target}")
+    await _attach(dispatch, repo, location, head, commit, target, ref,
+                  creating)
     return dirty
 
 
@@ -404,7 +461,8 @@ async def checkout(
         attached = creating or ref in known
         dirty = await move_head(dispatch, stat_path, links_of(doors), repo,
                                 location, head, commit, target,
-                                ref if attached else None, creating)
+                                ref if attached else None, creating, creating
+                                and start is None)
     except GitError as exc:
         return fatal(exc)
     carried = "".join(f"M\t{path}\n" for path in sorted(dirty))

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -24,7 +24,9 @@ from dulwich.refs import Ref
 from dulwich.repo import BaseRepo
 
 from mirage.commands.cli.builtin.git.branch import head_commit
-from mirage.commands.cli.builtin.git.changes import head_entries, work_changes
+from mirage.commands.cli.builtin.git.changes import (ADDED, DELETED, MODIFIED,
+                                                     head_entries,
+                                                     work_changes)
 from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     BadStartPointError, BranchExistsError, CheckoutConflictError, GitError,
@@ -156,8 +158,31 @@ def _tree_names(tree: Tree) -> set[str]:
     return {name.decode("utf-8", errors="replace") for name in tree}
 
 
-def _overwritten(after: Tree, untracked: list[str]) -> list[str]:
-    """Which untracked files the tree being switched to would write over.
+def _written(before: Tree, after: Tree) -> Tree:
+    """The entries a switch actually writes into the working tree.
+
+    Every check that asks what is standing in the way has to ask about
+    these rather than about the whole target tree. A path both trees
+    record identically is never written, so an untracked file sitting on
+    it is left exactly where it is; that file is one the index staged a
+    deletion for, and git carries the staged deletion rather than
+    refusing the switch over the copy left on disk. Content does not
+    enter into it from the other side either: a path only the target
+    records is refused even when the untracked copy already matches it
+    byte for byte. Pinned against git 2.50.1.
+
+    Args:
+        before (Tree): the tree HEAD records.
+        after (Tree): the tree being switched to.
+    """
+    return {
+        path: entry
+        for path, entry in after.items() if before.get(path) != entry
+    }
+
+
+def _overwritten(writing: Tree, untracked: list[str]) -> list[str]:
+    """Which untracked files the entries being written would write over.
 
     An untracked file is in neither tree and neither index, so the
     comparison above cannot see it, and writing the target branch's blob
@@ -171,15 +196,15 @@ def _overwritten(after: Tree, untracked: list[str]) -> list[str]:
     untracked file itself there, not the entry that needs the room.
 
     Args:
-        after (Tree): the tree being switched to.
+        writing (Tree): the entries the switch writes, from ``_written``.
         untracked (list[str]): every untracked path the walk found.
     """
-    names = _tree_names(after)
+    names = _tree_names(writing)
     return sorted(path for path in untracked
                   if path in names or any(under(name, path) for name in names))
 
 
-def _lost_directories(after: Tree, untracked: list[str]) -> list[str]:
+def _lost_directories(writing: Tree, untracked: list[str]) -> list[str]:
     """Which directories the switch would empty of untracked files.
 
     The mirror of the case above: the target records a *file* where the
@@ -190,24 +215,24 @@ def _lost_directories(after: Tree, untracked: list[str]) -> list[str]:
     2.50.1.
 
     Args:
-        after (Tree): the tree being switched to.
+        writing (Tree): the entries the switch writes, from ``_written``.
         untracked (list[str]): every untracked path the walk found.
     """
-    return sorted(name for name in _tree_names(after) if any(
+    return sorted(name for name in _tree_names(writing) if any(
         under(path, name) for path in untracked))
 
 
 async def _switch(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
-                  before: Tree, after: Tree, keep: set[str],
-                  staged: dict[bytes,
-                               IndexEntry], links: LinkView | None) -> None:
+                  before: Tree, after: Tree, links: LinkView | None) -> None:
     """Make the working tree and index match the tree being switched to.
 
-    Only paths whose recorded content differs are touched, so a file
-    that is the same on both branches keeps whatever the working tree
-    has, including an uncommitted edit. A path carried across keeps its
-    index entry too, which is what preserves a staged change that both
-    branches happen to agree about.
+    Only paths the two trees disagree about are touched, so a file that
+    is the same on both branches keeps whatever the working tree has,
+    including an uncommitted edit, and keeps its index entry, which is
+    what preserves a staged change both branches happen to agree about.
+    Every path the trees do disagree about has already been refused by
+    the caller if anything uncommitted stands on it, so the tree diff is
+    the whole decision here.
 
     Args:
         dispatch (DispatchFn): workspace op dispatcher.
@@ -215,19 +240,13 @@ async def _switch(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
         location (RepoLocation): the discovered repository.
         before (Tree): the tree HEAD records.
         after (Tree): the tree being switched to.
-        keep (set[str]): paths whose working-tree copy must not be
-            rewritten.
-        staged (dict[bytes, IndexEntry]): the index as it stands, read
-            for the entries of the paths being kept.
         links (LinkView | None): the name plane's link facts, so an
             entry that changes between a link and a file replaces what
             is there rather than writing through it.
     """
     state = await read_index(dispatch, location.gitdir)
-    state.entries.clear()
     state.conflicts.clear()
-    changed = sorted(path for path in after if before.get(path) != after[path]
-                     and path.decode("utf-8", errors="replace") not in keep)
+    changed = sorted(_written(before, after))
     blobs = await asyncio.to_thread(contents, repo,
                                     [after[path][1] for path in changed])
     # Removals first, and the emptied directories with them, because
@@ -247,13 +266,19 @@ async def _switch(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
         mode, sha = after[path]
         await restore_entry(dispatch, posixpath.join(location.worktree, name),
                             mode, blobs[sha], links)
-    for path, (mode, sha) in after.items():
-        name = path.decode("utf-8", errors="replace")
-        held = staged.get(path)
-        if name in keep and held is not None:
-            state.entries[path] = held
-        else:
-            state.entries[path] = restored(ObjectID(sha), mode)
+    # The index is git's two-way merge, not a copy of the target tree:
+    # only a path the two trees disagree about is decided by the
+    # target, and where they agree the entry is left exactly as it
+    # stands. That is what carries all three kinds of staged work
+    # across. Rebuilding the index from the target alone dropped a
+    # staged addition, which is in neither tree, and resurrected a
+    # staged deletion, which is in both and in no entry, turning both
+    # into unstaged changes a later commit would silently omit.
+    for path in changed:
+        mode, sha = after[path]
+        state.entries[path] = restored(ObjectID(sha), mode)
+    for path in set(before) - set(after):
+        state.entries.pop(path, None)
     await write_index(dispatch, location.gitdir, state)
 
 
@@ -312,11 +337,43 @@ async def _attach(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
                  f"checkout: moving from {where} to {target}")
 
 
+def _stage_letters(before: Tree, entries: dict[bytes,
+                                               IndexEntry]) -> dict[str, str]:
+    """How the index differs from HEAD, one status letter per path.
+
+    The same three comparisons ``status`` makes against HEAD, kept
+    here rather than borrowed from ``stage_changes`` because that one
+    pairs renames and this list does not: git letters a carried change
+    by what it is on its own, and an unmerged path cannot reach this
+    (the caller refuses one before any tree is read).
+
+    A path the index has no entry for is the one git's own reading gets
+    right and a walk of the entries cannot see at all: a staged
+    deletion is an absence, so it has to be read off HEAD's tree.
+
+    Args:
+        before (Tree): the tree HEAD records.
+        entries (dict[bytes, IndexEntry]): the index as it stands.
+    """
+    letters: dict[str, str] = {}
+    for path, entry in entries.items():
+        name = path.decode("utf-8", errors="replace")
+        recorded = before.get(path)
+        if recorded is None:
+            letters[name] = ADDED
+        elif recorded != (entry.mode, entry.sha):
+            letters[name] = MODIFIED
+    for path in before:
+        if path not in entries:
+            letters[path.decode("utf-8", errors="replace")] = DELETED
+    return letters
+
+
 async def move_head(dispatch: DispatchFn, stat_path: StatPath,
                     links: LinkView | None, repo: BaseRepo,
                     location: RepoLocation, head: HeadRef, commit: Commit,
                     target: str, ref: Ref | None, creating: bool,
-                    in_place: bool) -> set[str]:
+                    in_place: bool) -> dict[str, str]:
     """Move HEAD, the index and the working tree to a commit.
 
     The one procedure ``checkout`` and ``switch`` share, since the two
@@ -347,7 +404,8 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
             new branch is being created where HEAD already is.
 
     Returns:
-        set[str]: paths whose uncommitted changes were carried across.
+        dict[str, str]: each path whose uncommitted change was carried
+        across, against the status letter git prints for it.
     """
     # A branch created where HEAD already is moves nothing: git writes
     # the ref, points HEAD at it, and never touches the working tree or
@@ -359,7 +417,7 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
     if in_place:
         await _attach(dispatch, repo, location, head, commit, target, ref,
                       creating)
-        return set()
+        return {}
     before = await asyncio.to_thread(head_entries, repo) or {}
     after = await asyncio.to_thread(tree_of, repo, commit.id)
     state = await read_index(dispatch, location.gitdir)
@@ -384,25 +442,24 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
                        links)
     unstaged = await work_changes(dispatch, location.worktree, state.entries,
                                   found)
+    staged = _stage_letters(before, state.entries)
     # Both kinds of uncommitted change count: an edit in the working
     # tree, and one already staged. Leaving the staged ones out is
-    # what silently threw them away.
-    staged = {
-        path.decode("utf-8", errors="replace")
-        for path, entry in state.entries.items()
-        if before.get(path) != (entry.mode, entry.sha)
-    }
-    dirty = set(unstaged) | staged
+    # what silently threw them away. The index column wins where a path
+    # has both, which is how git's own short status reads a row and how
+    # it letters this list.
+    carried = dict(unstaged) | staged
+    dirty = set(carried)
+    writing = _written(before, after)
     blocked = _conflicts(before, after, dirty)
-    overwritten = _overwritten(after, found.untracked)
-    lost = _lost_directories(after, found.untracked)
+    overwritten = _overwritten(writing, found.untracked)
+    lost = _lost_directories(writing, found.untracked)
     if blocked or overwritten or lost:
         raise CheckoutConflictError(blocked, overwritten, lost)
-    await _switch(dispatch, repo, location, before, after, dirty,
-                  state.entries, links)
+    await _switch(dispatch, repo, location, before, after, links)
     await _attach(dispatch, repo, location, head, commit, target, ref,
                   creating)
-    return dirty
+    return carried
 
 
 async def checkout(
@@ -459,13 +516,14 @@ async def checkout(
         else:
             commit = resolve_commit(repo, target if not creating else HEAD)
         attached = creating or ref in known
-        dirty = await move_head(dispatch, stat_path, links_of(doors), repo,
+        moved = await move_head(dispatch, stat_path, links_of(doors), repo,
                                 location, head, commit, target,
                                 ref if attached else None, creating, creating
                                 and start is None)
     except GitError as exc:
         return fatal(exc)
-    carried = "".join(f"M\t{path}\n" for path in sorted(dirty))
+    carried = "".join(f"{letter}\t{path}\n"
+                      for path, letter in sorted(moved.items()))
     note = previous_position(repo, head)
     if attached:
         verb = "Switched to a new branch" if creating else "Switched to branch"

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -34,7 +34,8 @@ from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     UnknownSwitchError)
 from mirage.commands.cli.builtin.git.format import short, subject
 from mirage.commands.cli.builtin.git.index import read_index, write_index
-from mirage.commands.cli.builtin.git.io import (remove_empty_parents,
+from mirage.commands.cli.builtin.git.io import (blocking_ancestor,
+                                                remove_empty_parents,
                                                 remove_file, restore_entry)
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.pathspec import under
@@ -204,6 +205,36 @@ def _overwritten(writing: Tree, untracked: list[str]) -> list[str]:
                   if path in names or any(under(name, path) for name in names))
 
 
+def _blocked_ancestors(writing: Tree, dirty: set[str]) -> list[str]:
+    """Which uncommitted paths stand where a written entry needs a directory.
+
+    The same shape as the untracked check above, over the other set: an
+    index entry at ``slot`` is in the way of a target recording
+    ``slot/child``, because the directory cannot be created without
+    removing the file. The exact-key comparison cannot see it, since
+    ``slot`` is in neither tree.
+
+    Deliberate divergence, and the same trade the staged case above
+    makes. git allows this and discards the staged addition in silence:
+    ``git switch`` onto a branch recording ``slot/child`` with ``slot``
+    staged succeeds, replaces the file with the directory and leaves a
+    clean status, with the staged blob reachable from nothing. Where the
+    working tree *also* differs from the index git refuses instead,
+    filed oddly under its untracked wording. mirage refuses both and
+    names the path: there is no reflog here to recover a staged blob
+    from, and a refusal the caller can act on beats a silent discard.
+    Pinned against git 2.50.1.
+
+    Args:
+        writing (Tree): the entries the switch writes, from ``_written``.
+        dirty (set[str]): paths whose working tree or index differs from
+            HEAD.
+    """
+    names = _tree_names(writing)
+    return sorted(path for path in dirty if any(
+        under(name, path) for name in names))
+
+
 def _lost_directories(writing: Tree, untracked: list[str]) -> list[str]:
     """Which directories the switch would empty of untracked files.
 
@@ -222,8 +253,9 @@ def _lost_directories(writing: Tree, untracked: list[str]) -> list[str]:
         under(path, name) for path in untracked))
 
 
-async def _switch(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
-                  before: Tree, after: Tree, links: LinkView | None) -> None:
+async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
+                  location: RepoLocation, before: Tree, after: Tree,
+                  links: LinkView | None) -> None:
     """Make the working tree and index match the tree being switched to.
 
     Only paths the two trees disagree about are touched, so a file that
@@ -236,6 +268,7 @@ async def _switch(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
 
     Args:
         dispatch (DispatchFn): workspace op dispatcher.
+        stat_path (StatPath): the data plane's stat, which dereferences.
         repo (BaseRepo): the opened repository.
         location (RepoLocation): the discovered repository.
         before (Tree): the tree HEAD records.
@@ -264,6 +297,16 @@ async def _switch(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
     for path in changed:
         name = path.decode("utf-8", errors="replace")
         mode, sha = after[path]
+        # Whatever the removals above did not take, a component above
+        # the entry may still not be a directory: an ignored file or
+        # link is in neither tree and in no collision list, so it
+        # reaches here. git replaces it with the directory the entry
+        # needs rather than writing through it, which is what keeps a
+        # link's target tree, a path no branch named, out of the way.
+        above = await blocking_ancestor(stat_path, location.worktree, name,
+                                        links)
+        if above is not None:
+            await remove_file(dispatch, above)
         await restore_entry(dispatch, posixpath.join(location.worktree, name),
                             mode, blobs[sha], links)
     # The index is git's two-way merge, not a copy of the target tree:
@@ -451,12 +494,14 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
     carried = dict(unstaged) | staged
     dirty = set(carried)
     writing = _written(before, after)
-    blocked = _conflicts(before, after, dirty)
+    blocked = sorted(
+        set(_conflicts(before, after, dirty))
+        | set(_blocked_ancestors(writing, dirty)))
     overwritten = _overwritten(writing, found.untracked)
     lost = _lost_directories(writing, found.untracked)
     if blocked or overwritten or lost:
         raise CheckoutConflictError(blocked, overwritten, lost)
-    await _switch(dispatch, repo, location, before, after, links)
+    await _switch(dispatch, stat_path, repo, location, before, after, links)
     await _attach(dispatch, repo, location, head, commit, target, ref,
                   creating)
     return carried

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -36,7 +36,7 @@ from mirage.commands.cli.builtin.git.index import (read_index,
                                                    refuse_unresolved,
                                                    write_index)
 from mirage.commands.cli.builtin.git.io import (  # yapf: disable
-    blocking_ancestor, keep_gitlink, refuse_replaced_mounts,
+    blocking_ancestor, drop_gitlink, keep_gitlink, refuse_replaced_mounts,
     remove_empty_parents, remove_file, remove_tree, restore_entry)
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.pathspec import under
@@ -47,7 +47,8 @@ from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, blocking_ref,
 from mirage.commands.cli.builtin.git.reset import restored
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
-from mirage.commands.cli.builtin.git.types import HeadRef, RepoLocation
+from mirage.commands.cli.builtin.git.types import (HeadMove, HeadRef,
+                                                   RepoLocation)
 from mirage.commands.cli.builtin.git.util import (  # yapf: disable
     check_operands, escaped, fatal, links_of, mounts_of)
 from mirage.commands.cli.builtin.git.worktree import UNTRACKED_ALL, scan
@@ -295,7 +296,8 @@ def _lost_directories(writing: Tree, untracked: list[str]) -> list[str]:
 
 async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
                   location: RepoLocation, before: Tree, after: Tree,
-                  links: LinkView | None, mounts: MountView | None) -> None:
+                  links: LinkView | None,
+                  mounts: MountView | None) -> list[str]:
     """Make the working tree and index match the tree being switched to.
 
     Only paths the two trees disagree about are touched, so a file that
@@ -345,10 +347,21 @@ async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
     # file while the directory is. Nothing is read back from the
     # working tree, so emptying it first is free. ``restore`` orders
     # its own pass the same way, for the same reason.
+    notes: list[str] = []
     for path in sorted(set(before) - set(after)):
         name = path.decode("utf-8", errors="replace")
         where = posixpath.join(location.worktree, name)
-        await remove_file(dispatch, where)
+        # A gitlink the target tree drops is a directory, not a file:
+        # git rmdirs it and warns rather than failing when something is
+        # still in it, where the unlink here died on it with the
+        # removals ahead of it already applied.
+        if before[path][0] == GITLINK:
+            warned = await drop_gitlink(dispatch, stat_path, where, name,
+                                        links)
+            if warned is not None:
+                notes.append(warned)
+        else:
+            await remove_file(dispatch, where)
         await remove_empty_parents(dispatch, where, location.worktree, mounts)
     for path in changed:
         name = path.decode("utf-8", errors="replace")
@@ -394,6 +407,7 @@ async def _switch(dispatch: DispatchFn, stat_path: StatPath, repo: BaseRepo,
     for path in set(before) - set(after):
         state.entries.pop(path, None)
     await write_index(dispatch, location.gitdir, state)
+    return notes
 
 
 def previous_position(repo: BaseRepo, head: HeadRef) -> str:
@@ -487,7 +501,7 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
                     links: LinkView | None, mounts: MountView | None,
                     repo: BaseRepo, location: RepoLocation, head: HeadRef,
                     commit: Commit, target: str, ref: Ref | None,
-                    creating: bool, in_place: bool) -> dict[str, str]:
+                    creating: bool, in_place: bool) -> HeadMove:
     """Move HEAD, the index and the working tree to a commit.
 
     The one procedure ``checkout`` and ``switch`` share, since the two
@@ -520,8 +534,8 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
             new branch is being created where HEAD already is.
 
     Returns:
-        dict[str, str]: each path whose uncommitted change was carried
-        across, against the status letter git prints for it.
+        HeadMove: the paths whose uncommitted change was carried across,
+        and any warning the removals could not avoid.
     """
     # A branch created where HEAD already is moves nothing: git writes
     # the ref, points HEAD at it, and never touches the working tree or
@@ -533,7 +547,7 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
     if in_place:
         await _attach(dispatch, repo, location, head, commit, target, ref,
                       creating)
-        return {}
+        return HeadMove({}, "")
     before = await asyncio.to_thread(head_entries, repo) or {}
     after = await asyncio.to_thread(tree_of, repo, commit.id)
     state = await read_index(dispatch, location.gitdir)
@@ -572,11 +586,11 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
     lost = _lost_directories(writing, found.untracked)
     if blocked or overwritten or lost:
         raise CheckoutConflictError(blocked, overwritten, lost)
-    await _switch(dispatch, stat_path, repo, location, before, after, links,
-                  mounts)
+    notes = await _switch(dispatch, stat_path, repo, location, before, after,
+                          links, mounts)
     await _attach(dispatch, repo, location, head, commit, target, ref,
                   creating)
-    return carried
+    return HeadMove(carried, "".join(notes))
 
 
 async def checkout(
@@ -652,8 +666,11 @@ async def checkout(
     except GitError as exc:
         return fatal(exc)
     carried = "".join(f"{letter}\t{path}\n"
-                      for path, letter in sorted(moved.items()))
-    note = previous_position(repo, head)
+                      for path, letter in sorted(moved.carried.items()))
+    # git writes the warning above everything it says about the move,
+    # because the directory it could not remove is a fact about the
+    # working tree rather than about where HEAD went.
+    note = moved.warnings + previous_position(repo, head)
     if attached:
         verb = "Switched to a new branch" if creating else "Switched to branch"
         note += f"{verb} '{target}'\n"

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -79,21 +79,30 @@ Turn off this advice by setting config variable advice.detachedHead to false
 """
 
 
-def tree_of(repo: BaseRepo, commit_id: ObjectID) -> Tree:
-    """Every path a commit's tree holds, with its mode and blob id.
+def flat_tree(repo: BaseRepo, tree_id: ObjectID) -> Tree:
+    """Every path one tree holds, with its mode and blob id.
 
     Synchronous, and called on a worker thread: reading a tree pulls
     objects through the dispatcher.
 
     Args:
         repo (BaseRepo): the opened repository.
-        commit_id (ObjectID): the commit to read.
+        tree_id (ObjectID): the tree to read.
     """
-    commit = parse_commit(repo, commit_id)
     return {
         entry.path: (entry.mode, entry.sha)
-        for entry in iter_tree_contents(repo.object_store, commit.tree)
+        for entry in iter_tree_contents(repo.object_store, tree_id)
     }
+
+
+def tree_of(repo: BaseRepo, commit_id: ObjectID) -> Tree:
+    """Every path a commit's tree holds, with its mode and blob id.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        commit_id (ObjectID): the commit to read.
+    """
+    return flat_tree(repo, parse_commit(repo, commit_id).tree)
 
 
 def contents(repo: BaseRepo, shas: list[bytes]) -> dict[bytes, bytes]:

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -30,16 +30,14 @@ from mirage.commands.cli.builtin.git.changes import (ADDED, DELETED, MODIFIED,
 from mirage.commands.cli.builtin.git.constants import GITLINK, HEAD
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     BadStartPointError, BranchExistsError, CheckoutConflictError, GitError,
-    NoWorkspaceError, RefLockError, ResolveIndexError, UnknownPathspecError,
-    UnknownSwitchError)
+    NoWorkspaceError, RefLockError, UnknownPathspecError, UnknownSwitchError)
 from mirage.commands.cli.builtin.git.format import short, subject
-from mirage.commands.cli.builtin.git.index import read_index, write_index
-from mirage.commands.cli.builtin.git.io import (blocking_ancestor,
-                                                keep_gitlink,
-                                                refuse_replaced_mounts,
-                                                remove_empty_parents,
-                                                remove_file, remove_tree,
-                                                restore_entry)
+from mirage.commands.cli.builtin.git.index import (read_index,
+                                                   refuse_unresolved,
+                                                   write_index)
+from mirage.commands.cli.builtin.git.io import (  # yapf: disable
+    blocking_ancestor, keep_gitlink, refuse_replaced_mounts,
+    remove_empty_parents, remove_file, remove_tree, restore_entry)
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.pathspec import under
 from mirage.commands.cli.builtin.git.reflog import record
@@ -276,11 +274,22 @@ def _lost_directories(writing: Tree, untracked: list[str]) -> list[str]:
     the directory is what the caller has to move. Pinned against git
     2.50.1.
 
+    A gitlink is not one of those entries. It asks for a directory, not
+    for a file, so an existing one is left standing with everything in
+    it, and git takes this switch rather than refusing it. Pinned
+    against git 2.50.1; an untracked *file* at the same name is still
+    refused, by the check above, because the directory cannot be made
+    without deleting it.
+
     Args:
         writing (Tree): the entries the switch writes, from ``_written``.
         untracked (list[str]): every untracked path the walk found.
     """
-    return sorted(name for name in _tree_names(writing) if any(
+    replacing = _tree_names({
+        path: entry
+        for path, entry in writing.items() if entry[0] != GITLINK
+    })
+    return sorted(name for name in replacing if any(
         under(path, name) for path in untracked))
 
 
@@ -533,10 +542,7 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
     # reads stage 0, so a path held only as conflict stages is invisible
     # to all of them and the move would clear the stages and delete the
     # file, throwing away a resolution in progress.
-    if state.conflicts:
-        raise ResolveIndexError([
-            path.decode("utf-8", errors="replace") for path in state.conflicts
-        ])
+    refuse_unresolved(state)
     tracked = {
         path.decode("utf-8", errors="replace")
         for path in state.entries
@@ -613,6 +619,12 @@ async def checkout(
             except GitError as exc:
                 raise UnknownPathspecError(target) from exc
         if not creating and target == head.branch:
+            # The shortcut moves nothing, and that is exactly why it
+            # has to read the index: git refuses the line over an
+            # unresolved index rather than answering that there is
+            # nothing to do, so a caller cannot read "Already on" as
+            # proof the repository is in a state it can build on.
+            refuse_unresolved(await read_index(dispatch, location.gitdir))
             return None, IOResult(stderr=f"Already on '{target}'\n".encode())
         # ``checkout -b <new> [<start>]`` branches from the start point
         # when one is given, HEAD otherwise. Forcing HEAD here put the new

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -18,28 +18,29 @@ import time
 
 from dulwich.index import IndexEntry
 from dulwich.object_store import iter_tree_contents
-from dulwich.objects import Blob, ObjectID
+from dulwich.objects import Blob, Commit, ObjectID
 from dulwich.objectspec import parse_commit
 from dulwich.refs import Ref
 from dulwich.repo import BaseRepo
 
+from mirage.commands.cli.builtin.git.branch import head_commit
 from mirage.commands.cli.builtin.git.changes import head_entries, work_changes
 from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     BadStartPointError, BranchExistsError, CheckoutConflictError, GitError,
     NoWorkspaceError, UnknownPathspecError, UnknownSwitchError)
-from mirage.commands.cli.builtin.git.format import short
+from mirage.commands.cli.builtin.git.format import short, subject
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import remove_file, restore_entry
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.reflog import record
-from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, HEAD_REF,
-                                                  detach_head, read_head,
-                                                  set_head, write_ref)
+from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, detach_head,
+                                                  read_head, set_head,
+                                                  write_ref)
 from mirage.commands.cli.builtin.git.reset import restored
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
-from mirage.commands.cli.builtin.git.types import RepoLocation
+from mirage.commands.cli.builtin.git.types import HeadRef, RepoLocation
 from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
                                                   links_of)
 from mirage.commands.cli.builtin.git.worktree import UNTRACKED_ALL, scan
@@ -47,7 +48,7 @@ from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
-from mirage.ops.types import LinkView
+from mirage.ops.types import LinkView, StatPath
 from mirage.runtime.types import DispatchFn
 
 Tree = dict[bytes, tuple[int, bytes]]
@@ -203,16 +204,112 @@ async def _switch(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
     await write_index(dispatch, location.gitdir, state)
 
 
+def previous_position(repo: BaseRepo, head: HeadRef) -> str:
+    """git's line for leaving a detached HEAD, empty when it was on a branch.
+
+    Printed before the line saying where HEAD went, because a commit made
+    while detached is reachable from nothing once HEAD moves, and this is
+    the one place its id is still written down for the caller.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        head (HeadRef): what HEAD pointed at before the move.
+    """
+    if head.commit is None:
+        return ""
+    commit = repo.object_store[ObjectID(head.commit.encode())]
+    if not isinstance(commit, Commit):
+        return ""
+    return (f"Previous HEAD position was "
+            f"{short(commit.id, abbrev_for(repo))} {subject(commit)}\n")
+
+
+async def move_head(dispatch: DispatchFn, stat_path: StatPath,
+                    links: LinkView | None, repo: BaseRepo,
+                    location: RepoLocation, head: HeadRef, commit: Commit,
+                    target: str, ref: Ref | None, creating: bool) -> set[str]:
+    """Move HEAD, the index and the working tree to a commit.
+
+    The one procedure ``checkout`` and ``switch`` share, since the two
+    differ only in what they accept and how they word a miss. Refuses
+    rather than overwriting when the move would destroy work that is
+    not committed, whether that is an edit to a tracked file or an
+    untracked file the target holds. That check is the whole reason
+    either verb is safe to offer: without it a branch switch silently
+    throws away whatever was changed and not staged, and there is no
+    reflog here to get it back from.
+
+    Args:
+        dispatch (DispatchFn): workspace op dispatcher.
+        stat_path (StatPath): dispatcher-backed stat, both channels.
+        links (LinkView | None): the name plane's link facts, None
+            outside a workspace.
+        repo (BaseRepo): the opened repository.
+        location (RepoLocation): the discovered repository.
+        head (HeadRef): what HEAD pointed at before the move.
+        commit (Commit): the commit to move to.
+        target (str): the operand as the user spelled it, for the
+            reflog.
+        ref (Ref | None): the branch to attach HEAD to, None to detach
+            it at the commit.
+        creating (bool): whether ``ref`` is a new branch to write first.
+
+    Returns:
+        set[str]: paths whose uncommitted changes were carried across.
+    """
+    before = await asyncio.to_thread(head_entries, repo) or {}
+    after = await asyncio.to_thread(tree_of, repo, commit.id)
+    state = await read_index(dispatch, location.gitdir)
+    tracked = {
+        path.decode("utf-8", errors="replace")
+        for path in state.entries
+    }
+    # UNTRACKED_ALL, not the mode status uses: "normal" collapses a
+    # wholly untracked directory to one ``dir/`` entry, and a
+    # collision has to be decided per file. git names the file
+    # inside such a directory, so the list has to hold it.
+    found = await scan(dispatch, stat_path, location, tracked, UNTRACKED_ALL,
+                       links)
+    unstaged = await work_changes(dispatch, location.worktree, state.entries,
+                                  found)
+    # Both kinds of uncommitted change count: an edit in the working
+    # tree, and one already staged. Leaving the staged ones out is
+    # what silently threw them away.
+    staged = {
+        path.decode("utf-8", errors="replace")
+        for path, entry in state.entries.items()
+        if before.get(path) != (entry.mode, entry.sha)
+    }
+    dirty = set(unstaged) | staged
+    blocked = _conflicts(before, after, dirty)
+    overwritten = _overwritten(after, found.untracked)
+    if blocked or overwritten:
+        raise CheckoutConflictError(blocked, overwritten)
+    await _switch(dispatch, repo, location, before, after, dirty,
+                  state.entries, links)
+    if creating and ref is not None:
+        await write_ref(dispatch, location.commondir, ref.decode(), commit.id)
+    if ref is not None:
+        await set_head(dispatch, location.gitdir, ref.decode())
+    else:
+        await detach_head(dispatch, location.gitdir, commit.id)
+    where = head.branch if head.branch is not None else short(
+        (head.commit or "").encode(), abbrev_for(repo))
+    await record(dispatch, location.gitdir,
+                 ref.decode() if ref is not None else None,
+                 head_commit(repo,
+                             head), commit.id, IDENTITY, int(time.time()),
+                 f"checkout: moving from {where} to {target}")
+    return dirty
+
+
 async def checkout(
         inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
     """Switch the working tree to another branch or commit.
 
     Refuses rather than overwriting when the switch would destroy work
-    that is not committed, whether that is an edit to a tracked file or
-    an untracked file the target branch happens to hold. That check is
-    the whole reason this verb is safe to offer: without it a branch
-    switch silently throws away whatever was changed and not staged, and
-    there is no reflog here to get it back from.
+    that is not committed; see ``move_head``, which does the moving for
+    ``switch`` as well.
 
     Args:
         inv (CLIInvocation[None]): the line's invocation record.
@@ -259,62 +356,19 @@ async def checkout(
                 raise BadStartPointError(start, target) from exc
         else:
             commit = resolve_commit(repo, target if not creating else HEAD)
-        before = await asyncio.to_thread(head_entries, repo) or {}
-        after = await asyncio.to_thread(tree_of, repo, commit.id)
-        state = await read_index(dispatch, location.gitdir)
-        tracked = {
-            path.decode("utf-8", errors="replace")
-            for path in state.entries
-        }
-        # UNTRACKED_ALL, not the mode status uses: "normal" collapses a
-        # wholly untracked directory to one ``dir/`` entry, and a
-        # collision has to be decided per file. git names the file
-        # inside such a directory, so the list has to hold it.
-        found = await scan(dispatch, stat_path, location, tracked,
-                           UNTRACKED_ALL, links_of(doors))
-        unstaged = await work_changes(dispatch, location.worktree,
-                                      state.entries, found)
-        # Both kinds of uncommitted change count: an edit in the working
-        # tree, and one already staged. Leaving the staged ones out is
-        # what silently threw them away.
-        staged = {
-            path.decode("utf-8", errors="replace")
-            for path, entry in state.entries.items()
-            if before.get(path) != (entry.mode, entry.sha)
-        }
-        dirty = set(unstaged) | staged
-        blocked = _conflicts(before, after, dirty)
-        overwritten = _overwritten(after, found.untracked)
-        if blocked or overwritten:
-            raise CheckoutConflictError(blocked, overwritten)
-        await _switch(dispatch, repo, location, before, after, dirty,
-                      state.entries, links_of(doors))
         attached = creating or ref in known
-        if creating:
-            await write_ref(dispatch, location.commondir, ref.decode(),
-                            commit.id)
-        if attached:
-            await set_head(dispatch, location.gitdir, ref.decode())
-        else:
-            await detach_head(dispatch, location.gitdir, commit.id)
-        where = head.branch if head.branch is not None else short(
-            (head.commit or "").encode(), abbrev_for(repo))
-        await record(
-            dispatch, location.gitdir,
-            ref.decode() if attached else None,
-            head.commit.encode() if head.commit else
-            (repo.refs[HEAD_REF] if head.ref in known else None), commit.id,
-            IDENTITY, int(time.time()),
-            f"checkout: moving from {where} to {target}")
+        dirty = await move_head(dispatch, stat_path, links_of(doors), repo,
+                                location, head, commit, target,
+                                ref if attached else None, creating)
     except GitError as exc:
         return fatal(exc)
     carried = "".join(f"M\t{path}\n" for path in sorted(dirty))
+    note = previous_position(repo, head)
     if attached:
         verb = "Switched to a new branch" if creating else "Switched to branch"
-        note = f"{verb} '{target}'\n"
+        note += f"{verb} '{target}'\n"
     else:
-        subject = commit.message.decode(errors="replace").splitlines()[0]
-        note = (f"Note: switching to '{target}'.\n\n{DETACHED_ADVICE}\n"
-                f"HEAD is now at {short(commit.id, abbrev_for(repo))} "
-                f"{subject}\n")
+        note += (f"Note: switching to '{target}'.\n\n{DETACHED_ADVICE}\n"
+                 f"HEAD is now at {short(commit.id, abbrev_for(repo))} "
+                 f"{subject(commit)}\n")
     return yield_bytes(carried.encode()), IOResult(stderr=note.encode())

--- a/python/mirage/commands/cli/builtin/git/checkout.py
+++ b/python/mirage/commands/cli/builtin/git/checkout.py
@@ -33,6 +33,7 @@ from mirage.commands.cli.builtin.git.format import short, subject
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import remove_file, restore_entry
 from mirage.commands.cli.builtin.git.objects import abbrev_for
+from mirage.commands.cli.builtin.git.pathspec import under
 from mirage.commands.cli.builtin.git.reflog import record
 from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, detach_head,
                                                   read_head, set_head,
@@ -41,8 +42,8 @@ from mirage.commands.cli.builtin.git.reset import restored
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.types import HeadRef, RepoLocation
-from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
-                                                  links_of)
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal, links_of)
 from mirage.commands.cli.builtin.git.worktree import UNTRACKED_ALL, scan
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
@@ -144,6 +145,15 @@ def _conflicts(before: Tree, after: Tree, dirty: set[str]) -> list[str]:
                   if before.get(path.encode()) != after.get(path.encode()))
 
 
+def _tree_names(tree: Tree) -> set[str]:
+    """The paths a tree records, as text.
+
+    Args:
+        tree (Tree): a flattened tree, keyed by encoded path.
+    """
+    return {name.decode("utf-8", errors="replace") for name in tree}
+
+
 def _overwritten(after: Tree, untracked: list[str]) -> list[str]:
     """Which untracked files the tree being switched to would write over.
 
@@ -153,11 +163,36 @@ def _overwritten(after: Tree, untracked: list[str]) -> list[str]:
     one. An ignored file is not in this list and git overwrites it
     silently, which is the same split. Pinned against git 2.50.
 
+    Equality is not the whole test. An untracked file ``slot`` is also
+    in the way of a target that records ``slot/child``, because the
+    directory cannot be created without deleting it; git names the
+    untracked file itself there, not the entry that needs the room.
+
     Args:
         after (Tree): the tree being switched to.
         untracked (list[str]): every untracked path the walk found.
     """
-    return sorted(path for path in untracked if path.encode() in after)
+    names = _tree_names(after)
+    return sorted(path for path in untracked
+                  if path in names or any(under(name, path) for name in names))
+
+
+def _lost_directories(after: Tree, untracked: list[str]) -> list[str]:
+    """Which directories the switch would empty of untracked files.
+
+    The mirror of the case above: the target records a *file* where the
+    working tree has a directory, so writing it means removing the
+    directory, and anything untracked inside it is gone. git words this
+    one differently and names the directory rather than the files, since
+    the directory is what the caller has to move. Pinned against git
+    2.50.1.
+
+    Args:
+        after (Tree): the tree being switched to.
+        untracked (list[str]): every untracked path the walk found.
+    """
+    return sorted(name for name in _tree_names(after) if any(
+        under(path, name) for path in untracked))
 
 
 async def _switch(dispatch: DispatchFn, repo: BaseRepo, location: RepoLocation,
@@ -292,8 +327,9 @@ async def move_head(dispatch: DispatchFn, stat_path: StatPath,
     dirty = set(unstaged) | staged
     blocked = _conflicts(before, after, dirty)
     overwritten = _overwritten(after, found.untracked)
-    if blocked or overwritten:
-        raise CheckoutConflictError(blocked, overwritten)
+    lost = _lost_directories(after, found.untracked)
+    if blocked or overwritten or lost:
+        raise CheckoutConflictError(blocked, overwritten, lost)
     await _switch(dispatch, repo, location, before, after, dirty,
                   state.entries, links)
     if creating and ref is not None:
@@ -335,7 +371,7 @@ async def checkout(
     try:
         if dispatch is None or stat_path is None:
             raise NoWorkspaceError()
-        check_operands(texts, UnknownSwitchError)
+        check_operands(texts, UnknownSwitchError, escaped(inv.argv))
         if not texts:
             raise UnknownPathspecError("")
         target = texts[0]

--- a/python/mirage/commands/cli/builtin/git/constants.py
+++ b/python/mirage/commands/cli/builtin/git/constants.py
@@ -24,6 +24,10 @@ REGULAR = 0o100644
 EXECUTABLE = 0o100755
 SYMLINK = 0o120000
 OWNER_EXECUTE = 0o100
+# The part of a tree entry's mode that is a permission: what a restored
+# entry's own bits are set from, the object type above it being the
+# mount's business rather than the tree's.
+PERMISSION_BITS = 0o777
 
 # The symbolic ref every verb resolves first, and the ref-space spelling
 # dulwich takes for it.

--- a/python/mirage/commands/cli/builtin/git/constants.py
+++ b/python/mirage/commands/cli/builtin/git/constants.py
@@ -23,6 +23,10 @@ from dulwich.refs import Ref
 REGULAR = 0o100644
 EXECUTABLE = 0o100755
 SYMLINK = 0o120000
+# A gitlink: the commit another repository is checked out at. It is not
+# an object this repository holds, so nothing about it is written into
+# the working tree; git only makes sure a directory stands at the name.
+GITLINK = 0o160000
 OWNER_EXECUTE = 0o100
 # The part of a tree entry's mode that is a permission: what a restored
 # entry's own bits are set from, the object type above it being the

--- a/python/mirage/commands/cli/builtin/git/diff.py
+++ b/python/mirage/commands/cli/builtin/git/diff.py
@@ -24,7 +24,8 @@ from mirage.commands.cli.builtin.git.errors import (GitError,
                                                     NoWorkspaceError)
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
-from mirage.commands.cli.builtin.git.util import check_operands, fatal
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
@@ -90,7 +91,7 @@ async def diff(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
     try:
         if dispatch is None:
             raise NoWorkspaceError()
-        check_operands(texts, InvalidOptionError)
+        check_operands(texts, InvalidOptionError, escaped(inv.argv))
         repo, _location = await opened(fl, doors)
         new_rev = texts[1] if len(texts) >= 2 else HEAD
         body = await asyncio.to_thread(_render, repo, texts[0], new_rev)

--- a/python/mirage/commands/cli/builtin/git/errors.py
+++ b/python/mirage/commands/cli/builtin/git/errors.py
@@ -467,13 +467,18 @@ class UnknownPathspecError(GitError):
                          f"known to git")
 
 
-def _conflict_block(header: str, paths: list[str], advice: str) -> str:
+def _conflict_block(header: str, paths: list[str], advice: str = "") -> str:
     """One named-files paragraph of a checkout refusal.
+
+    The advice line is optional because one of git's three paragraphs
+    has none: the directory one ends at its list, which renders as the
+    blank line before the next paragraph.
 
     Args:
         header (str): the line that introduces the list.
         paths (list[str]): the files to name, one per tab-indented line.
-        advice (str): the line telling the caller what to do about them.
+        advice (str): the line telling the caller what to do about them,
+            empty for a paragraph git words without one.
     """
     listed = "\n".join(f"\t{path}" for path in sorted(paths))
     return f"{header}\n{listed}\n{advice}"
@@ -486,21 +491,28 @@ class CheckoutConflictError(GitError):
     the one safety check that makes checkout usable at all: without it a
     branch switch silently destroys whatever was edited and not staged.
 
-    Two kinds of work are at risk and git words them differently: a
-    tracked file carrying uncommitted changes, and an untracked file the
-    target branch would write over. Both are carried here rather than
-    raised separately because when both apply git prints both
-    paragraphs and aborts once, pinned against git 2.50.
+    Three kinds of work are at risk and git words them differently: a
+    tracked file carrying uncommitted changes, an untracked *directory*
+    the target replaces with a file of the same name, and an untracked
+    file the target branch would write over. All three are carried here
+    rather than raised separately because when several apply git prints
+    every paragraph and aborts once, in this order, pinned against git
+    2.50.1.
 
     Args:
         local (list[str]): tracked files with uncommitted changes.
+        directories (list[str]): directories holding untracked files
+            that the target records a file at.
         untracked (list[str]): untracked files the target branch holds.
     """
 
     prefix = "error"
     code = 1
 
-    def __init__(self, local: list[str], untracked: list[str]) -> None:
+    def __init__(self,
+                 local: list[str],
+                 untracked: list[str],
+                 directories: list[str] | None = None) -> None:
         blocks: list[str] = []
         if local:
             blocks.append(
@@ -509,6 +521,11 @@ class CheckoutConflictError(GitError):
                     "overwritten by checkout:", local,
                     "Please commit your changes or stash them before you "
                     "switch branches."))
+        if directories:
+            blocks.append(
+                _conflict_block(
+                    "Updating the following directories would lose "
+                    "untracked files in them:", directories))
         if untracked:
             blocks.append(
                 _conflict_block(

--- a/python/mirage/commands/cli/builtin/git/errors.py
+++ b/python/mirage/commands/cli/builtin/git/errors.py
@@ -44,11 +44,17 @@ class GitError(Exception):
     refusal is a report rather than an error ("nothing to commit"), and
     such a report goes to stdout because that is where the report it
     replaces would have gone.
+
+    ``report`` is the other half of a refusal git splits across both
+    streams: the sentence saying it refused goes to stderr, and the
+    per-path diagnosis naming what is in the way goes to stdout, which
+    is where the same lines would have gone had the command run.
     """
 
     prefix: str | None = "fatal"
     code = FATAL_EXIT
     stream = "stderr"
+    report = ""
 
 
 class NotARepositoryError(GitError):
@@ -536,6 +542,59 @@ class CheckoutConflictError(GitError):
         # carries the prefix inline: the renderer only writes the first.
         joined = "error: ".join(f"{block}\n" for block in blocks)
         super().__init__(f"{joined}Aborting")
+
+
+class ResolveIndexError(GitError):
+    """A branch move while the index still records conflict stages.
+
+    Every collision check a checkout makes reads stage 0, so a path
+    held only as stages 1-3 is invisible to all of them: the move would
+    clear the stages and delete the working-tree copy, throwing away a
+    conflict resolution in progress with no reflog to recover it from.
+    git refuses first, before it reads either tree.
+
+    Both streams carry part of it, pinned against git 2.50.1: the
+    per-path diagnosis is stdout's, written by the index refresh that
+    found the stages, and the sentence saying the command stopped is
+    stderr's. Exit 1, not the 128 a fatal takes.
+
+    Args:
+        paths (list[str]): every path the index still holds stages for.
+    """
+
+    prefix = "error"
+    code = 1
+
+    def __init__(self, paths: list[str]) -> None:
+        self.report = "".join(f"{path}: needs merge\n"
+                              for path in sorted(paths))
+        super().__init__("you need to resolve your current index first")
+
+
+class UnmergedPathError(GitError):
+    """``restore`` naming a path the source cannot put back.
+
+    A path with conflict stages has no stage-0 content, so restoring
+    the working tree from the index has nothing to write and restoring
+    the index from a tree that does not hold the path has nothing to
+    stage. git names each such path and does none of the work; a path
+    the source *does* hold restores normally and the stages go with it.
+
+    One line per path, so several are refused in one answer rather than
+    one per run. Pinned against git 2.50.1.
+
+    Args:
+        paths (list[str]): the selected paths still in conflict.
+    """
+
+    prefix = "error"
+    code = 1
+
+    def __init__(self, paths: list[str]) -> None:
+        # git emits each path as its own error, so every line after the
+        # first carries the prefix inline: the renderer writes one.
+        super().__init__("\nerror: ".join(f"path '{path}' is unmerged"
+                                          for path in sorted(paths)))
 
 
 class UnknownSwitchError(GitError):

--- a/python/mirage/commands/cli/builtin/git/errors.py
+++ b/python/mirage/commands/cli/builtin/git/errors.py
@@ -939,6 +939,49 @@ class TagNotFoundError(GitError):
         super().__init__(f"tag '{name}' not found.")
 
 
+class ListModeOnlyError(GitError):
+    """``-n`` on a ``tag`` line that deletes rather than lists.
+
+    ``-n`` asks for message lines beside each name, which only a listing
+    prints, and git makes it *imply* a listing rather than refuse it:
+    ``git tag -n1 nosuch`` is a listing whose pattern matches nothing
+    and exits 0. The implication is what cannot happen once ``-d`` has
+    already said what mode the line is in, so git dies there instead,
+    with the tags untouched. Refusing it matters more here than the
+    wording does: read as a listing flag and dropped, the line went on
+    to delete the refs its operands named. Pinned against git 2.50.1.
+
+    Args:
+        None.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("the '-n' option is only allowed in list mode")
+
+
+class RefUpdateConflictError(GitError):
+    """``tag -d`` naming one tag twice.
+
+    git stages every deletion on the line as one ref transaction, and a
+    transaction holding two updates for the same ref is refused before
+    any of them applies, so the whole line is a no-op: the repeated tag
+    survives, and so does every other tag the line named. The ref it
+    blames is the first in ref order rather than the first typed, since
+    the transaction sorts before it looks for the repeat. Reported the
+    way git reports it, as an ``error`` exiting 1 rather than a fatal.
+
+    Args:
+        ref (str): the full ref name given twice (``refs/tags/v``).
+    """
+
+    prefix = "error"
+    code = 1
+
+    def __init__(self, ref: str) -> None:
+        super().__init__("could not delete references: multiple updates "
+                         f"for ref '{ref}' not allowed")
+
+
 class InvalidTagNameError(GitError):
     """A tag name git's ref rules refuse.
 

--- a/python/mirage/commands/cli/builtin/git/errors.py
+++ b/python/mirage/commands/cli/builtin/git/errors.py
@@ -537,3 +537,329 @@ class InvalidOptionError(GitError):
 
     def __init__(self, argument: str) -> None:
         super().__init__(f"invalid option: {argument}")
+
+
+class NoPathspecRemoveError(GitError):
+    """``rm`` with no pathspec at all.
+
+    Args:
+        None.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("No pathspec was given. Which files should I remove?")
+
+
+class NotRecursiveError(GitError):
+    """``rm`` naming a directory without ``-r``.
+
+    Args:
+        operand (str): the operand as the user spelled it.
+    """
+
+    def __init__(self, operand: str) -> None:
+        super().__init__(f"not removing '{operand}' recursively without -r")
+
+
+# The three refusals ``rm`` groups its paths under, in the order git
+# prints them: a path whose staged content matches neither the file
+# nor HEAD, a path with a staged change, a path with an unstaged edit.
+# Each header comes in a singular and a plural form.
+STAGED_BOTH = ("the following file has staged content different from "
+               "both the\nfile and the HEAD:",
+               "the following files have staged content different from "
+               "both the\nfile and the HEAD:", "(use -f to force removal)")
+STAGED_INDEX = ("the following file has changes staged in the index:",
+                "the following files have changes staged in the index:",
+                "(use --cached to keep the file, or -f to force removal)")
+LOCAL_CHANGES = ("the following file has local modifications:",
+                 "the following files have local modifications:",
+                 "(use --cached to keep the file, or -f to force removal)")
+
+
+def _removal_block(wording: tuple[str, str, str], paths: list[str]) -> str:
+    """One paragraph of an ``rm`` refusal.
+
+    Args:
+        wording (tuple[str, str, str]): singular header, plural header,
+            and the hint line that closes the paragraph.
+        paths (list[str]): the paths to name, repository-relative.
+    """
+    header = wording[0] if len(paths) == 1 else wording[1]
+    listed = "\n".join(f"    {path}" for path in sorted(paths))
+    return f"{header}\n{listed}\n{wording[2]}"
+
+
+class RemovalRefusedError(GitError):
+    """``rm`` naming a path whose removal would lose uncommitted work.
+
+    git refuses rather than deleting, and names every path under the
+    reason it refused it. Three reasons, printed as three paragraphs in
+    a fixed order when more than one applies, pinned against git 2.50.1.
+
+    Args:
+        both (list[str]): paths staged with content that matches neither
+            the working tree nor HEAD.
+        staged (list[str]): paths with a change staged in the index.
+        local (list[str]): paths with an unstaged edit.
+    """
+
+    prefix = "error"
+    code = 1
+
+    def __init__(self, both: list[str], staged: list[str],
+                 local: list[str]) -> None:
+        blocks = [
+            _removal_block(wording, paths)
+            for wording, paths in ((STAGED_BOTH, both), (STAGED_INDEX, staged),
+                                   (LOCAL_CHANGES, local)) if paths
+        ]
+        # git emits each paragraph as its own error, so the second one
+        # carries the prefix inline: the renderer only writes the first.
+        super().__init__("\nerror: ".join(blocks))
+
+
+class MoveUsageError(GitError):
+    """``mv`` with fewer than two operands.
+
+    git prints its usage and exits 129. Only the two synopsis lines are
+    kept: the option list below them describes flags this build does
+    not all have.
+
+    Args:
+        None.
+    """
+
+    prefix = None
+    code = OPTION_EXIT
+
+    def __init__(self) -> None:
+        super().__init__("usage: git mv [-v] [-f] [-n] [-k] <source> "
+                         "<destination>\n   or: git mv [-v] [-f] [-n] [-k] "
+                         "<source>... <destination-directory>")
+
+
+class MoveRefusedError(GitError):
+    """``mv`` refusing one source, in git's ``reason, source, destination``
+    shape.
+
+    Args:
+        reason (str): git's own wording for what is wrong.
+        source (str): the source, repository-relative.
+        destination (str): the destination, repository-relative.
+    """
+
+    def __init__(self, reason: str, source: str, destination: str) -> None:
+        super().__init__(f"{reason}, source={source}, "
+                         f"destination={destination}")
+
+
+class NotADirectoryDestinationError(GitError):
+    """``mv`` with several sources and a destination that is not a directory.
+
+    Args:
+        destination (str): the destination, repository-relative.
+    """
+
+    def __init__(self, destination: str) -> None:
+        super().__init__(f"destination '{destination}' is not a directory")
+
+
+class RenameFailedError(GitError):
+    """``mv`` whose rename the mount refused.
+
+    git names the source and the strerror. The one reason a mount gives
+    is a destination whose directory does not exist: git does not create
+    it, and neither does this.
+
+    Args:
+        source (str): the source, repository-relative.
+        reason (str): the strerror to name.
+    """
+
+    def __init__(self,
+                 source: str,
+                 reason: str = "No such file or directory") -> None:
+        super().__init__(f"renaming '{source}' failed: {reason}")
+
+
+class NoRestorePathsError(GitError):
+    """``restore`` with no pathspec at all.
+
+    Args:
+        None.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("you must specify path(s) to restore")
+
+
+class UnresolvableSourceError(GitError):
+    """``restore --source`` naming a tree this repository cannot resolve.
+
+    Args:
+        source (str): the source as the user spelled it.
+    """
+
+    def __init__(self, source: str) -> None:
+        super().__init__(f"could not resolve {source}")
+
+
+class InvalidReferenceError(GitError):
+    """``switch`` naming something that is neither a branch nor a commit.
+
+    ``switch`` words the miss differently from ``checkout``, which calls
+    the same operand a pathspec: switch never takes a path, so nothing
+    it was given could have been one.
+
+    Args:
+        name (str): the operand as the user spelled it.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"invalid reference: {name}")
+
+
+class BranchExpectedError(GitError):
+    """``switch`` given a commit, tag or remote branch without ``--detach``.
+
+    git refuses rather than detaching, because a detached HEAD is the
+    state an agent loses commits in, and ``switch`` exists to be the
+    verb that never gets there by accident.
+
+    Args:
+        kind (str): what the operand named: ``commit``, ``tag`` or
+            ``remote branch``.
+        name (str): the operand as the user spelled it.
+    """
+
+    def __init__(self, kind: str, name: str) -> None:
+        super().__init__(f"a branch is expected, got {kind} '{name}'\n"
+                         f"hint: If you want to detach HEAD at the commit, "
+                         f"try again with the --detach option.")
+
+
+class MissingBranchArgumentError(GitError):
+    """``switch`` with nothing to switch to.
+
+    Args:
+        None.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("missing branch or commit argument")
+
+
+class OneReferenceError(GitError):
+    """``switch`` given more than one operand.
+
+    Args:
+        None.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("only one reference expected")
+
+
+class DetachWithCreateError(GitError):
+    """``switch -c`` together with ``--detach``.
+
+    Args:
+        None.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("'--detach' cannot be used with '-b/-B/--orphan'")
+
+
+class TagExistsError(GitError):
+    """``tag <name>`` naming a tag that is already there.
+
+    Args:
+        name (str): the tag name.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"tag '{name}' already exists")
+
+
+class TagNotFoundError(GitError):
+    """``tag -d`` naming a tag that is not there.
+
+    Reported and moved past: git deletes the other names on the line and
+    exits 1 at the end, so this is rendered per name rather than raised.
+
+    Args:
+        name (str): the tag name as the user spelled it.
+    """
+
+    prefix = "error"
+    code = 1
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"tag '{name}' not found.")
+
+
+class InvalidTagNameError(GitError):
+    """A tag name git's ref rules refuse.
+
+    Args:
+        name (str): the name as the user spelled it.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"'{name}' is not a valid tag name.")
+
+
+class UnresolvedRefError(GitError):
+    """``tag`` given an object it cannot resolve.
+
+    Args:
+        revision (str): the operand as the user spelled it.
+    """
+
+    def __init__(self, revision: str) -> None:
+        super().__init__(f"Failed to resolve '{revision}' as a valid ref.")
+
+
+class TooManyArgumentsError(GitError):
+    """``tag`` given more operands than a name and an object.
+
+    Args:
+        None.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("too many arguments")
+
+
+class MissingTagMessageError(GitError):
+    """``tag -a`` with no ``-m``.
+
+    git would open an editor here, exactly as ``commit`` would, and the
+    same answer applies: a mount has no editor, and inventing a message
+    would put an unreviewed one into the repository.
+
+    Args:
+        None.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("no tag message supplied (mirage has no editor to "
+                         "open; pass -m)")
+
+
+class IncompatibleOptionsError(GitError):
+    """Two options git refuses to take together.
+
+    Args:
+        first (str): the first option as spelled on the command line.
+        second (str): the second.
+    """
+
+    prefix = "error"
+    code = OPTION_EXIT
+
+    def __init__(self, first: str, second: str) -> None:
+        super().__init__(f"options '{first}' and '{second}' cannot be used "
+                         f"together")

--- a/python/mirage/commands/cli/builtin/git/errors.py
+++ b/python/mirage/commands/cli/builtin/git/errors.py
@@ -792,6 +792,21 @@ class NoRestorePathsError(GitError):
         super().__init__("you must specify path(s) to restore")
 
 
+class UnreadableTreeError(GitError):
+    """``restore --source`` naming an object that is no tree.
+
+    A revision that resolves is reported by the id it resolved to
+    rather than by the spelling, which is git's own wording: the
+    complaint is about the object found, not about the name.
+
+    Args:
+        oid (str): hex id of the object the source resolved to.
+    """
+
+    def __init__(self, oid: str) -> None:
+        super().__init__(f"unable to read tree ({oid})")
+
+
 class UnresolvableSourceError(GitError):
     """``restore --source`` naming a tree this repository cannot resolve.
 

--- a/python/mirage/commands/cli/builtin/git/errors.py
+++ b/python/mirage/commands/cli/builtin/git/errors.py
@@ -743,6 +743,38 @@ class RemovePathError(GitError):
         self.report = report
 
 
+class MountInWayError(GitError):
+    """A working-tree removal that would take a nested mount with it.
+
+    A mount nested inside the repository is served by another resource
+    entirely, so removing the directory it stands in empties that
+    backend rather than the repository: the store behind it is gone,
+    and no branch ever recorded a line of it. mirage refuses instead,
+    which is the rule ``MountRootPolicy`` already enforces for ``rm``
+    and ``mv`` at the command tier; a git verb reaches the dispatcher
+    directly, so it has to ask for itself.
+
+    The mount is named only when the session may be told about it. A
+    hidden one blocks the removal just the same, because avoiding a
+    boundary and naming it are two different questions, and naming a
+    hidden mount is the one thing the hide exists to prevent.
+
+    Args:
+        path (str): absolute virtual path being removed.
+        mount (str | None): the mount root in the way, None when the
+            session may not be told which one it is.
+    """
+
+    def __init__(self, path: str, mount: str | None = None) -> None:
+        if mount is None:
+            held = "it holds a mount root"
+        elif mount == path:
+            held = "it is a mount root"
+        else:
+            held = f"'{mount}' is a mount root"
+        super().__init__(f"cannot remove '{path}': {held}")
+
+
 class MoveUsageError(GitError):
     """``mv`` with fewer than two operands.
 
@@ -976,6 +1008,27 @@ class ListModeOnlyError(GitError):
 
     def __init__(self) -> None:
         super().__init__("the '-n' option is only allowed in list mode")
+
+
+class TagLinesError(GitError):
+    """``tag -n<num>`` with a count below the one git reserves.
+
+    ``-n`` carries an optional count, and git's parser starts that
+    count at -1 to mean "not given at all". ``-n-1`` is therefore not a
+    listing flag at all: ``git tag -d -n-1 v`` deletes and
+    ``git tag -n-1 -a v -m m`` creates, where a real ``-n`` refuses
+    both. Anything below -1 is a count, and a count has to be positive,
+    which git discovers while parsing the format it lists with rather
+    than while parsing the option: the list-mode refusal outranks this
+    one, and it fires in a repository holding no tags at all. Pinned
+    against git 2.50.1.
+
+    Args:
+        lines (int): the count as typed.
+    """
+
+    def __init__(self, lines: int) -> None:
+        super().__init__(f"positive value expected contents:lines={lines}")
 
 
 class RefUpdateConflictError(GitError):

--- a/python/mirage/commands/cli/builtin/git/errors.py
+++ b/python/mirage/commands/cli/builtin/git/errors.py
@@ -717,6 +717,32 @@ class RemovalRefusedError(GitError):
         super().__init__("\nerror: ".join(blocks))
 
 
+class RemovePathError(GitError):
+    """``rm`` whose working-tree deletion the mount refused.
+
+    git names the path and the strerror. The one reason a mount gives
+    is a directory standing where a tracked file was: ``unlink`` refuses
+    that, and git reports it rather than removing the tree.
+
+    The ``rm`` lines ride along on stdout because git prints them for
+    every selected path before it deletes anything, so the ones printed
+    before the failure are printed whether the line goes through or not.
+
+    Args:
+        path (str): the path, repository-relative.
+        report (str): the ``rm`` lines already printed, empty under
+            ``-q``.
+        reason (str): the strerror to name.
+    """
+
+    def __init__(self,
+                 path: str,
+                 report: str = "",
+                 reason: str = "Is a directory") -> None:
+        super().__init__(f"git rm: '{path}': {reason}")
+        self.report = report
+
+
 class MoveUsageError(GitError):
     """``mv`` with fewer than two operands.
 

--- a/python/mirage/commands/cli/builtin/git/errors.py
+++ b/python/mirage/commands/cli/builtin/git/errors.py
@@ -778,6 +778,25 @@ class MoveRefusedError(GitError):
                          f"destination={destination}")
 
 
+class MoveOverlapError(GitError):
+    """``mv`` given both a directory and something inside it.
+
+    git refuses the whole line rather than one source, and ``-k`` does
+    not skip it: the two moves would race for the same bytes, and the
+    one that lost would be reported as a rename that failed after the
+    other had already changed the working tree. The child is named
+    first however the operands were ordered. Pinned against git 2.50.1.
+
+    Args:
+        child (str): the source below the other, repository-relative.
+        parent (str): the directory source above it.
+    """
+
+    def __init__(self, child: str, parent: str) -> None:
+        super().__init__(f"cannot move both '{child}' and its parent "
+                         f"directory '{parent}'")
+
+
 class NotADirectoryDestinationError(GitError):
     """``mv`` with several sources and a destination that is not a directory.
 
@@ -980,6 +999,24 @@ class RefUpdateConflictError(GitError):
     def __init__(self, ref: str) -> None:
         super().__init__("could not delete references: multiple updates "
                          f"for ref '{ref}' not allowed")
+
+
+class RefLockError(GitError):
+    """A ref that cannot be written because another one holds its path.
+
+    git reports this as a failure to take the lock rather than as a
+    name that is already taken, and names the ref standing in the way.
+    ``-f`` does not help: the obstacle is the path, not the value.
+    Pinned against git 2.50.1.
+
+    Args:
+        ref (str): the full ref name that cannot be written.
+        held (str): the full ref name already there.
+    """
+
+    def __init__(self, ref: str, held: str) -> None:
+        super().__init__(f"cannot lock ref '{ref}': '{held}' exists; "
+                         f"cannot create '{ref}'")
 
 
 class InvalidTagNameError(GitError):

--- a/python/mirage/commands/cli/builtin/git/errors.py
+++ b/python/mirage/commands/cli/builtin/git/errors.py
@@ -29,6 +29,9 @@ ADVICE_IGNORED = ('hint: Disable this message with "git config set '
                   'advice.addIgnoredFile false"')
 ADVICE_EMPTY_PATHSPEC = ('hint: Disable this message with "git config '
                          'set advice.addEmptyPathspec false"')
+ADVICE_REF_FORMAT = "hint: See `man git check-ref-format`"
+ADVICE_REF_SYNTAX = ('hint: Disable this message with "git config set '
+                     'advice.refSyntax false"')
 
 
 class GitError(Exception):
@@ -352,6 +355,25 @@ class BranchExistsError(GitError):
 
     def __init__(self, name: str) -> None:
         super().__init__(f"a branch named '{name}' already exists")
+
+
+class InvalidBranchNameError(GitError):
+    """A branch name git's ref rules refuse.
+
+    Refused before the name reaches a ref file, because a ref is
+    written as a path below ``.git``: ``../../config`` would land on
+    the repository's own configuration rather than on a branch. git
+    closes the refusal with the two hint lines kept here, and words it
+    without the full stop its tag twin carries. Pinned against git
+    2.50.1.
+
+    Args:
+        name (str): the name as the user spelled it.
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(f"'{name}' is not a valid branch name\n"
+                         f"{ADVICE_REF_FORMAT}\n{ADVICE_REF_SYNTAX}")
 
 
 class BranchNameRequiredError(GitError):
@@ -820,6 +842,32 @@ class UnresolvedRefError(GitError):
 
     def __init__(self, revision: str) -> None:
         super().__init__(f"Failed to resolve '{revision}' as a valid ref.")
+
+
+class TagUsageError(GitError):
+    """``tag`` given a creation option with no tag name to create.
+
+    ``-a``, ``-m`` and ``-f`` are creation options, so git refuses them
+    on a line that lists or deletes instead: no operand at all lists,
+    and ``-l`` or ``-d`` says so outright. It prints its usage and
+    exits 129, where an operand-free ``git tag`` or ``git tag -d``
+    lists and exits 0. The synopsis is trimmed to the options this
+    build has, the way ``mv``'s is: git's own lines advertise ``-s``,
+    ``-u``, ``-F``, ``-e`` and ``-v``, which would be a promise
+    nothing here keeps. Pinned against git 2.50.1.
+
+    Args:
+        None.
+    """
+
+    prefix = None
+    code = OPTION_EXIT
+
+    def __init__(self) -> None:
+        super().__init__("usage: git tag [-a] [-f] [-m <msg>] <tagname> "
+                         "[<commit> | <object>]\n"
+                         "   or: git tag -d <tagname>...\n"
+                         "   or: git tag [-n[<num>]] -l [<pattern>...]")
 
 
 class TooManyArgumentsError(GitError):

--- a/python/mirage/commands/cli/builtin/git/index.py
+++ b/python/mirage/commands/cli/builtin/git/index.py
@@ -19,6 +19,7 @@ from typing import IO, BinaryIO, cast
 from dulwich.index import (ConflictedIndexEntry, IndexEntry, read_index_dict,
                            write_index_dict)
 
+from mirage.commands.cli.builtin.git.errors import ResolveIndexError
 from mirage.commands.cli.builtin.git.io import read_optional, write_file
 from mirage.commands.cli.builtin.git.types import IndexState
 from mirage.runtime.types import DispatchFn
@@ -95,3 +96,24 @@ async def write_index(dispatch: DispatchFn, gitdir: str,
     write_index_dict(cast(IO[bytes], buffer), merged)
     await write_file(dispatch, posixpath.join(gitdir, INDEX_FILE),
                      buffer.getvalue())
+
+
+def refuse_unresolved(state: IndexState) -> None:
+    """Refuse a branch move while the index still records conflict stages.
+
+    Every collision check a checkout makes reads stage 0, so a path held
+    only as stages 1-3 is invisible to all of them, and git refuses
+    before it reads either tree. The refusal is not the moving side's
+    alone: ``git switch <current>`` and ``git checkout <current>`` move
+    nothing and still die on it, so a line that answers "Already on" out
+    of a shortcut has to ask the index first. Pinned against git 2.50.1,
+    where ``git switch -c <new>`` is the one line that survives an
+    unresolved index, because it writes a ref and nothing else.
+
+    Args:
+        state (IndexState): the index as read, entries and stages.
+    """
+    if not state.conflicts:
+        return
+    raise ResolveIndexError(
+        [path.decode("utf-8", errors="replace") for path in state.conflicts])

--- a/python/mirage/commands/cli/builtin/git/io.py
+++ b/python/mirage/commands/cli/builtin/git/io.py
@@ -330,7 +330,8 @@ async def rename_path(dispatch: DispatchFn, source: str, target: str) -> None:
                    dst=PathSpec.from_str_path(target))
 
 
-async def remove_tree(dispatch: DispatchFn, path: str) -> None:
+async def remove_tree(dispatch: DispatchFn, path: str,
+                      links: LinkView | None) -> None:
     """Delete a path and everything under it, tracked or not.
 
     git replaces a tree entry rather than merging with it, so a
@@ -344,9 +345,20 @@ async def remove_tree(dispatch: DispatchFn, path: str) -> None:
     since ``readdir`` reads a non-directory as nothing there and
     ``rmdir`` refuses it.
 
+    A child that is a symlink is unlinked, never descended into. The
+    name plane has to say so, because ``readdir`` dereferences: a link
+    to a directory lists that directory's contents, and recursing on
+    them deletes a tree outside the one being replaced. ``rm -r`` does
+    not follow a link either, so a branch recording a file where the
+    working tree has a directory takes the link away with the directory
+    and leaves whatever it pointed at exactly as it was. Pinned against
+    git 2.50.1.
+
     Args:
         dispatch (DispatchFn): workspace op dispatcher.
         path (str): absolute virtual path to clear.
+        links (LinkView | None): the name plane's link facts, None when
+            no namespace is wired.
     """
     for entry in await read_names(dispatch, path):
         # A listing answers in whole paths, so the child is rebuilt from
@@ -354,7 +366,11 @@ async def remove_tree(dispatch: DispatchFn, path: str) -> None:
         name = entry.rstrip("/").rsplit("/", 1)[-1]
         if not name:
             continue
-        await remove_tree(dispatch, posixpath.join(path, name))
+        child = posixpath.join(path, name)
+        if links is not None and links.stat_at(child) is not None:
+            await remove_file(dispatch, child)
+            continue
+        await remove_tree(dispatch, child, links)
     try:
         await dispatch("rmdir", PathSpec.from_str_path(path))
     except MISS_ERRORS as exc:

--- a/python/mirage/commands/cli/builtin/git/io.py
+++ b/python/mirage/commands/cli/builtin/git/io.py
@@ -117,6 +117,37 @@ async def restore_entry(dispatch: DispatchFn,
                    mode=mode & PERMISSION_BITS)
 
 
+async def keep_gitlink(dispatch: DispatchFn, stat_path: StatPath, path: str,
+                       links: LinkView | None) -> None:
+    """Leave a submodule's working tree alone, but make sure it has one.
+
+    A 160000 entry names a commit in another repository, which this one
+    does not hold: reading it as a blob is either a miss (an ordinary
+    submodule keeps its objects in its own store) or, when the id does
+    happen to resolve here, an empty string written over the directory.
+    git does neither. It checks out no submodule content at all without
+    ``--recurse-submodules``, and all the entry asks of the working tree
+    is that a directory stand at the name: an existing one is left
+    exactly as it is, untracked work included, a regular file or a link
+    is replaced by an empty one, and a missing one is created. Pinned
+    against git 2.50.1.
+
+    Args:
+        dispatch (DispatchFn): workspace op dispatcher.
+        stat_path (StatPath): the data plane's stat, which dereferences.
+        path (str): absolute virtual path of the submodule.
+        links (LinkView | None): the name plane's link facts, None when
+            no namespace is wired.
+    """
+    linked = links is not None and links.stat_at(path) is not None
+    info = None if linked else await stat_path(path)
+    if info is not None and info.type is FileType.DIRECTORY:
+        return
+    if linked or info is not None:
+        await remove_file(dispatch, path)
+    await ensure_dir(dispatch, path)
+
+
 async def read_range(dispatch: DispatchFn, path: str, offset: int,
                      size: int) -> bytes:
     """Read a byte range of one virtual path.

--- a/python/mirage/commands/cli/builtin/git/io.py
+++ b/python/mirage/commands/cli/builtin/git/io.py
@@ -16,7 +16,7 @@ import logging
 import posixpath
 
 from mirage.commands.cli.builtin.git.constants import SYMLINK
-from mirage.ops.types import LinkView
+from mirage.ops.types import LinkView, StatPath
 from mirage.runtime.types import DispatchFn
 from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
 from mirage.utils.errors import MISS_ERRORS
@@ -235,6 +235,50 @@ async def write_once(dispatch: DispatchFn, path: str, data: bytes) -> None:
     if await exists(dispatch, path):
         return
     await write_file(dispatch, path, data)
+
+
+async def blocking_ancestor(stat_path: StatPath, worktree: str, name: str,
+                            links: LinkView | None) -> str | None:
+    """The nearest component above an entry that is not a directory.
+
+    An entry's path is only a way through the working tree while every
+    component above it is a directory. Anything else standing on one --
+    a symlink, a regular file, tracked or not -- is not a way through,
+    and the two directions take it differently. Writing the entry
+    *replaces* it with the directory the entry needs, leaving whatever
+    a link pointed at exactly as it was; removing the entry does
+    nothing at all, because the path never led there. That is git's
+    ``create_directories`` and ``check_leading_path``, and both halves
+    were probed against git 2.50.1.
+
+    The namespace is asked before the data plane, and the order is the
+    whole point: ``stat_path`` dereferences, so a link to a directory
+    stats as a directory and the walk would carry on straight through
+    it. Only the name plane can say that the component is a link.
+
+    An exact-path lookup cannot see any of this, since what is in the
+    way sits above the name being looked up rather than on it.
+
+    Args:
+        stat_path (StatPath): the data plane's stat, which dereferences.
+        worktree (str): absolute virtual path of the working tree root.
+        name (str): the entry, repository-relative.
+        links (LinkView | None): the name plane's link facts, None when
+            no namespace is wired.
+
+    Returns:
+        str | None: absolute virtual path of the nearest such component,
+        None when every component above the entry is a directory.
+    """
+    current = worktree
+    for part in name.split("/")[:-1]:
+        current = posixpath.join(current, part)
+        if links is not None and links.stat_at(current) is not None:
+            return current
+        info = await stat_path(current)
+        if info is not None and info.type is not FileType.DIRECTORY:
+            return current
+    return None
 
 
 async def remove_file(dispatch: DispatchFn, path: str) -> None:

--- a/python/mirage/commands/cli/builtin/git/io.py
+++ b/python/mirage/commands/cli/builtin/git/io.py
@@ -15,7 +15,7 @@
 import logging
 import posixpath
 
-from mirage.commands.cli.builtin.git.constants import SYMLINK
+from mirage.commands.cli.builtin.git.constants import PERMISSION_BITS, SYMLINK
 from mirage.ops.types import LinkView, StatPath
 from mirage.runtime.types import DispatchFn
 from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
@@ -82,6 +82,17 @@ async def restore_entry(dispatch: DispatchFn,
     The check is a namespace lookup, so the ordinary file-for-file case
     costs nothing.
 
+    The permission bits are part of the entry, not decoration on it.
+    git records exactly one of them, the owner's execute bit, and puts
+    it back in both directions: ``chmod -x`` on a ``100755`` path is a
+    modification ``restore`` undoes, and ``chmod +x`` on a ``100644``
+    one is a modification it undoes the other way. Writing the bytes
+    alone left the bit as the working tree had it, so the file came back
+    unrunnable and ``status`` went on calling it modified for ever. The
+    write is unconditional rather than probed: a stat to decide costs
+    the same op as the setattr it would save, and the backends git
+    actually runs on apply it natively, so nothing reaches the overlay.
+
     Args:
         dispatch (DispatchFn): workspace op dispatcher.
         path (str): absolute virtual path to materialize at.
@@ -100,6 +111,9 @@ async def restore_entry(dispatch: DispatchFn,
     if linked:
         await remove_file(dispatch, path)
     await write_file(dispatch, path, blob)
+    await dispatch("setattr",
+                   PathSpec.from_str_path(path),
+                   mode=mode & PERMISSION_BITS)
 
 
 async def read_range(dispatch: DispatchFn, path: str, offset: int,

--- a/python/mirage/commands/cli/builtin/git/io.py
+++ b/python/mirage/commands/cli/builtin/git/io.py
@@ -363,6 +363,41 @@ def refuse_mount(mounts: MountView | None, path: str) -> None:
     raise MountInWayError(path, named[0] if named else None)
 
 
+async def refuse_replaced_mounts(stat_path: StatPath, worktree: str,
+                                 names: list[str], links: LinkView | None,
+                                 mounts: MountView | None) -> None:
+    """Ask of every destination first what the write loop would meet later.
+
+    ``remove_tree`` refuses a directory holding a mount, but the loop
+    reaches one entry at a time, so a refusal there leaves the entries
+    already written standing on the target's content with HEAD and the
+    index still where they were. Asking first is the shape every other
+    collision check in these verbs already has: name what is in the way
+    and change nothing. The condition mirrors the write loop's exactly,
+    a link included, so a destination the loop would not clear is not
+    refused here either.
+
+    Args:
+        stat_path (StatPath): the data plane's stat, which dereferences.
+        worktree (str): absolute virtual path of the working tree root.
+        names (list[str]): repository-relative paths about to be
+            written.
+        links (LinkView | None): the name plane's link facts, None when
+            no namespace is wired.
+        mounts (MountView | None): the name plane's mount boundaries,
+            None when no namespace is wired.
+    """
+    if mounts is None:
+        return
+    for name in sorted(names):
+        where = posixpath.join(worktree, name)
+        if links is not None and links.stat_at(where) is not None:
+            continue
+        info = await stat_path(where)
+        if info is not None and info.type is FileType.DIRECTORY:
+            refuse_mount(mounts, where)
+
+
 async def remove_tree(dispatch: DispatchFn, path: str, links: LinkView | None,
                       mounts: MountView | None) -> None:
     """Delete a path and everything under it, tracked or not.

--- a/python/mirage/commands/cli/builtin/git/io.py
+++ b/python/mirage/commands/cli/builtin/git/io.py
@@ -16,7 +16,8 @@ import logging
 import posixpath
 
 from mirage.commands.cli.builtin.git.constants import PERMISSION_BITS, SYMLINK
-from mirage.ops.types import LinkView, StatPath
+from mirage.commands.cli.builtin.git.errors import MountInWayError
+from mirage.ops.types import LinkView, MountView, StatPath
 from mirage.runtime.types import DispatchFn
 from mirage.types import LINK_TARGET_KEY, FileStat, FileType, PathSpec
 from mirage.utils.errors import MISS_ERRORS
@@ -330,8 +331,40 @@ async def rename_path(dispatch: DispatchFn, source: str, target: str) -> None:
                    dst=PathSpec.from_str_path(target))
 
 
-async def remove_tree(dispatch: DispatchFn, path: str,
-                      links: LinkView | None) -> None:
+def refuse_mount(mounts: MountView | None, path: str) -> None:
+    """Refuse a removal that would take a nested mount with it.
+
+    A mount nested inside the working tree is served by another
+    resource, and ``readdir`` merges it into the parent's listing, so a
+    walk that empties a directory walks straight into the child backend
+    and unlinks what is in it. No branch ever recorded any of that, and
+    the ``rmdir`` that follows takes the mount root itself. Asking the
+    mount table is the only way to see the boundary: the parent
+    backend cannot.
+
+    Two questions, two fields, the way ``MountView`` says: the
+    boundary is *avoided* by the unfiltered list, so a mount this
+    session cannot see still blocks the removal, and it is *named*
+    from the visible one, since naming a hidden mount is what the hide
+    exists to prevent.
+
+    Args:
+        mounts (MountView | None): the name plane's mount boundaries,
+            None when no namespace is wired.
+        path (str): absolute virtual path about to be removed.
+    """
+    if mounts is None:
+        return
+    if mounts.is_root(path):
+        raise MountInWayError(path, path)
+    if not mounts.descendants(path):
+        return
+    named = sorted(mounts.visible_descendants(path))
+    raise MountInWayError(path, named[0] if named else None)
+
+
+async def remove_tree(dispatch: DispatchFn, path: str, links: LinkView | None,
+                      mounts: MountView | None) -> None:
     """Delete a path and everything under it, tracked or not.
 
     git replaces a tree entry rather than merging with it, so a
@@ -359,7 +392,14 @@ async def remove_tree(dispatch: DispatchFn, path: str,
         path (str): absolute virtual path to clear.
         links (LinkView | None): the name plane's link facts, None when
             no namespace is wired.
+        mounts (MountView | None): the name plane's mount boundaries,
+            None when no namespace is wired.
     """
+    # Before the first deletion rather than at the boundary itself, so
+    # a mount deep under the directory costs the caller nothing: the
+    # scan sees every depth at once and the tree is still whole when
+    # it refuses.
+    refuse_mount(mounts, path)
     for entry in await read_names(dispatch, path):
         # A listing answers in whole paths, so the child is rebuilt from
         # the basename the way every other walk here does.
@@ -370,7 +410,7 @@ async def remove_tree(dispatch: DispatchFn, path: str,
         if links is not None and links.stat_at(child) is not None:
             await remove_file(dispatch, child)
             continue
-        await remove_tree(dispatch, child, links)
+        await remove_tree(dispatch, child, links, mounts)
     try:
         await dispatch("rmdir", PathSpec.from_str_path(path))
     except MISS_ERRORS as exc:
@@ -382,8 +422,8 @@ async def remove_tree(dispatch: DispatchFn, path: str,
         await remove_file(dispatch, path)
 
 
-async def remove_empty_parents(dispatch: DispatchFn, path: str,
-                               stop: str) -> None:
+async def remove_empty_parents(dispatch: DispatchFn, path: str, stop: str,
+                               mounts: MountView | None) -> None:
     """Drop the directories a deletion left empty, up to a root.
 
     git removes a directory the moment its last tracked file is deleted
@@ -395,10 +435,19 @@ async def remove_empty_parents(dispatch: DispatchFn, path: str,
         dispatch (DispatchFn): workspace op dispatcher.
         path (str): absolute virtual path of the file that was removed.
         stop (str): absolute virtual path of the working tree root.
+        mounts (MountView | None): the name plane's mount boundaries,
+            None when no namespace is wired.
     """
     root = stop.rstrip("/") or "/"
     current = posixpath.dirname(path)
     while current != root and current.startswith(root):
+        # A mount root is not a directory git made, and an empty one is
+        # still a whole backend: removing it here would destroy the
+        # store behind it as a side effect of tidying up. The walk
+        # stops rather than refusing, because nothing the caller asked
+        # for has failed.
+        if mounts is not None and mounts.is_root(current):
+            return
         if await read_names(dispatch, current):
             return
         try:

--- a/python/mirage/commands/cli/builtin/git/io.py
+++ b/python/mirage/commands/cli/builtin/git/io.py
@@ -148,6 +148,48 @@ async def keep_gitlink(dispatch: DispatchFn, stat_path: StatPath, path: str,
     await ensure_dir(dispatch, path)
 
 
+async def drop_gitlink(dispatch: DispatchFn, stat_path: StatPath, path: str,
+                       name: str, links: LinkView | None) -> str | None:
+    """Take a submodule's directory away, or say why it stays.
+
+    The other direction of ``keep_gitlink``, and it is not an unlink:
+    what stands at a 160000 entry is a directory, so git calls
+    ``rmdir`` and warns rather than failing when that cannot be done.
+    An empty one goes; one still holding a checked-out submodule, or
+    anything else untracked, stays and is named; a regular file or a
+    link at the name is the ``ENOTDIR`` wording of the same warning;
+    a name with nothing at it is silent. The switch itself succeeds
+    either way, which is the whole point of warning instead of raising.
+    Pinned against git 2.50.1.
+
+    Args:
+        dispatch (DispatchFn): workspace op dispatcher.
+        stat_path (StatPath): the data plane's stat, which dereferences.
+        path (str): absolute virtual path of the submodule.
+        name (str): the path as git prints it, repository-relative.
+        links (LinkView | None): the name plane's link facts, None when
+            no namespace is wired.
+
+    Returns:
+        str | None: the warning line to write, None when there is
+        nothing to say.
+    """
+    # A link is answered before the stat, which dereferences: rmdir
+    # never follows one, so a link to a directory is ENOTDIR here even
+    # though stat would call it a directory.
+    if links is not None and links.stat_at(path) is not None:
+        return f"warning: unable to rmdir '{name}': Not a directory\n"
+    info = await stat_path(path)
+    if info is None:
+        return None
+    if info.type is not FileType.DIRECTORY:
+        return f"warning: unable to rmdir '{name}': Not a directory\n"
+    if await read_names(dispatch, path):
+        return f"warning: unable to rmdir '{name}': Directory not empty\n"
+    await dispatch("rmdir", PathSpec.from_str_path(path))
+    return None
+
+
 async def read_range(dispatch: DispatchFn, path: str, offset: int,
                      size: int) -> bytes:
     """Read a byte range of one virtual path.

--- a/python/mirage/commands/cli/builtin/git/io.py
+++ b/python/mirage/commands/cli/builtin/git/io.py
@@ -252,3 +252,48 @@ async def remove_file(dispatch: DispatchFn, path: str) -> None:
         await dispatch("unlink", PathSpec.from_str_path(path))
     except MISS_ERRORS as exc:
         logger.debug("nothing to remove at %s: %s", path, exc)
+
+
+async def rename_path(dispatch: DispatchFn, source: str, target: str) -> None:
+    """Move one virtual path, file or directory, to another name.
+
+    The mount's own rename, so a directory moves with everything under
+    it, tracked or not, which is what ``git mv`` does with a directory.
+    The destination's directory is not created: git's rename fails when
+    it is missing, and the caller words that failure.
+
+    Args:
+        dispatch (DispatchFn): workspace op dispatcher.
+        source (str): absolute virtual path to move.
+        target (str): absolute virtual path to move it to.
+    """
+    await dispatch("rename",
+                   PathSpec.from_str_path(source),
+                   dst=PathSpec.from_str_path(target))
+
+
+async def remove_empty_parents(dispatch: DispatchFn, path: str,
+                               stop: str) -> None:
+    """Drop the directories a deletion left empty, up to a root.
+
+    git removes a directory the moment its last tracked file is deleted
+    or restored away, so ``rm -r docs`` leaves no ``docs/`` behind. The
+    walk stops at the first directory that still holds something and
+    never touches ``stop`` itself.
+
+    Args:
+        dispatch (DispatchFn): workspace op dispatcher.
+        path (str): absolute virtual path of the file that was removed.
+        stop (str): absolute virtual path of the working tree root.
+    """
+    root = stop.rstrip("/") or "/"
+    current = posixpath.dirname(path)
+    while current != root and current.startswith(root):
+        if await read_names(dispatch, current):
+            return
+        try:
+            await dispatch("rmdir", PathSpec.from_str_path(current))
+        except MISS_ERRORS as exc:
+            logger.debug("no directory to remove at %s: %s", current, exc)
+            return
+        current = posixpath.dirname(current)

--- a/python/mirage/commands/cli/builtin/git/io.py
+++ b/python/mirage/commands/cli/builtin/git/io.py
@@ -272,6 +272,42 @@ async def rename_path(dispatch: DispatchFn, source: str, target: str) -> None:
                    dst=PathSpec.from_str_path(target))
 
 
+async def remove_tree(dispatch: DispatchFn, path: str) -> None:
+    """Delete a path and everything under it, tracked or not.
+
+    git replaces a tree entry rather than merging with it, so a
+    directory standing where the source keeps a file goes entirely.
+    That is one of the few places git removes a file it never tracked:
+    an untracked child keeps the directory alive after the tracked ones
+    are gone, and restoring the file over it would otherwise fail with
+    the index already changed.
+
+    A file and an absent path both walk out through the same two steps,
+    since ``readdir`` reads a non-directory as nothing there and
+    ``rmdir`` refuses it.
+
+    Args:
+        dispatch (DispatchFn): workspace op dispatcher.
+        path (str): absolute virtual path to clear.
+    """
+    for entry in await read_names(dispatch, path):
+        # A listing answers in whole paths, so the child is rebuilt from
+        # the basename the way every other walk here does.
+        name = entry.rstrip("/").rsplit("/", 1)[-1]
+        if not name:
+            continue
+        await remove_tree(dispatch, posixpath.join(path, name))
+    try:
+        await dispatch("rmdir", PathSpec.from_str_path(path))
+    except MISS_ERRORS as exc:
+        # Not a directory, or already gone: the path is whatever one file
+        # it is, and remove_file tolerates an absent one. A directory the
+        # walk above was supposed to empty raises OSError(ENOTEMPTY),
+        # which is not a miss and stays raised.
+        logger.debug("no directory to remove at %s: %s", path, exc)
+        await remove_file(dispatch, path)
+
+
 async def remove_empty_parents(dispatch: DispatchFn, path: str,
                                stop: str) -> None:
     """Drop the directories a deletion left empty, up to a root.

--- a/python/mirage/commands/cli/builtin/git/log.py
+++ b/python/mirage/commands/cli/builtin/git/log.py
@@ -28,8 +28,8 @@ from mirage.commands.cli.builtin.git.history import (LogFlags, decorations,
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
-from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
-                                                  revision_arg)
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal, revision_arg)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
@@ -119,7 +119,7 @@ async def log(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
     try:
         if dispatch is None:
             raise NoWorkspaceError()
-        check_operands(texts)
+        check_operands(texts, marked=escaped(inv.argv))
         parsed = parse_flags(fl)
         repo, _location = await opened(fl, doors)
         commits, decor = await asyncio.to_thread(

--- a/python/mirage/commands/cli/builtin/git/mv.py
+++ b/python/mirage/commands/cli/builtin/git/mv.py
@@ -391,7 +391,17 @@ async def apply(dispatch: DispatchFn, location: RepoLocation,
         raise RenameFailedError(move.source) from exc
     for path in move.paths:
         entry = state.entries.pop(path.encode())
-        state.entries[moved_path(move, path).encode()] = entry
+        landing = moved_path(move, path).encode()
+        state.entries[landing] = entry
+        # The stages of whatever was standing at the destination go
+        # with it. ``-f`` is the only way to reach an occupied
+        # destination, and git's own answer there is one stage-0 entry
+        # holding the source: ``ls-files -u`` is empty afterwards.
+        # Leaving them is not a smaller divergence but a worse one,
+        # since write_index lays the stages back over the entry and the
+        # moved blob is the copy that disappears. Pinned against git
+        # 2.50.1.
+        state.conflicts.pop(landing, None)
 
 
 async def mv(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:

--- a/python/mirage/commands/cli/builtin/git/mv.py
+++ b/python/mirage/commands/cli/builtin/git/mv.py
@@ -1,0 +1,284 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import posixpath
+from dataclasses import dataclass
+
+from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
+    GitError, MoveRefusedError, MoveUsageError, NotADirectoryDestinationError,
+    NoWorkspaceError, RenameFailedError, UnknownSwitchError)
+from mirage.commands.cli.builtin.git.index import read_index, write_index
+from mirage.commands.cli.builtin.git.io import remove_file, rename_path
+from mirage.commands.cli.builtin.git.pathspec import repo_relative, under
+from mirage.commands.cli.builtin.git.session import opened
+from mirage.commands.cli.builtin.git.types import IndexState, RepoLocation
+from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
+                                                  links_of, start_point)
+from mirage.commands.cli.types import CLIDoors, CLIInvocation
+from mirage.commands.spec.types import FlagView
+from mirage.io.stream import yield_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.ops.types import LinkView, StatPath
+from mirage.runtime.types import DispatchFn
+from mirage.types import FileStat, FileType
+from mirage.utils.errors import MISS_ERRORS
+
+# git's own wording for each way a source can be refused, in the shape
+# ``fatal: <reason>, source=<src>, destination=<dst>``.
+BAD_SOURCE = "bad source"
+INTO_ITSELF = "can not move directory into itself"
+DESTINATION_EXISTS = "destination exists"
+DESTINATION_ALREADY_EXISTS = "destination already exists"
+SOURCE_DIRECTORY_EMPTY = "source directory is empty"
+NOT_UNDER_VERSION_CONTROL = "not under version control"
+
+
+@dataclass(frozen=True, slots=True)
+class MvFlags:
+    """The parsed shape of a ``git mv`` invocation.
+
+    Args:
+        force (bool): ``-f``, overwrite an existing destination file.
+        skip (bool): ``-k``, skip a source that cannot move rather than
+            refusing the line.
+        dry_run (bool): ``-n``, report what would move and move nothing.
+        verbose (bool): ``-v``, print one line per move; implied by
+            ``-n``.
+    """
+    force: bool
+    skip: bool
+    dry_run: bool
+    verbose: bool
+
+
+def parse_flags(fl: FlagView) -> MvFlags:
+    """Read the raw mv flag kwargs into a frozen struct.
+
+    Args:
+        fl (FlagView): spec-validated view over the raw flag kwargs.
+    """
+    dry_run = fl.as_bool("dry_run")
+    return MvFlags(force=fl.as_bool("force"),
+                   skip=fl.as_bool("k"),
+                   dry_run=dry_run,
+                   verbose=fl.as_bool("verbose") or dry_run)
+
+
+@dataclass(frozen=True, slots=True)
+class Move:
+    """One source and where it goes.
+
+    Args:
+        source (str): repository-relative path being moved.
+        destination (str): repository-relative path it moves to, already
+            joined with the source's basename when the destination was a
+            directory.
+        paths (tuple[str, ...]): the tracked paths that move with it: the
+            source itself for a file, everything under it for a
+            directory.
+        directory (bool): whether the source is a directory.
+    """
+    source: str
+    destination: str
+    paths: tuple[str, ...]
+    directory: bool
+
+
+async def lstat(stat_path: StatPath, links: LinkView | None,
+                path: str) -> FileStat | None:
+    """What sits at a path, without following a link.
+
+    Args:
+        stat_path (StatPath): dispatcher-backed stat, both channels.
+        links (LinkView | None): the name plane's link facts.
+        path (str): absolute virtual path.
+    """
+    if links is not None:
+        link = links.stat_at(path)
+        if link is not None:
+            return link
+    return await stat_path(path)
+
+
+def moved_path(move: Move, path: str) -> str:
+    """Where one tracked path lands after a move.
+
+    Args:
+        move (Move): the move.
+        path (str): one of ``move.paths``.
+    """
+    if not move.directory:
+        return move.destination
+    return f"{move.destination}{path[len(move.source):]}"
+
+
+async def check(stat_path: StatPath, links: LinkView | None,
+                location: RepoLocation, source: str, destination: str,
+                tracked: set[str],
+                force: bool) -> tuple[str | None, tuple[str, ...], bool]:
+    """Whether one source can move, in git's own order of refusals.
+
+    Args:
+        stat_path (StatPath): dispatcher-backed stat, both channels.
+        links (LinkView | None): the name plane's link facts.
+        location (RepoLocation): the discovered repository.
+        source (str): repository-relative source.
+        destination (str): repository-relative destination.
+        tracked (set[str]): repository-relative paths the index holds.
+        force (bool): whether ``-f`` was given.
+
+    Returns:
+        tuple: the refusal wording or None, the tracked paths that move,
+        and whether the source is a directory.
+    """
+    info = await lstat(stat_path, links,
+                       posixpath.join(location.worktree, source))
+    if info is None:
+        return BAD_SOURCE, (), False
+    if destination == source or destination.startswith(f"{source}/"):
+        return INTO_ITSELF, (), False
+    target = await lstat(stat_path, links,
+                         posixpath.join(location.worktree, destination))
+    if info.type is FileType.DIRECTORY:
+        if target is not None:
+            return DESTINATION_ALREADY_EXISTS, (), True
+        inside = tuple(sorted(path for path in tracked if under(path, source)))
+        if not inside:
+            return SOURCE_DIRECTORY_EMPTY, (), True
+        return None, inside, True
+    if source not in tracked:
+        return NOT_UNDER_VERSION_CONTROL, (), False
+    if target is not None and (not force or target.type is FileType.DIRECTORY):
+        return DESTINATION_EXISTS, (), False
+    return None, (source, ), False
+
+
+async def plan(stat_path: StatPath, links: LinkView | None,
+               location: RepoLocation, start: str, operands: tuple[str, ...],
+               tracked: set[str], flags: MvFlags) -> list[Move]:
+    """Decide every move before making any, which is git's order too.
+
+    The last operand is the destination. With several sources it has to
+    be a directory that exists; with one, an existing directory takes
+    the source under its own name and anything else is the new name.
+
+    Args:
+        stat_path (StatPath): dispatcher-backed stat, both channels.
+        links (LinkView | None): the name plane's link facts.
+        location (RepoLocation): the discovered repository.
+        start (str): absolute virtual path git is running in.
+        operands (tuple[str, ...]): the operands as typed.
+        tracked (set[str]): repository-relative paths the index holds.
+        flags (MvFlags): the parsed flags.
+    """
+    destination = repo_relative(location, start, operands[-1])
+    target = await lstat(stat_path, links,
+                         posixpath.join(location.worktree, destination))
+    into = destination == "" or (target is not None
+                                 and target.type is FileType.DIRECTORY)
+    if len(operands) > 2 and not into:
+        raise NotADirectoryDestinationError(destination)
+    moves: list[Move] = []
+    for operand in operands[:-1]:
+        source = repo_relative(location, start, operand)
+        landing = (posixpath.join(destination, posixpath.basename(source))
+                   if into else destination)
+        reason, paths, directory = await check(stat_path, links, location,
+                                               source, landing, tracked,
+                                               flags.force)
+        if reason is not None:
+            if flags.skip:
+                continue
+            raise MoveRefusedError(reason, source, landing)
+        moves.append(Move(source, landing, paths, directory))
+    return moves
+
+
+async def apply(dispatch: DispatchFn, location: RepoLocation,
+                state: IndexState, move: Move, force: bool) -> None:
+    """Make one move in the working tree and the index.
+
+    The working tree moves first, through the mount's own rename so a
+    directory carries its untracked files along, and the index entries
+    are re-keyed with their blob ids and modes untouched. That is what
+    lets ``status`` read the result as a rename rather than a delete
+    beside an add.
+
+    Args:
+        dispatch (DispatchFn): workspace op dispatcher.
+        location (RepoLocation): the discovered repository.
+        state (IndexState): the index, updated in place.
+        move (Move): the move to make.
+        force (bool): whether ``-f`` was given, which removes a file
+            already at the destination first.
+    """
+    source = posixpath.join(location.worktree, move.source)
+    destination = posixpath.join(location.worktree, move.destination)
+    if force and not move.directory:
+        await remove_file(dispatch, destination)
+    try:
+        await rename_path(dispatch, source, destination)
+    except MISS_ERRORS as exc:
+        raise RenameFailedError(move.source) from exc
+    for path in move.paths:
+        entry = state.entries.pop(path.encode())
+        state.entries[moved_path(move, path).encode()] = entry
+
+
+async def mv(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
+    """Move or rename a file or directory, and stage the move.
+
+    Args:
+        inv (CLIInvocation[None]): the line's invocation record.
+            git declares no config_model; the planes it reads
+            (data through ``dispatch``, names through ``ns``) ride
+            ``inv.doors``.
+    """
+    doors = inv.doors or CLIDoors()
+    dispatch = doors.dispatch
+    stat_path = doors.stat_path
+    texts = inv.texts
+    fl = FlagView(inv.flags)
+    try:
+        if dispatch is None or stat_path is None:
+            raise NoWorkspaceError()
+        check_operands(texts, UnknownSwitchError)
+        flags = parse_flags(fl)
+        if len(texts) < 2:
+            raise MoveUsageError()
+        repo, location = await opened(fl, doors)
+        state = await read_index(dispatch, location.gitdir)
+        tracked = {
+            path.decode("utf-8", errors="replace")
+            for path in state.entries
+        }
+        moves = await plan(stat_path, links_of(doors), location,
+                           start_point(fl), texts, tracked, flags)
+        lines: list[str] = []
+        if flags.dry_run:
+            lines.extend(f"Checking rename of '{move.source}' to "
+                         f"'{move.destination}'" for move in moves)
+        if flags.verbose:
+            lines.extend(f"Renaming {move.source} to {move.destination}"
+                         for move in moves)
+        if not flags.dry_run:
+            for move in moves:
+                await apply(dispatch, location, state, move, flags.force)
+            await write_index(dispatch, location.gitdir, state)
+    except GitError as exc:
+        return fatal(exc)
+    if not lines:
+        return None, IOResult()
+    return yield_bytes("".join(f"{line}\n"
+                               for line in lines).encode()), IOResult()

--- a/python/mirage/commands/cli/builtin/git/mv.py
+++ b/python/mirage/commands/cli/builtin/git/mv.py
@@ -23,13 +23,13 @@ from mirage.commands.cli.builtin.git.io import remove_file, rename_path
 from mirage.commands.cli.builtin.git.pathspec import repo_relative, under
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.types import IndexState, RepoLocation
-from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
-                                                  links_of, start_point)
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal, links_of, mounts_of, start_point)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
-from mirage.ops.types import LinkView, StatPath
+from mirage.ops.types import LinkView, MountView, StatPath
 from mirage.runtime.types import DispatchFn
 from mirage.types import FileStat, FileType
 from mirage.utils.errors import MISS_ERRORS
@@ -44,6 +44,10 @@ SOURCE_DIRECTORY_EMPTY = "source directory is empty"
 NOT_UNDER_VERSION_CONTROL = "not under version control"
 MULTIPLE_SOURCES = "multiple sources for the same target"
 CONFLICTED = "conflicted"
+# Not one of git's, because git has no concept to word: a mount is
+# mirage's own boundary, so the refusal borrows the strerror the kernel
+# gives for a rename it will not perform.
+BUSY = "Device or resource busy"
 
 
 @dataclass(frozen=True, slots=True)
@@ -168,6 +172,27 @@ def clashing(move: Move, claimed: set[str]) -> tuple[str, str] | None:
     return None
 
 
+def spanning(mounts: MountView | None, path: str) -> bool:
+    """Whether renaming a path would leave a mount behind.
+
+    A mount nested in the repository is served by another resource, and
+    the rename op reaches only the backend holding the parent path: that
+    backend cannot see the child's keys, so it moves everything except
+    them and the index is then re-keyed onto files that never moved. The
+    mount root itself is the same problem one level up, since the table
+    still points at the old prefix. Neither is something the verb can
+    repair afterwards, so both are refused before anything moves.
+
+    Args:
+        mounts (MountView | None): the name plane's mount boundaries,
+            None outside a workspace.
+        path (str): absolute virtual path of the source.
+    """
+    if mounts is None:
+        return False
+    return mounts.is_root(path) or bool(mounts.descendants(path))
+
+
 async def check(stat_path: StatPath, links: LinkView | None,
                 location: RepoLocation, source: str, destination: str,
                 tracked: set[str], conflicted: set[str],
@@ -222,9 +247,9 @@ async def check(stat_path: StatPath, links: LinkView | None,
 
 
 async def plan(stat_path: StatPath, links: LinkView | None,
-               location: RepoLocation, start: str, operands: tuple[str, ...],
-               tracked: set[str], conflicted: set[str],
-               flags: MvFlags) -> list[Move]:
+               mounts: MountView | None, location: RepoLocation, start: str,
+               operands: tuple[str, ...], tracked: set[str],
+               conflicted: set[str], flags: MvFlags) -> list[Move]:
     """Decide every move before making any, which is git's order too.
 
     The last operand is the destination. With several sources it has to
@@ -234,6 +259,7 @@ async def plan(stat_path: StatPath, links: LinkView | None,
     Args:
         stat_path (StatPath): dispatcher-backed stat, both channels.
         links (LinkView | None): the name plane's link facts.
+        mounts (MountView | None): the name plane's mount boundaries.
         location (RepoLocation): the discovered repository.
         start (str): absolute virtual path git is running in.
         operands (tuple[str, ...]): the operands as typed.
@@ -273,6 +299,14 @@ async def plan(stat_path: StatPath, links: LinkView | None,
             clash = clashing(move, claimed)
             if clash is not None:
                 reason, named = MULTIPLE_SOURCES, clash
+        if reason is None and spanning(
+                mounts, posixpath.join(location.worktree, source)):
+            # Last, after every check git itself makes, so a source git
+            # would refuse anyway is refused in git's own words. ``-k``
+            # skips it like any other rename this source cannot survive.
+            if flags.skip:
+                continue
+            raise RenameFailedError(source, BUSY)
         if reason is not None:
             if flags.skip:
                 continue
@@ -330,7 +364,7 @@ async def mv(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
     try:
         if dispatch is None or stat_path is None:
             raise NoWorkspaceError()
-        check_operands(texts, UnknownSwitchError)
+        check_operands(texts, UnknownSwitchError, escaped(inv.argv))
         flags = parse_flags(fl)
         if len(texts) < 2:
             raise MoveUsageError()
@@ -347,7 +381,8 @@ async def mv(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
             path.decode("utf-8", errors="replace")
             for path in state.entries
         } | conflicted
-        moves = await plan(stat_path, links_of(doors), location,
+        moves = await plan(stat_path,
+                           links_of(doors), mounts_of(doors), location,
                            start_point(fl), texts, tracked, conflicted, flags)
         lines: list[str] = []
         if flags.dry_run:

--- a/python/mirage/commands/cli/builtin/git/mv.py
+++ b/python/mirage/commands/cli/builtin/git/mv.py
@@ -16,8 +16,9 @@ import posixpath
 from dataclasses import dataclass
 
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
-    GitError, MoveRefusedError, MoveUsageError, NotADirectoryDestinationError,
-    NoWorkspaceError, RenameFailedError, UnknownSwitchError)
+    GitError, MoveOverlapError, MoveRefusedError, MoveUsageError,
+    NotADirectoryDestinationError, NoWorkspaceError, RenameFailedError,
+    UnknownSwitchError)
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import remove_file, rename_path
 from mirage.commands.cli.builtin.git.pathspec import repo_relative, under
@@ -256,6 +257,32 @@ async def check(stat_path: StatPath, links: LinkView | None,
     return None, (source, ), False
 
 
+def overlapping(moves: list[Move]) -> tuple[str, str] | None:
+    """The first source that sits inside another source in the same line.
+
+    git reads this off the whole line once every source has passed its
+    own checks, which is why a source with a fault of its own is still
+    refused for that fault first, and why ``-k`` skipping a source
+    takes it out of this comparison too. The pair reported is the first
+    directory source in operand order and the first source under it,
+    named child first whatever order the line put them in.
+
+    Args:
+        moves (list[Move]): the moves planned so far, in operand order.
+
+    Returns:
+        tuple: the source inside the other and the directory holding
+        it, or None when no source sits inside another.
+    """
+    for move in moves:
+        if not move.directory:
+            continue
+        for other in moves:
+            if under(other.source, move.source):
+                return other.source, move.source
+    return None
+
+
 async def plan(stat_path: StatPath, links: LinkView | None,
                mounts: MountView | None, location: RepoLocation, start: str,
                operands: tuple[str, ...], tracked: set[str],
@@ -324,6 +351,15 @@ async def plan(stat_path: StatPath, links: LinkView | None,
             raise MoveRefusedError(reason, named[0], named[1])
         claimed.update(moved_path(move, path) for path in move.paths)
         moves.append(move)
+    # After the per-source loop rather than inside it, which is git's
+    # order and observable twice over: a source with a fault of its own
+    # outranks this, and so does a same-target collision anywhere on
+    # the line. ``-k`` does not reach it, since an overlap is not a
+    # rename this source could survive being skipped for: moving the
+    # directory first is what makes the other source disappear.
+    overlap = overlapping(moves)
+    if overlap is not None:
+        raise MoveOverlapError(overlap[0], overlap[1])
     return moves
 
 

--- a/python/mirage/commands/cli/builtin/git/mv.py
+++ b/python/mirage/commands/cli/builtin/git/mv.py
@@ -172,7 +172,7 @@ def clashing(move: Move, claimed: set[str]) -> tuple[str, str] | None:
     return None
 
 
-def spanning(mounts: MountView | None, path: str) -> bool:
+def spanning(mounts: MountView | None, path: str, landing: str) -> bool:
     """Whether renaming a path would leave a mount behind.
 
     A mount nested in the repository is served by another resource, and
@@ -183,14 +183,24 @@ def spanning(mounts: MountView | None, path: str) -> bool:
     still points at the old prefix. Neither is something the verb can
     repair afterwards, so both are refused before anything moves.
 
+    The destination is the same fault read from the other end, and it
+    catches an ordinary file the first two questions pass: the op is
+    bound to the backend serving the source, so a landing another mount
+    serves is written into the source's backend at a path it does not
+    own. The file is then hidden behind the other mount while the index
+    names the new path, which is the same broken pair one level down.
+
     Args:
         mounts (MountView | None): the name plane's mount boundaries,
             None outside a workspace.
         path (str): absolute virtual path of the source.
+        landing (str): absolute virtual path the source moves to.
     """
     if mounts is None:
         return False
-    return mounts.is_root(path) or bool(mounts.descendants(path))
+    if mounts.is_root(path) or bool(mounts.descendants(path)):
+        return True
+    return mounts.root_of(path) != mounts.root_of(landing)
 
 
 async def check(stat_path: StatPath, links: LinkView | None,
@@ -300,7 +310,8 @@ async def plan(stat_path: StatPath, links: LinkView | None,
             if clash is not None:
                 reason, named = MULTIPLE_SOURCES, clash
         if reason is None and spanning(
-                mounts, posixpath.join(location.worktree, source)):
+                mounts, posixpath.join(location.worktree, source),
+                posixpath.join(location.worktree, landing)):
             # Last, after every check git itself makes, so a source git
             # would refuse anyway is refused in git's own words. ``-k``
             # skips it like any other rename this source cannot survive.

--- a/python/mirage/commands/cli/builtin/git/mv.py
+++ b/python/mirage/commands/cli/builtin/git/mv.py
@@ -43,6 +43,7 @@ DESTINATION_ALREADY_EXISTS = "destination already exists"
 SOURCE_DIRECTORY_EMPTY = "source directory is empty"
 NOT_UNDER_VERSION_CONTROL = "not under version control"
 MULTIPLE_SOURCES = "multiple sources for the same target"
+CONFLICTED = "conflicted"
 
 
 @dataclass(frozen=True, slots=True)
@@ -124,6 +125,26 @@ def moved_path(move: Move, path: str) -> str:
     return f"{move.destination}{path[len(move.source):]}"
 
 
+def conflicting(move: Move, conflicted: set[str]) -> tuple[str, str] | None:
+    """The first path in a move that the index left unmerged.
+
+    Named the way the collision is named, by the path itself rather than
+    by the operand that carried it, which is what git reports for a
+    directory holding one.
+
+    Args:
+        move (Move): the move being planned.
+        conflicted (set[str]): repository-relative paths with stages.
+
+    Returns:
+        tuple: the source path and the landing it wanted, or None.
+    """
+    for path in move.paths:
+        if path in conflicted:
+            return path, moved_path(move, path)
+    return None
+
+
 def clashing(move: Move, claimed: set[str]) -> tuple[str, str] | None:
     """The first path in a move that lands where an earlier one already does.
 
@@ -149,9 +170,15 @@ def clashing(move: Move, claimed: set[str]) -> tuple[str, str] | None:
 
 async def check(stat_path: StatPath, links: LinkView | None,
                 location: RepoLocation, source: str, destination: str,
-                tracked: set[str],
+                tracked: set[str], conflicted: set[str],
                 force: bool) -> tuple[str | None, tuple[str, ...], bool]:
     """Whether one source can move, in git's own order of refusals.
+
+    The index is read before the destination is looked at, which is
+    git's order and observable: a conflicted source is refused as
+    conflicted even when the destination is occupied, and a directory
+    holding an unmerged path is refused for that rather than for a
+    destination that already exists.
 
     Args:
         stat_path (StatPath): dispatcher-backed stat, both channels.
@@ -159,7 +186,9 @@ async def check(stat_path: StatPath, links: LinkView | None,
         location (RepoLocation): the discovered repository.
         source (str): repository-relative source.
         destination (str): repository-relative destination.
-        tracked (set[str]): repository-relative paths the index holds.
+        tracked (set[str]): repository-relative paths the index holds,
+            unmerged ones included.
+        conflicted (set[str]): of those, the ones left unmerged.
         force (bool): whether ``-f`` was given.
 
     Returns:
@@ -172,17 +201,21 @@ async def check(stat_path: StatPath, links: LinkView | None,
         return BAD_SOURCE, (), False
     if destination == source or destination.startswith(f"{source}/"):
         return INTO_ITSELF, (), False
-    target = await lstat(stat_path, links,
-                         posixpath.join(location.worktree, destination))
+    landing = posixpath.join(location.worktree, destination)
     if info.type is FileType.DIRECTORY:
-        if target is not None:
-            return DESTINATION_ALREADY_EXISTS, (), True
         inside = tuple(sorted(path for path in tracked if under(path, source)))
+        if any(path in conflicted for path in inside):
+            return CONFLICTED, inside, True
+        if await lstat(stat_path, links, landing) is not None:
+            return DESTINATION_ALREADY_EXISTS, (), True
         if not inside:
             return SOURCE_DIRECTORY_EMPTY, (), True
         return None, inside, True
     if source not in tracked:
         return NOT_UNDER_VERSION_CONTROL, (), False
+    if source in conflicted:
+        return CONFLICTED, (source, ), False
+    target = await lstat(stat_path, links, landing)
     if target is not None and (not force or target.type is FileType.DIRECTORY):
         return DESTINATION_EXISTS, (), False
     return None, (source, ), False
@@ -190,7 +223,8 @@ async def check(stat_path: StatPath, links: LinkView | None,
 
 async def plan(stat_path: StatPath, links: LinkView | None,
                location: RepoLocation, start: str, operands: tuple[str, ...],
-               tracked: set[str], flags: MvFlags) -> list[Move]:
+               tracked: set[str], conflicted: set[str],
+               flags: MvFlags) -> list[Move]:
     """Decide every move before making any, which is git's order too.
 
     The last operand is the destination. With several sources it has to
@@ -203,7 +237,9 @@ async def plan(stat_path: StatPath, links: LinkView | None,
         location (RepoLocation): the discovered repository.
         start (str): absolute virtual path git is running in.
         operands (tuple[str, ...]): the operands as typed.
-        tracked (set[str]): repository-relative paths the index holds.
+        tracked (set[str]): repository-relative paths the index holds,
+            unmerged ones included.
+        conflicted (set[str]): of those, the ones left unmerged.
         flags (MvFlags): the parsed flags.
     """
     destination = repo_relative(location, start, operands[-1])
@@ -221,9 +257,15 @@ async def plan(stat_path: StatPath, links: LinkView | None,
                    if into else destination)
         reason, paths, directory = await check(stat_path, links, location,
                                                source, landing, tracked,
-                                               flags.force)
+                                               conflicted, flags.force)
         move = Move(source, landing, paths, directory)
         named = (source, landing)
+        if reason == CONFLICTED:
+            # git names the unmerged path, which for a directory is one
+            # of the paths inside rather than the operand.
+            found = conflicting(move, conflicted)
+            if found is not None:
+                named = found
         if reason is None:
             # Last of the per-source refusals, which is git's order:
             # a source with a fault of its own is refused for that
@@ -294,12 +336,19 @@ async def mv(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
             raise MoveUsageError()
         repo, location = await opened(fl, doors)
         state = await read_index(dispatch, location.gitdir)
+        conflicted = {
+            path.decode("utf-8", errors="replace")
+            for path in state.conflicts
+        }
+        # An unmerged path holds no ordinary entry, so a tracked set
+        # built from the entries alone would call it untracked and let
+        # a directory holding one move with its stages left behind.
         tracked = {
             path.decode("utf-8", errors="replace")
             for path in state.entries
-        }
+        } | conflicted
         moves = await plan(stat_path, links_of(doors), location,
-                           start_point(fl), texts, tracked, flags)
+                           start_point(fl), texts, tracked, conflicted, flags)
         lines: list[str] = []
         if flags.dry_run:
             lines.extend(f"Checking rename of '{move.source}' to "

--- a/python/mirage/commands/cli/builtin/git/mv.py
+++ b/python/mirage/commands/cli/builtin/git/mv.py
@@ -42,6 +42,7 @@ DESTINATION_EXISTS = "destination exists"
 DESTINATION_ALREADY_EXISTS = "destination already exists"
 SOURCE_DIRECTORY_EMPTY = "source directory is empty"
 NOT_UNDER_VERSION_CONTROL = "not under version control"
+MULTIPLE_SOURCES = "multiple sources for the same target"
 
 
 @dataclass(frozen=True, slots=True)
@@ -123,6 +124,29 @@ def moved_path(move: Move, path: str) -> str:
     return f"{move.destination}{path[len(move.source):]}"
 
 
+def clashing(move: Move, claimed: set[str]) -> tuple[str, str] | None:
+    """The first path in a move that lands where an earlier one already does.
+
+    Landings are compared one tracked path at a time rather than one
+    operand at a time, because a directory operand moves every path
+    under it and two directories sharing a child name collide there and
+    nowhere else. git reports that collision by the colliding path too,
+    not by the operand that carried it.
+
+    Args:
+        move (Move): the move being planned.
+        claimed (set[str]): every landing the earlier moves take.
+
+    Returns:
+        tuple: the source path and the landing it wanted, or None.
+    """
+    for path in move.paths:
+        landing = moved_path(move, path)
+        if landing in claimed:
+            return path, landing
+    return None
+
+
 async def check(stat_path: StatPath, links: LinkView | None,
                 location: RepoLocation, source: str, destination: str,
                 tracked: set[str],
@@ -190,6 +214,7 @@ async def plan(stat_path: StatPath, links: LinkView | None,
     if len(operands) > 2 and not into:
         raise NotADirectoryDestinationError(destination)
     moves: list[Move] = []
+    claimed: set[str] = set()
     for operand in operands[:-1]:
         source = repo_relative(location, start, operand)
         landing = (posixpath.join(destination, posixpath.basename(source))
@@ -197,11 +222,21 @@ async def plan(stat_path: StatPath, links: LinkView | None,
         reason, paths, directory = await check(stat_path, links, location,
                                                source, landing, tracked,
                                                flags.force)
+        move = Move(source, landing, paths, directory)
+        named = (source, landing)
+        if reason is None:
+            # Last of the per-source refusals, which is git's order:
+            # a source with a fault of its own is refused for that
+            # fault even when it also collides with an earlier one.
+            clash = clashing(move, claimed)
+            if clash is not None:
+                reason, named = MULTIPLE_SOURCES, clash
         if reason is not None:
             if flags.skip:
                 continue
-            raise MoveRefusedError(reason, source, landing)
-        moves.append(Move(source, landing, paths, directory))
+            raise MoveRefusedError(reason, named[0], named[1])
+        claimed.update(moved_path(move, path) for path in move.paths)
+        moves.append(move)
     return moves
 
 

--- a/python/mirage/commands/cli/builtin/git/pathspec.py
+++ b/python/mirage/commands/cli/builtin/git/pathspec.py
@@ -71,12 +71,18 @@ def under(path: str, directory: str) -> bool:
 
 
 def matched(paths: set[str], target: str) -> set[str]:
-    """Every path a single operand selects: itself, or a whole subtree.
+    """Every path a single operand selects: itself and its whole subtree.
+
+    Both, not one or the other. A pathspec matches a path that equals it
+    and a path it is a leading directory of, and the two are not
+    exclusive as soon as the candidates come from more than one tree:
+    restoring ``slot`` where the index holds the file ``slot`` and the
+    source holds ``slot/child`` has to select both, or the file is
+    deleted and the directory never written. git 2.50.1 replaces one
+    with the other in either direction.
 
     Args:
         paths (set[str]): the candidate paths, repository-relative.
         target (str): the operand, repository-relative.
     """
-    if target in paths:
-        return {target}
-    return {path for path in paths if under(path, target)}
+    return {path for path in paths if path == target or under(path, target)}

--- a/python/mirage/commands/cli/builtin/git/refs.py
+++ b/python/mirage/commands/cli/builtin/git/refs.py
@@ -29,6 +29,7 @@ PACKED_REFS = "packed-refs"
 REFS_DIR = "refs"
 SYMREF_PREFIX = "ref: "
 BRANCH_PREFIX = "refs/heads/"
+TAG_PREFIX = "refs/tags/"
 
 
 async def read_head(dispatch: DispatchFn, gitdir: str) -> HeadRef:
@@ -196,3 +197,36 @@ async def load_refs(dispatch: DispatchFn,
     elif head.commit is not None:
         refs[HEAD_REF] = head.commit.encode()
     return DictRefsContainer(refs)
+
+
+# Every byte git forbids anywhere in a ref name, on top of the control
+# characters: the shell metacharacters that would make a name unusable
+# as a revision, and the backslash.
+FORBIDDEN_IN_REF = frozenset(" ~^:?*[\\")
+LOCK_SUFFIX = ".lock"
+
+
+def valid_ref_name(name: str) -> bool:
+    """Whether a name passes git's ref rules (``git check-ref-format``).
+
+    The rules, in git's own order: no component may start with ``.`` or
+    end with ``.lock``; ``..`` may not appear; no control character,
+    space or shell metacharacter; no leading, trailing or doubled ``/``;
+    no trailing ``.``; and no ``@{``. Empty is refused too. A bare ``@``
+    is refused only as a whole ref, and a name here always sits below
+    ``refs/``, so it passes. Pinned against git 2.50.1.
+
+    Args:
+        name (str): the name below ``refs/heads/`` or ``refs/tags/``.
+    """
+    if not name or name.startswith("/") or name.endswith("/"):
+        return False
+    if "//" in name or ".." in name or "@{" in name or name.endswith("."):
+        return False
+    for ch in name:
+        if ord(ch) < 0x20 or ord(ch) == 0x7F or ch in FORBIDDEN_IN_REF:
+            return False
+    for part in name.split("/"):
+        if part.startswith(".") or part.endswith(LOCK_SUFFIX):
+            return False
+    return True

--- a/python/mirage/commands/cli/builtin/git/refs.py
+++ b/python/mirage/commands/cli/builtin/git/refs.py
@@ -105,13 +105,47 @@ async def write_ref(dispatch: DispatchFn, commondir: str, ref: str,
     await write_file(dispatch, posixpath.join(commondir, ref), sha + b"\n")
 
 
-async def delete_ref(dispatch: DispatchFn, commondir: str, ref: str) -> None:
-    """Remove a loose ref file.
+def without_packed(data: bytes, ref: str) -> bytes | None:
+    """``packed-refs`` with one ref's lines removed, None if it held none.
 
-    Only the loose copy is removed. A ref that also sits in
-    ``packed-refs`` would come back, which is a real gap rather than a
-    silent one: ``branch -d`` refuses below unless the loose file is
-    what actually holds the branch.
+    A packed ref is two lines rather than one when it is an annotated
+    tag: the tag object's own id, then a ``^`` line holding the commit
+    it peels to. The peeled line belongs to the ref above it, so
+    dropping a ref drops the ``^`` line that follows it and nothing
+    else.
+
+    Args:
+        data (bytes): the file as it stands.
+        ref (str): full ref name to drop.
+    """
+    wanted = ref.encode()
+    kept: list[bytes] = []
+    dropped = False
+    found = False
+    for line in data.split(b"\n"):
+        if line.startswith(b"^"):
+            if not dropped:
+                kept.append(line)
+            continue
+        dropped = False
+        if line and not line.startswith(b"#"):
+            space = line.find(b" ")
+            if space != -1 and line[space + 1:].strip() == wanted:
+                dropped = True
+                found = True
+                continue
+        kept.append(line)
+    return b"\n".join(kept) if found else None
+
+
+async def delete_ref(dispatch: DispatchFn, commondir: str, ref: str) -> None:
+    """Remove a ref, loose copy and packed copy alike.
+
+    Both are removed because either alone can be what holds the ref,
+    and removing only the loose one would report a deletion the next
+    read undoes: after ``git pack-refs`` a ref exists nowhere else, and
+    a force-updated one exists in both, where dropping the loose file
+    would resurrect the older packed value.
 
     Args:
         dispatch (DispatchFn): workspace op dispatcher.
@@ -120,6 +154,13 @@ async def delete_ref(dispatch: DispatchFn, commondir: str, ref: str) -> None:
         ref (str): full ref name.
     """
     await remove_file(dispatch, posixpath.join(commondir, ref))
+    path = posixpath.join(commondir, PACKED_REFS)
+    data = await read_optional(dispatch, path)
+    if data is None:
+        return
+    rewritten = without_packed(data, ref)
+    if rewritten is not None:
+        await write_file(dispatch, path, rewritten)
 
 
 async def set_head(dispatch: DispatchFn, gitdir: str, ref: str) -> None:

--- a/python/mirage/commands/cli/builtin/git/refs.py
+++ b/python/mirage/commands/cli/builtin/git/refs.py
@@ -247,6 +247,40 @@ FORBIDDEN_IN_REF = frozenset(" ~^:?*[\\")
 LOCK_SUFFIX = ".lock"
 
 
+def blocking_ref(known: set[Ref], ref: str) -> str | None:
+    """The existing ref that stops a new one from being written.
+
+    A ref is a path, so two of them cannot coexist when one spells a
+    directory the other spells a file: with ``refs/tags/foo`` already
+    there, ``refs/tags/foo/bar`` has no directory to live in, and with
+    ``refs/tags/foo/bar`` there, ``refs/tags/foo`` has a directory
+    standing on its name. git refuses both and names the ref already
+    written; a repository can only ever hold one of the two shapes, so
+    the two searches cannot both answer.
+
+    Nothing below git's own storage can be relied on to say so. A disk
+    mount raises whatever its host filesystem raises, which reaches the
+    user as neither git's wording nor git's exit code, and a prefix
+    store takes both keys happily and leaves a ref the loose-ref walk
+    cannot find.
+
+    Args:
+        known (set[Ref]): every ref the repository holds.
+        ref (str): the full ref name about to be written.
+
+    Returns:
+        str | None: the ref standing in the way, None when none does.
+    """
+    parts = ref.split("/")
+    for depth in range(1, len(parts)):
+        above = "/".join(parts[:depth])
+        if Ref(above.encode()) in known:
+            return above
+    below = f"{ref}/".encode()
+    found = sorted(name for name in known if name.startswith(below))
+    return found[0].decode() if found else None
+
+
 def valid_ref_name(name: str) -> bool:
     """Whether a name passes git's ref rules (``git check-ref-format``).
 

--- a/python/mirage/commands/cli/builtin/git/reset.py
+++ b/python/mirage/commands/cli/builtin/git/reset.py
@@ -26,8 +26,8 @@ from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.pathspec import matched, repo_relative
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
-from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
-                                                  links_of, start_point)
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal, links_of, start_point)
 from mirage.commands.cli.builtin.git.worktree import UNTRACKED_NO, scan
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
@@ -108,7 +108,7 @@ async def reset(
     try:
         if dispatch is None or stat_path is None:
             raise NoWorkspaceError()
-        check_operands(texts, UnknownSwitchError)
+        check_operands(texts, UnknownSwitchError, escaped(inv.argv))
         repo, location = await opened(fl, doors)
         state = await read_index(dispatch, location.gitdir)
         tree = await asyncio.to_thread(head_entries, repo) or {}

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -147,6 +147,12 @@ async def restore(
                 state.entries[name.encode()] = restored(ObjectID(sha), mode)
             for name in absent:
                 state.entries.pop(name.encode(), None)
+            # A restored path is no longer unmerged, and saying so is
+            # not optional: write_index lays the conflict stages over
+            # the entries, so a stage left behind both keeps the path
+            # conflicted and discards the entry just written for it.
+            for name in selected:
+                state.conflicts.pop(name.encode(), None)
             await write_index(dispatch, location.gitdir, state)
         if flags.worktree:
             blobs = await asyncio.to_thread(

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -41,7 +41,7 @@ from mirage.commands.cli.builtin.git.revparse import (TREE, resolve_object,
                                                       unwrapped)
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.util import (  # yapf: disable
-    check_operands, escaped, fatal, links_of, start_point)
+    check_operands, escaped, fatal, links_of, mounts_of, start_point)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.types import ByteSource, IOResult
@@ -222,6 +222,7 @@ async def restore(
             await write_index(dispatch, location.gitdir, state)
         if flags.worktree:
             links = links_of(doors)
+            mounts = mounts_of(doors)
             blobs = await asyncio.to_thread(
                 contents, repo, [tree[name.encode()][1] for name in present])
             # Removals first, because the two sets can name the same
@@ -242,7 +243,8 @@ async def restore(
                                            links):
                     continue
                 await remove_file(dispatch, path)
-                await remove_empty_parents(dispatch, path, location.worktree)
+                await remove_empty_parents(dispatch, path, location.worktree,
+                                           mounts)
             for name in sorted(present):
                 mode, sha = tree[name.encode()]
                 where = posixpath.join(location.worktree, name)
@@ -268,7 +270,7 @@ async def restore(
                 if links is None or links.stat_at(where) is None:
                     info = await stat_path(where)
                     if info is not None and info.type is FileType.DIRECTORY:
-                        await remove_tree(dispatch, where, links)
+                        await remove_tree(dispatch, where, links, mounts)
                 await restore_entry(dispatch, where, mode, blobs[sha], links)
     except GitError as exc:
         return fatal(exc)

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -32,6 +32,7 @@ from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     UnresolvableSourceError)
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import (blocking_ancestor,
+                                                refuse_replaced_mounts,
                                                 remove_empty_parents,
                                                 remove_file, remove_tree,
                                                 restore_entry)
@@ -207,6 +208,16 @@ async def restore(
         ]
         if unmerged:
             raise UnmergedPathError(unmerged)
+        links = links_of(doors)
+        mounts = mounts_of(doors)
+        # Before the index is written, not at the entry that meets it:
+        # ``-SW`` stages first and restores after, so a refusal in the
+        # working-tree pass would leave the index moved and the tree
+        # exactly as it was, which is the one outcome this verb has no
+        # wording for.
+        if flags.worktree:
+            await refuse_replaced_mounts(stat_path, location.worktree,
+                                         sorted(present), links, mounts)
         if flags.staged:
             for name in present:
                 mode, sha = tree[name.encode()]
@@ -221,8 +232,6 @@ async def restore(
                 state.conflicts.pop(name.encode(), None)
             await write_index(dispatch, location.gitdir, state)
         if flags.worktree:
-            links = links_of(doors)
-            mounts = mounts_of(doors)
             blobs = await asyncio.to_thread(
                 contents, repo, [tree[name.encode()][1] for name in present])
             # Removals first, because the two sets can name the same

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -18,8 +18,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from dulwich.index import IndexEntry
-from dulwich.objects import ObjectID
-from dulwich.objectspec import parse_tree
+from dulwich.objects import Commit, ObjectID
 from dulwich.repo import BaseRepo
 
 from mirage.commands.cli.builtin.git.changes import head_entries
@@ -28,19 +27,22 @@ from mirage.commands.cli.builtin.git.checkout import (Tree, contents,
 from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     NoRestorePathsError, NoWorkspaceError, UnknownPathspecError,
-    UnknownSwitchError, UnmergedPathError, UnresolvableSourceError)
+    UnknownSwitchError, UnmergedPathError, UnreadableTreeError,
+    UnresolvableSourceError)
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import (remove_empty_parents,
-                                                remove_file, restore_entry)
+                                                remove_file, remove_tree,
+                                                restore_entry)
 from mirage.commands.cli.builtin.git.pathspec import matched, repo_relative
 from mirage.commands.cli.builtin.git.reset import restored
-from mirage.commands.cli.builtin.git.revparse import resolve_commit
+from mirage.commands.cli.builtin.git.revparse import TREE, resolve_object
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.util import (  # yapf: disable
     check_operands, escaped, fatal, links_of, start_point)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.types import ByteSource, IOResult
+from mirage.types import FileType
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,30 +95,31 @@ def decoded(paths: Iterable[bytes]) -> set[str]:
 def source_tree(repo: BaseRepo, revision: str) -> Tree:
     """Every path a ``--source`` names, commit-ish or tree-ish.
 
-    git takes any tree-ish here, so a raw tree id
-    (``--source=$(git rev-parse HEAD^{tree})``) is as good as a branch.
-    A commit-ish is tried first because it is what the option is
-    normally spelled with and it is the only form carrying ancestry
-    suffixes; a revision neither reading resolves is unresolvable.
+    git takes any tree-ish here, and the option's own help says so
+    (``--source <tree-ish>``), so the whole object grammar is legal:
+    a branch, a raw tree id, a peel (``HEAD^{tree}``, ``v1^{tree}``)
+    and a subtree at a path (``HEAD:sub``) all name a tree.
+
+    The two refusals are worded differently because they are different
+    complaints. A spelling that resolves to nothing is reported by the
+    spelling; one that resolves to an object which is no tree is
+    reported by the id it reached, since the name was fine and the
+    object was not.
 
     Args:
         repo (BaseRepo): the opened repository.
         revision (str): the source as the user spelled it.
     """
     try:
-        commit = resolve_commit(repo, revision)
-    except GitError:
-        # Not a commit-ish. The id is read as a tree before the
-        # revision is called unresolvable, never instead of reporting
-        # it: a spelling neither reading accepts still refuses here.
-        try:
-            return flat_tree(repo, parse_tree(repo, revision).id)
-        except (AssertionError, KeyError, ValueError) as exc:
-            # dulwich asserts rather than raises on a name that is not
-            # hex at all, so the refusal has to catch that too or a
-            # typo escapes as an unhandled error.
-            raise UnresolvableSourceError(revision) from exc
-    return tree_of(repo, commit.id)
+        found = resolve_object(repo, revision)
+    except GitError as exc:
+        raise UnresolvableSourceError(revision) from exc
+    if isinstance(found, Commit):
+        # git's one implicit peel: a commit stands for its tree here.
+        return tree_of(repo, found.id)
+    if found.type_name.decode() != TREE:
+        raise UnreadableTreeError(found.id.decode())
+    return flat_tree(repo, found.id)
 
 
 async def restore(
@@ -200,6 +203,7 @@ async def restore(
                 state.conflicts.pop(name.encode(), None)
             await write_index(dispatch, location.gitdir, state)
         if flags.worktree:
+            links = links_of(doors)
             blobs = await asyncio.to_thread(
                 contents, repo, [tree[name.encode()][1] for name in present])
             # Removals first, because the two sets can name the same
@@ -214,9 +218,20 @@ async def restore(
                 await remove_empty_parents(dispatch, path, location.worktree)
             for name in sorted(present):
                 mode, sha = tree[name.encode()]
-                await restore_entry(dispatch,
-                                    posixpath.join(location.worktree, name),
-                                    mode, blobs[sha], links_of(doors))
+                where = posixpath.join(location.worktree, name)
+                # A directory can still stand here after the loop
+                # above: it removed the tracked children, but an
+                # untracked one keeps it alive and the write would
+                # fail on it with the index already updated. git
+                # replaces the whole directory, untracked children
+                # included. A link is left to restore_entry, which
+                # retargets it; following one to a directory here
+                # would delete a tree no branch named.
+                if links is None or links.stat_at(where) is None:
+                    info = await stat_path(where)
+                    if info is not None and info.type is FileType.DIRECTORY:
+                        await remove_tree(dispatch, where)
+                await restore_entry(dispatch, where, mode, blobs[sha], links)
     except GitError as exc:
         return fatal(exc)
     return None, IOResult()

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -35,8 +35,8 @@ from mirage.commands.cli.builtin.git.pathspec import matched, repo_relative
 from mirage.commands.cli.builtin.git.reset import restored
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
-from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
-                                                  links_of, start_point)
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal, links_of, start_point)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.types import ByteSource, IOResult
@@ -144,7 +144,7 @@ async def restore(
     try:
         if dispatch is None or stat_path is None:
             raise NoWorkspaceError()
-        check_operands(texts, UnknownSwitchError)
+        check_operands(texts, UnknownSwitchError, escaped(inv.argv))
         if not texts:
             raise NoRestorePathsError()
         flags = parse_flags(fl)
@@ -185,15 +185,21 @@ async def restore(
         if flags.worktree:
             blobs = await asyncio.to_thread(
                 contents, repo, [tree[name.encode()][1] for name in present])
+            # Removals first, because the two sets can name the same
+            # place: restoring a directory over a file writes
+            # ``slot/child`` where the file ``slot`` still sits, and the
+            # other direction writes the file where the directory still
+            # sits. Nothing is read back from the working tree, so
+            # emptying it first is free.
+            for name in sorted(absent):
+                path = posixpath.join(location.worktree, name)
+                await remove_file(dispatch, path)
+                await remove_empty_parents(dispatch, path, location.worktree)
             for name in sorted(present):
                 mode, sha = tree[name.encode()]
                 await restore_entry(dispatch,
                                     posixpath.join(location.worktree, name),
                                     mode, blobs[sha], links_of(doors))
-            for name in sorted(absent):
-                path = posixpath.join(location.worktree, name)
-                await remove_file(dispatch, path)
-                await remove_empty_parents(dispatch, path, location.worktree)
     except GitError as exc:
         return fatal(exc)
     return None, IOResult()

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -32,7 +32,7 @@ from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     UnresolvableSourceError)
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import (  # yapf: disable
-    blocking_ancestor, keep_gitlink, refuse_replaced_mounts,
+    blocking_ancestor, drop_gitlink, keep_gitlink, refuse_replaced_mounts,
     remove_empty_parents, remove_file, remove_tree, restore_entry)
 from mirage.commands.cli.builtin.git.pathspec import (matched, repo_relative,
                                                       under)
@@ -153,6 +153,7 @@ async def restore(
     stat_path = doors.stat_path
     texts = inv.texts
     fl = FlagView(inv.flags)
+    notes: list[str] = []
     try:
         if dispatch is None or stat_path is None:
             raise NoWorkspaceError()
@@ -268,7 +269,17 @@ async def restore(
                 if await blocking_ancestor(stat_path, location.worktree, name,
                                            links):
                     continue
-                await remove_file(dispatch, path)
+                # What stands at a gitlink is a directory, so taking it
+                # away is an rmdir that may legitimately fail: unlink
+                # died on it with the index already written, which is
+                # the half-restore this verb has no wording for.
+                if held.get(name.encode(), (0, b""))[0] == GITLINK:
+                    warned = await drop_gitlink(dispatch, stat_path, path,
+                                                name, links)
+                    if warned is not None:
+                        notes.append(warned)
+                else:
+                    await remove_file(dispatch, path)
                 await remove_empty_parents(dispatch, path, location.worktree,
                                            mounts)
             for name in sorted(present):
@@ -303,4 +314,5 @@ async def restore(
                 await restore_entry(dispatch, where, mode, blobs[sha], links)
     except GitError as exc:
         return fatal(exc)
-    return None, IOResult()
+    told = "".join(notes).encode()
+    return None, IOResult(stderr=told) if told else IOResult()

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -18,9 +18,12 @@ from dataclasses import dataclass
 
 from dulwich.index import IndexEntry
 from dulwich.objects import ObjectID
+from dulwich.objectspec import parse_tree
+from dulwich.repo import BaseRepo
 
 from mirage.commands.cli.builtin.git.changes import head_entries
-from mirage.commands.cli.builtin.git.checkout import Tree, contents, tree_of
+from mirage.commands.cli.builtin.git.checkout import (Tree, contents,
+                                                      flat_tree, tree_of)
 from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     NoRestorePathsError, NoWorkspaceError, UnknownPathspecError,
@@ -86,6 +89,35 @@ def decoded(paths: set[bytes] | dict[bytes, tuple[int, bytes]]) -> set[str]:
     return {path.decode("utf-8", errors="replace") for path in paths}
 
 
+def source_tree(repo: BaseRepo, revision: str) -> Tree:
+    """Every path a ``--source`` names, commit-ish or tree-ish.
+
+    git takes any tree-ish here, so a raw tree id
+    (``--source=$(git rev-parse HEAD^{tree})``) is as good as a branch.
+    A commit-ish is tried first because it is what the option is
+    normally spelled with and it is the only form carrying ancestry
+    suffixes; a revision neither reading resolves is unresolvable.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        revision (str): the source as the user spelled it.
+    """
+    try:
+        commit = resolve_commit(repo, revision)
+    except GitError:
+        # Not a commit-ish. The id is read as a tree before the
+        # revision is called unresolvable, never instead of reporting
+        # it: a spelling neither reading accepts still refuses here.
+        try:
+            return flat_tree(repo, parse_tree(repo, revision).id)
+        except (AssertionError, KeyError, ValueError) as exc:
+            # dulwich asserts rather than raises on a name that is not
+            # hex at all, so the refusal has to catch that too or a
+            # typo escapes as an unhandled error.
+            raise UnresolvableSourceError(revision) from exc
+    return tree_of(repo, commit.id)
+
+
 async def restore(
         inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
     """Put paths back to what a source records.
@@ -120,12 +152,8 @@ async def restore(
         state = await read_index(dispatch, location.gitdir)
         held = index_tree(state.entries)
         if flags.source is not None:
-            try:
-                commit = resolve_commit(repo, flags.source)
-            except GitError as exc:
-                raise UnresolvableSourceError(flags.source) from exc
             source: Tree | None = await asyncio.to_thread(
-                tree_of, repo, commit.id)
+                source_tree, repo, flags.source)
         elif flags.staged:
             source = await asyncio.to_thread(head_entries, repo) or {}
         else:

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -24,6 +24,7 @@ from dulwich.repo import BaseRepo
 from mirage.commands.cli.builtin.git.changes import head_entries
 from mirage.commands.cli.builtin.git.checkout import (Tree, contents,
                                                       flat_tree, tree_of)
+from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     NoRestorePathsError, NoWorkspaceError, UnknownPathspecError,
@@ -159,7 +160,17 @@ async def restore(
             source: Tree | None = await asyncio.to_thread(
                 source_tree, repo, flags.source)
         elif flags.staged:
-            source = await asyncio.to_thread(head_entries, repo) or {}
+            # Before the first commit there is no HEAD to restore the
+            # index from, and reading that as an empty tree unstaged
+            # every selected path and reported success. git refuses the
+            # whole line instead, index untouched. The working tree
+            # restores from the index, so it is only the implicit HEAD
+            # source that has nothing to read: ``--source`` naming a
+            # tree still works in the same repository.
+            found = await asyncio.to_thread(head_entries, repo)
+            if found is None:
+                raise UnresolvableSourceError(HEAD)
+            source = found
         else:
             source = None
         tree = held if source is None else source

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -1,0 +1,165 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import posixpath
+from dataclasses import dataclass
+
+from dulwich.index import IndexEntry
+from dulwich.objects import ObjectID
+
+from mirage.commands.cli.builtin.git.changes import head_entries
+from mirage.commands.cli.builtin.git.checkout import Tree, contents, tree_of
+from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
+from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
+    NoRestorePathsError, NoWorkspaceError, UnknownPathspecError,
+    UnknownSwitchError, UnresolvableSourceError)
+from mirage.commands.cli.builtin.git.index import read_index, write_index
+from mirage.commands.cli.builtin.git.io import (remove_empty_parents,
+                                                remove_file, restore_entry)
+from mirage.commands.cli.builtin.git.pathspec import matched, repo_relative
+from mirage.commands.cli.builtin.git.reset import restored
+from mirage.commands.cli.builtin.git.revparse import resolve_commit
+from mirage.commands.cli.builtin.git.session import opened
+from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
+                                                  links_of, start_point)
+from mirage.commands.cli.types import CLIDoors, CLIInvocation
+from mirage.commands.spec.types import FlagView
+from mirage.io.types import ByteSource, IOResult
+
+
+@dataclass(frozen=True, slots=True)
+class RestoreFlags:
+    """The parsed shape of a ``git restore`` invocation.
+
+    Args:
+        staged (bool): ``--staged``, put the index back.
+        worktree (bool): ``--worktree``, put the working tree back. The
+            default when ``--staged`` is absent, which is git's rule.
+        source (str | None): ``--source``, the tree to restore from.
+            None means the index for the working tree and HEAD for the
+            index.
+    """
+    staged: bool
+    worktree: bool
+    source: str | None
+
+
+def parse_flags(fl: FlagView) -> RestoreFlags:
+    """Read the raw restore flag kwargs into a frozen struct.
+
+    Args:
+        fl (FlagView): spec-validated view over the raw flag kwargs.
+    """
+    staged = fl.as_bool("staged")
+    return RestoreFlags(staged=staged,
+                        worktree=fl.as_bool("worktree") or not staged,
+                        source=fl.as_str("source"))
+
+
+def index_tree(entries: dict[bytes, IndexEntry]) -> Tree:
+    """The index read as a tree: every path with its mode and blob id.
+
+    Args:
+        entries (dict[bytes, IndexEntry]): the index.
+    """
+    return {path: (entry.mode, entry.sha) for path, entry in entries.items()}
+
+
+def decoded(paths: set[bytes] | dict[bytes, tuple[int, bytes]]) -> set[str]:
+    """Repository-relative paths as text.
+
+    Args:
+        paths (set[bytes] | dict): index or tree keys.
+    """
+    return {path.decode("utf-8", errors="replace") for path in paths}
+
+
+async def restore(
+        inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
+    """Put paths back to what a source records.
+
+    Two targets and one source, git's own model. ``--staged`` restores
+    the index and ``--worktree`` the working tree; the default is the
+    working tree alone. The source is the index for the working tree
+    and HEAD for the index unless ``--source`` names a tree, in which
+    case a selected path the source does not hold is removed from
+    whichever target is being restored, since that is what "make it
+    match the source" means for it. Pinned against git 2.50.1.
+
+    Args:
+        inv (CLIInvocation[None]): the line's invocation record.
+            git declares no config_model; the planes it reads
+            (data through ``dispatch``, names through ``ns``) ride
+            ``inv.doors``.
+    """
+    doors = inv.doors or CLIDoors()
+    dispatch = doors.dispatch
+    stat_path = doors.stat_path
+    texts = inv.texts
+    fl = FlagView(inv.flags)
+    try:
+        if dispatch is None or stat_path is None:
+            raise NoWorkspaceError()
+        check_operands(texts, UnknownSwitchError)
+        if not texts:
+            raise NoRestorePathsError()
+        flags = parse_flags(fl)
+        repo, location = await opened(fl, doors)
+        state = await read_index(dispatch, location.gitdir)
+        held = index_tree(state.entries)
+        if flags.source is not None:
+            try:
+                commit = resolve_commit(repo, flags.source)
+            except GitError as exc:
+                raise UnresolvableSourceError(flags.source) from exc
+            source: Tree | None = await asyncio.to_thread(
+                tree_of, repo, commit.id)
+        elif flags.staged:
+            source = await asyncio.to_thread(head_entries, repo) or {}
+        else:
+            source = None
+        tree = held if source is None else source
+        names = decoded(held) | decoded(tree)
+        start = start_point(fl)
+        selected: set[str] = set()
+        for operand in texts:
+            hits = matched(names, repo_relative(location, start, operand))
+            if not hits:
+                raise UnknownPathspecError(operand)
+            selected |= hits
+        present = {name for name in selected if name.encode() in tree}
+        absent = selected - present
+        if flags.staged:
+            for name in present:
+                mode, sha = tree[name.encode()]
+                state.entries[name.encode()] = restored(ObjectID(sha), mode)
+            for name in absent:
+                state.entries.pop(name.encode(), None)
+            await write_index(dispatch, location.gitdir, state)
+        if flags.worktree:
+            blobs = await asyncio.to_thread(
+                contents, repo, [tree[name.encode()][1] for name in present])
+            for name in sorted(present):
+                mode, sha = tree[name.encode()]
+                await restore_entry(dispatch,
+                                    posixpath.join(location.worktree, name),
+                                    mode, blobs[sha], links_of(doors))
+            for name in sorted(absent):
+                path = posixpath.join(location.worktree, name)
+                await remove_file(dispatch, path)
+                await remove_empty_parents(dispatch, path, location.worktree)
+    except GitError as exc:
+        return fatal(exc)
+    return None, IOResult()

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -24,7 +24,7 @@ from dulwich.repo import BaseRepo
 from mirage.commands.cli.builtin.git.changes import head_entries
 from mirage.commands.cli.builtin.git.checkout import (Tree, contents,
                                                       flat_tree, tree_of)
-from mirage.commands.cli.builtin.git.constants import HEAD
+from mirage.commands.cli.builtin.git.constants import GITLINK, HEAD
 from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     NoRestorePathsError, NoWorkspaceError, UnknownPathspecError,
@@ -32,6 +32,7 @@ from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     UnresolvableSourceError)
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import (blocking_ancestor,
+                                                keep_gitlink,
                                                 refuse_replaced_mounts,
                                                 remove_empty_parents,
                                                 remove_file, remove_tree,
@@ -215,9 +216,15 @@ async def restore(
         # working-tree pass would leave the index moved and the tree
         # exactly as it was, which is the one outcome this verb has no
         # wording for.
+        # A gitlink is not written into the working tree at all, so it
+        # is neither read as a blob nor allowed to clear what stands at
+        # the name; keep_gitlink is the whole of what the entry asks
+        # for, and the preflight has nothing to say about it either.
+        replacing = sorted(name for name in present
+                           if tree[name.encode()][0] != GITLINK)
         if flags.worktree:
             await refuse_replaced_mounts(stat_path, location.worktree,
-                                         sorted(present), links, mounts)
+                                         replacing, links, mounts)
         if flags.staged:
             for name in present:
                 mode, sha = tree[name.encode()]
@@ -233,7 +240,7 @@ async def restore(
             await write_index(dispatch, location.gitdir, state)
         if flags.worktree:
             blobs = await asyncio.to_thread(
-                contents, repo, [tree[name.encode()][1] for name in present])
+                contents, repo, [tree[name.encode()][1] for name in replacing])
             # Removals first, because the two sets can name the same
             # place: restoring a directory over a file writes
             # ``slot/child`` where the file ``slot`` still sits, and the
@@ -257,6 +264,9 @@ async def restore(
             for name in sorted(present):
                 mode, sha = tree[name.encode()]
                 where = posixpath.join(location.worktree, name)
+                if mode == GITLINK:
+                    await keep_gitlink(dispatch, stat_path, where, links)
+                    continue
                 # The write direction takes the same component the
                 # other way round: the entry needs a directory where it
                 # stands, so git replaces it with one rather than

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -36,13 +36,15 @@ from mirage.commands.cli.builtin.git.io import (remove_empty_parents,
                                                 restore_entry)
 from mirage.commands.cli.builtin.git.pathspec import matched, repo_relative
 from mirage.commands.cli.builtin.git.reset import restored
-from mirage.commands.cli.builtin.git.revparse import TREE, resolve_object
+from mirage.commands.cli.builtin.git.revparse import (TREE, resolve_object,
+                                                      unwrapped)
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.util import (  # yapf: disable
     check_operands, escaped, fatal, links_of, start_point)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.types import ByteSource, IOResult
+from mirage.ops.types import LinkView
 from mirage.types import FileType
 
 
@@ -115,12 +117,52 @@ def source_tree(repo: BaseRepo, revision: str) -> Tree:
         found = resolve_object(repo, revision)
     except GitError as exc:
         raise UnresolvableSourceError(revision) from exc
+    # A bare id names the object itself, so an annotated tag arrives as
+    # the tag rather than as what it points at. A tag is no tree-ish,
+    # and unwrapping it is what makes ``--source=<tag-id>`` read the
+    # same tree ``--source=v1`` reads.
+    found = unwrapped(repo, found, revision)
     if isinstance(found, Commit):
         # git's one implicit peel: a commit stands for its tree here.
         return tree_of(repo, found.id)
     if found.type_name.decode() != TREE:
         raise UnreadableTreeError(found.id.decode())
     return flat_tree(repo, found.id)
+
+
+def linked_ancestor(worktree: str, name: str,
+                    links: LinkView | None) -> str | None:
+    """The nearest directory above an entry that is really a symlink.
+
+    An entry's path is only a way through the working tree while every
+    component above it is a directory. A link standing on one is not,
+    and neither a write nor a removal may be attempted through it: both
+    resolve past the link and land in whatever tree it points at,
+    damaging files no branch named while the link itself stays. git
+    checks the leading path for exactly this and takes the two
+    directions differently, which is what the callers do here.
+
+    Exact-path link lookups cannot see this, since the link sits above
+    the name being looked up rather than on it.
+
+    Args:
+        worktree (str): absolute virtual path of the working tree root.
+        name (str): the entry, repository-relative.
+        links (LinkView | None): the name plane's link facts, None when
+            no namespace is wired.
+
+    Returns:
+        str | None: absolute virtual path of the nearest such link,
+        None when every component above the entry is a directory.
+    """
+    if links is None:
+        return None
+    current = worktree
+    for part in name.split("/")[:-1]:
+        current = posixpath.join(current, part)
+        if links.stat_at(current) is not None:
+            return current
+    return None
 
 
 async def restore(
@@ -225,11 +267,26 @@ async def restore(
             # emptying it first is free.
             for name in sorted(absent):
                 path = posixpath.join(location.worktree, name)
+                # A link above the entry is not a way through to it:
+                # the unlink would resolve past the link and delete a
+                # file inside whatever it points at, which no branch
+                # named. git checks the leading path and removes
+                # nothing when it finds one, so neither does this.
+                if linked_ancestor(location.worktree, name, links):
+                    continue
                 await remove_file(dispatch, path)
                 await remove_empty_parents(dispatch, path, location.worktree)
             for name in sorted(present):
                 mode, sha = tree[name.encode()]
                 where = posixpath.join(location.worktree, name)
+                # The write direction takes the same link the other way
+                # round: the entry needs a directory where the link
+                # stands, so git replaces the link with one rather than
+                # writing through it. The tree the link pointed at is
+                # left exactly as it was.
+                above = linked_ancestor(location.worktree, name, links)
+                if above is not None:
+                    await remove_file(dispatch, above)
                 # A directory can still stand here after the loop
                 # above: it removed the tracked children, but an
                 # untracked one keeps it alive and the write would

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -268,7 +268,7 @@ async def restore(
                 if links is None or links.stat_at(where) is None:
                     info = await stat_path(where)
                     if info is not None and info.type is FileType.DIRECTORY:
-                        await remove_tree(dispatch, where)
+                        await remove_tree(dispatch, where, links)
                 await restore_entry(dispatch, where, mode, blobs[sha], links)
     except GitError as exc:
         return fatal(exc)

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -31,13 +31,11 @@ from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     UnknownSwitchError, UnmergedPathError, UnreadableTreeError,
     UnresolvableSourceError)
 from mirage.commands.cli.builtin.git.index import read_index, write_index
-from mirage.commands.cli.builtin.git.io import (blocking_ancestor,
-                                                keep_gitlink,
-                                                refuse_replaced_mounts,
-                                                remove_empty_parents,
-                                                remove_file, remove_tree,
-                                                restore_entry)
-from mirage.commands.cli.builtin.git.pathspec import matched, repo_relative
+from mirage.commands.cli.builtin.git.io import (  # yapf: disable
+    blocking_ancestor, keep_gitlink, refuse_replaced_mounts,
+    remove_empty_parents, remove_file, remove_tree, restore_entry)
+from mirage.commands.cli.builtin.git.pathspec import (matched, repo_relative,
+                                                      under)
 from mirage.commands.cli.builtin.git.reset import restored
 from mirage.commands.cli.builtin.git.revparse import (TREE, resolve_object,
                                                       unwrapped)
@@ -222,6 +220,18 @@ async def restore(
         # for, and the preflight has nothing to say about it either.
         replacing = sorted(name for name in present
                            if tree[name.encode()][0] != GITLINK)
+        # A gitlink's directory is not this verb's to empty either. The
+        # entry is a placeholder for a repository mirage cannot read, so
+        # git writes the directory and leaves every path under it alone:
+        # a child the source drops loses its index entry and keeps its
+        # working-tree copy, edits included. Removing it here is the one
+        # loss nothing can undo, since the content was never staged.
+        # Pinned against git 2.50.1.
+        linked = [
+            name for name in present if tree[name.encode()][0] == GITLINK
+        ]
+        dropped = sorted(name for name in absent
+                         if not any(under(name, root) for root in linked))
         if flags.worktree:
             await refuse_replaced_mounts(stat_path, location.worktree,
                                          replacing, links, mounts)
@@ -247,7 +257,7 @@ async def restore(
             # other direction writes the file where the directory still
             # sits. Nothing is read back from the working tree, so
             # emptying it first is free.
-            for name in sorted(absent):
+            for name in dropped:
                 path = posixpath.join(location.worktree, name)
                 # A component above the entry that is not a directory
                 # is not a way through to it: the unlink would resolve

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -31,7 +31,8 @@ from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     UnknownSwitchError, UnmergedPathError, UnreadableTreeError,
     UnresolvableSourceError)
 from mirage.commands.cli.builtin.git.index import read_index, write_index
-from mirage.commands.cli.builtin.git.io import (remove_empty_parents,
+from mirage.commands.cli.builtin.git.io import (blocking_ancestor,
+                                                remove_empty_parents,
                                                 remove_file, remove_tree,
                                                 restore_entry)
 from mirage.commands.cli.builtin.git.pathspec import matched, repo_relative
@@ -44,7 +45,6 @@ from mirage.commands.cli.builtin.git.util import (  # yapf: disable
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.types import ByteSource, IOResult
-from mirage.ops.types import LinkView
 from mirage.types import FileType
 
 
@@ -128,41 +128,6 @@ def source_tree(repo: BaseRepo, revision: str) -> Tree:
     if found.type_name.decode() != TREE:
         raise UnreadableTreeError(found.id.decode())
     return flat_tree(repo, found.id)
-
-
-def linked_ancestor(worktree: str, name: str,
-                    links: LinkView | None) -> str | None:
-    """The nearest directory above an entry that is really a symlink.
-
-    An entry's path is only a way through the working tree while every
-    component above it is a directory. A link standing on one is not,
-    and neither a write nor a removal may be attempted through it: both
-    resolve past the link and land in whatever tree it points at,
-    damaging files no branch named while the link itself stays. git
-    checks the leading path for exactly this and takes the two
-    directions differently, which is what the callers do here.
-
-    Exact-path link lookups cannot see this, since the link sits above
-    the name being looked up rather than on it.
-
-    Args:
-        worktree (str): absolute virtual path of the working tree root.
-        name (str): the entry, repository-relative.
-        links (LinkView | None): the name plane's link facts, None when
-            no namespace is wired.
-
-    Returns:
-        str | None: absolute virtual path of the nearest such link,
-        None when every component above the entry is a directory.
-    """
-    if links is None:
-        return None
-    current = worktree
-    for part in name.split("/")[:-1]:
-        current = posixpath.join(current, part)
-        if links.stat_at(current) is not None:
-            return current
-    return None
 
 
 async def restore(
@@ -267,24 +232,29 @@ async def restore(
             # emptying it first is free.
             for name in sorted(absent):
                 path = posixpath.join(location.worktree, name)
-                # A link above the entry is not a way through to it:
-                # the unlink would resolve past the link and delete a
-                # file inside whatever it points at, which no branch
-                # named. git checks the leading path and removes
-                # nothing when it finds one, so neither does this.
-                if linked_ancestor(location.worktree, name, links):
+                # A component above the entry that is not a directory
+                # is not a way through to it: the unlink would resolve
+                # past it and delete a file inside whatever it points
+                # at, which no branch named. git checks the leading
+                # path and removes nothing when it finds one, so
+                # neither does this.
+                if await blocking_ancestor(stat_path, location.worktree, name,
+                                           links):
                     continue
                 await remove_file(dispatch, path)
                 await remove_empty_parents(dispatch, path, location.worktree)
             for name in sorted(present):
                 mode, sha = tree[name.encode()]
                 where = posixpath.join(location.worktree, name)
-                # The write direction takes the same link the other way
-                # round: the entry needs a directory where the link
-                # stands, so git replaces the link with one rather than
-                # writing through it. The tree the link pointed at is
-                # left exactly as it was.
-                above = linked_ancestor(location.worktree, name, links)
+                # The write direction takes the same component the
+                # other way round: the entry needs a directory where it
+                # stands, so git replaces it with one rather than
+                # writing through it. A link's target tree is left
+                # exactly as it was, and an untracked file standing
+                # there is replaced in silence, which is what git's
+                # create_directories does to any leading non-directory.
+                above = await blocking_ancestor(stat_path, location.worktree,
+                                                name, links)
                 if above is not None:
                     await remove_file(dispatch, above)
                 # A directory can still stand here after the loop

--- a/python/mirage/commands/cli/builtin/git/restore.py
+++ b/python/mirage/commands/cli/builtin/git/restore.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import posixpath
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 from dulwich.index import IndexEntry
@@ -27,7 +28,7 @@ from mirage.commands.cli.builtin.git.checkout import (Tree, contents,
 from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     NoRestorePathsError, NoWorkspaceError, UnknownPathspecError,
-    UnknownSwitchError, UnresolvableSourceError)
+    UnknownSwitchError, UnmergedPathError, UnresolvableSourceError)
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import (remove_empty_parents,
                                                 remove_file, restore_entry)
@@ -80,11 +81,11 @@ def index_tree(entries: dict[bytes, IndexEntry]) -> Tree:
     return {path: (entry.mode, entry.sha) for path, entry in entries.items()}
 
 
-def decoded(paths: set[bytes] | dict[bytes, tuple[int, bytes]]) -> set[str]:
+def decoded(paths: Iterable[bytes]) -> set[str]:
     """Repository-relative paths as text.
 
     Args:
-        paths (set[bytes] | dict): index or tree keys.
+        paths (Iterable[bytes]): index, conflict or tree keys.
     """
     return {path.decode("utf-8", errors="replace") for path in paths}
 
@@ -159,7 +160,13 @@ async def restore(
         else:
             source = None
         tree = held if source is None else source
-        names = decoded(held) | decoded(tree)
+        # The conflict stages name paths too. An unmerged path has no
+        # stage-0 entry, so neither the index nor HEAD carries it and
+        # the pathspec would miss what git matches: to git it is an
+        # index entry like any other. Selecting it is what lets a
+        # source holding it put it back, stages and all, and what lets
+        # the refusal below name it when none does.
+        names = decoded(held) | decoded(tree) | decoded(state.conflicts)
         start = start_point(fl)
         selected: set[str] = set()
         for operand in texts:
@@ -169,6 +176,16 @@ async def restore(
             selected |= hits
         present = {name for name in selected if name.encode() in tree}
         absent = selected - present
+        # A selected path the source does not hold and the index still
+        # holds stages for cannot be restored either way: there is no
+        # stage-0 content to write into the working tree and no entry
+        # to stage. git names every one of them and does none of the
+        # work, where an absent path with no stages is simply removed.
+        unmerged = [
+            name for name in absent if name.encode() in state.conflicts
+        ]
+        if unmerged:
+            raise UnmergedPathError(unmerged)
         if flags.staged:
             for name in present:
                 mode, sha = tree[name.encode()]

--- a/python/mirage/commands/cli/builtin/git/revparse.py
+++ b/python/mirage/commands/cli/builtin/git/revparse.py
@@ -73,6 +73,10 @@ def split_revision(revision: str) -> tuple[str, tuple[AncestryStep, ...]]:
 
     Args:
         revision (str): revision as the user spelled it.
+
+    Raises:
+        AmbiguousArgumentError: when the suffix holds anything but
+            ancestry steps.
     """
     index = next(
         (i for i, ch in enumerate(revision) if ch in SUFFIXES),
@@ -83,6 +87,14 @@ def split_revision(revision: str) -> tuple[str, tuple[AncestryStep, ...]]:
     position = 0
     while position < len(rest):
         kind = rest[position]
+        # Only ``~`` and ``^`` are ancestry steps, and reading anything
+        # else as one is silent rather than loud: every other character
+        # counted as another first-parent hop, so ``HEAD^x`` resolved to
+        # ``HEAD^^`` and the caller was handed a commit it never named.
+        # git refuses the whole expression instead, and refuses
+        # ``main~٣`` with it, since the digits it counts are ASCII.
+        if kind not in SUFFIXES:
+            raise AmbiguousArgumentError(revision)
         position += 1
         digits = ""
         while position < len(rest) and rest[position] in "0123456789":

--- a/python/mirage/commands/cli/builtin/git/revparse.py
+++ b/python/mirage/commands/cli/builtin/git/revparse.py
@@ -12,7 +12,8 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-from dulwich.objects import Commit, ObjectID
+from dulwich.errors import NotTreeError
+from dulwich.objects import Commit, ObjectID, ShaFile, Tag, Tree
 from dulwich.objectspec import parse_commit
 from dulwich.repo import BaseRepo
 
@@ -23,6 +24,38 @@ from mirage.commands.cli.builtin.git.types import AncestryStep
 ANCESTOR = "~"
 PARENT = "^"
 SUFFIXES = (ANCESTOR, PARENT)
+# ``<rev>^{<type>}`` peels to a type; ``<rev>:<path>`` reads a tree.
+PEEL_OPEN = "^{"
+PEEL_CLOSE = "}"
+PATH_MARK = ":"
+COMMIT = "commit"
+TREE = "tree"
+
+
+def split_peel(revision: str) -> tuple[str, str | None]:
+    """Split a trailing ``^{<type>}`` off a revision.
+
+    ``HEAD^{tree}`` is a peel, not an ancestry step, and reading it as
+    one is silent rather than loud: ``^`` with no digits means "first
+    parent", so the suffix resolved to HEAD's parent commit and the
+    caller was handed a different object than it asked for without a
+    word. The braces tell the two apart, and git forbids both of them
+    in a ref name, so nothing else can end this way.
+
+    Args:
+        revision (str): revision as the user spelled it.
+
+    Returns:
+        tuple[str, str | None]: the revision without the peel, and the
+        type word inside it, empty for ``^{}`` and None when there is
+        no peel at all.
+    """
+    if not revision.endswith(PEEL_CLOSE):
+        return revision, None
+    index = revision.rfind(PEEL_OPEN)
+    if index < 0:
+        return revision, None
+    return revision[:index], revision[index + len(PEEL_OPEN):-1]
 
 
 def split_revision(revision: str) -> tuple[str, tuple[AncestryStep, ...]]:
@@ -108,11 +141,18 @@ def resolve_commit(repo: BaseRepo, revision: str) -> Commit:
     nothing about ``~`` and ``^``; those are applied here, on top of
     whatever its own parser returns.
 
+    A ``^{}`` or ``^{commit}`` peel asks for exactly what this returns
+    and is honoured; a peel naming any other type is a revision this
+    caller cannot use, so it is refused rather than quietly stripped.
+
     Args:
         repo (BaseRepo): repository to resolve against.
         revision (str): revision as the user spelled it.
     """
-    base, steps = split_revision(revision)
+    stem, want = split_peel(revision)
+    if want is not None and want not in ("", COMMIT):
+        raise AmbiguousArgumentError(revision)
+    base, steps = split_revision(stem)
     try:
         commit = parse_commit(repo, base)
     except (KeyError, ValueError) as exc:
@@ -120,3 +160,123 @@ def resolve_commit(repo: BaseRepo, revision: str) -> Commit:
     for step in steps:
         commit = _step(repo, commit, step, revision)
     return commit
+
+
+def object_at(repo: BaseRepo, revision: str) -> ShaFile:
+    """The object one id names, whatever its type.
+
+    Only an id, full or abbreviated: a ref and an ancestry suffix are
+    the caller's to try first, and this is what is left for the tree or
+    blob id git also takes wherever an object is wanted. An
+    abbreviation is expanded through the store rather than looked up,
+    since a store answers only a whole id.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        revision (str): the id as the user spelled it.
+
+    Raises:
+        KeyError: when no object carries that id.
+    """
+    wanted = revision.encode()
+    try:
+        return repo[ObjectID(wanted)]
+    except KeyError:
+        found = list(repo.object_store.iter_prefix(wanted))
+        if len(found) != 1:
+            raise
+        return repo[found[0]]
+
+
+def _object_by_id(repo: BaseRepo, sha: ObjectID, revision: str) -> ShaFile:
+    """Load one object by id, or report the revision as unknown.
+
+    Args:
+        repo (BaseRepo): repository holding the object.
+        sha (ObjectID): hex object id.
+        revision (str): the whole revision, for error attribution.
+    """
+    try:
+        return repo.object_store[sha]
+    except KeyError as exc:
+        raise AmbiguousArgumentError(revision) from exc
+
+
+def _peeled(repo: BaseRepo, obj: ShaFile, want: str, revision: str) -> ShaFile:
+    """Follow a ``^{<type>}`` peel from the object the stem named.
+
+    A tag is unwrapped first whatever the type asked for, which is what
+    ``^{}`` means on its own. ``^{tree}`` then takes a commit's tree,
+    git's one implicit step; every other spelling has to already name
+    the type it asks for, so ``HEAD^{blob}`` is refused rather than
+    answered with something else.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        obj (ShaFile): the object the stem resolved to.
+        want (str): the type word inside the braces, empty for ``^{}``.
+        revision (str): the whole revision, for error attribution.
+    """
+    while isinstance(obj, Tag):
+        obj = _object_by_id(repo, obj.object[1], revision)
+    if want == "":
+        return obj
+    if want == TREE and isinstance(obj, Commit):
+        obj = _object_by_id(repo, obj.tree, revision)
+    if obj.type_name.decode() != want:
+        raise AmbiguousArgumentError(revision)
+    return obj
+
+
+def _at_path(repo: BaseRepo, rev: str, path: str, revision: str) -> ShaFile:
+    """The object a ``<rev>:<path>`` names inside a tree.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        rev (str): the revision before the colon, HEAD when empty.
+        path (str): the path after it, repository-relative.
+        revision (str): the whole revision, for error attribution.
+    """
+    holder = resolve_object(repo, rev)
+    if isinstance(holder, Commit):
+        holder = _object_by_id(repo, holder.tree, revision)
+    if not isinstance(holder, Tree):
+        raise AmbiguousArgumentError(revision)
+    try:
+        _mode, sha = holder.lookup_path(repo.object_store.__getitem__,
+                                        path.encode())
+    except (KeyError, NotTreeError, ValueError) as exc:
+        raise AmbiguousArgumentError(revision) from exc
+    return _object_by_id(repo, sha, revision)
+
+
+def resolve_object(repo: BaseRepo, revision: str) -> ShaFile:
+    """The object a revision names, whatever type it turns out to be.
+
+    The whole grammar a caller that wants an object rather than a
+    commit has to read: ``HEAD:a.txt`` is the blob at a path,
+    ``HEAD^{tree}`` is a commit's tree, ``v1^{}`` is what a tag points
+    at, and a bare id of any type is itself. A commit-ish is tried
+    first because that is what the operand is normally spelled with,
+    and it is the only reading that understands ancestry.
+
+    Args:
+        repo (BaseRepo): repository to resolve against.
+        revision (str): revision as the user spelled it.
+    """
+    if PATH_MARK in revision:
+        rev, _, path = revision.partition(PATH_MARK)
+        return _at_path(repo, rev or HEAD, path, revision)
+    stem, want = split_peel(revision)
+    if want is None:
+        try:
+            return resolve_commit(repo, revision)
+        except AmbiguousArgumentError:
+            # Not a commit-ish. A raw id is read as itself before the
+            # revision is called unresolved, and the type is kept,
+            # since it is what a caller records.
+            try:
+                return object_at(repo, revision)
+            except (KeyError, ValueError) as exc:
+                raise AmbiguousArgumentError(revision) from exc
+    return _peeled(repo, resolve_object(repo, stem), want or "", revision)

--- a/python/mirage/commands/cli/builtin/git/revparse.py
+++ b/python/mirage/commands/cli/builtin/git/revparse.py
@@ -15,10 +15,12 @@
 from dulwich.errors import NotTreeError
 from dulwich.objects import Commit, ObjectID, ShaFile, Tag, Tree
 from dulwich.objectspec import parse_commit
+from dulwich.refs import Ref
 from dulwich.repo import BaseRepo
 
 from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import AmbiguousArgumentError
+from mirage.commands.cli.builtin.git.refs import TAG_PREFIX
 from mirage.commands.cli.builtin.git.types import AncestryStep
 
 ANCESTOR = "~"
@@ -30,6 +32,7 @@ PEEL_CLOSE = "}"
 PATH_MARK = ":"
 COMMIT = "commit"
 TREE = "tree"
+TAG = "tag"
 
 
 def split_peel(revision: str) -> tuple[str, str | None]:
@@ -205,11 +208,18 @@ def _object_by_id(repo: BaseRepo, sha: ObjectID, revision: str) -> ShaFile:
 def _peeled(repo: BaseRepo, obj: ShaFile, want: str, revision: str) -> ShaFile:
     """Follow a ``^{<type>}`` peel from the object the stem named.
 
-    A tag is unwrapped first whatever the type asked for, which is what
-    ``^{}`` means on its own. ``^{tree}`` then takes a commit's tree,
-    git's one implicit step; every other spelling has to already name
-    the type it asks for, so ``HEAD^{blob}`` is refused rather than
-    answered with something else.
+    A tag is unwrapped until the type asked for is reached, which for
+    ``^{}`` and for every non-tag type means unwrapping it entirely.
+    ``^{tag}`` is the one spelling that stops before the first hop, so
+    ``v1^{tag}`` is the tag object itself rather than a refusal saying
+    the commit behind it is no tag. ``^{tree}`` then takes a commit's
+    tree, git's one implicit step; every other spelling has to already
+    name the type it asks for, so ``HEAD^{blob}`` is refused rather
+    than answered with something else.
+
+    A lightweight tag is still refused by ``^{tag}``: the name resolves
+    straight to a commit, so there is no tag object to stop at and the
+    type check below is what says so.
 
     Args:
         repo (BaseRepo): the opened repository.
@@ -217,7 +227,7 @@ def _peeled(repo: BaseRepo, obj: ShaFile, want: str, revision: str) -> ShaFile:
         want (str): the type word inside the braces, empty for ``^{}``.
         revision (str): the whole revision, for error attribution.
     """
-    while isinstance(obj, Tag):
+    while isinstance(obj, Tag) and want != TAG:
         obj = _object_by_id(repo, obj.object[1], revision)
     if want == "":
         return obj
@@ -250,6 +260,34 @@ def _at_path(repo: BaseRepo, rev: str, path: str, revision: str) -> ShaFile:
     return _object_by_id(repo, sha, revision)
 
 
+def _tag_object(repo: BaseRepo, stem: str) -> Tag | None:
+    """The tag object a name or id denotes, None when it names no tag.
+
+    Read before the stem is resolved, and only for ``^{tag}``: every
+    other peel type sits at or below the commit, so unwrapping an
+    annotated tag on the way is git's own rule and costs nothing, while
+    ``^{tag}`` is the one spelling that has to stop above it. Resolving
+    the stem the ordinary way cannot serve it, because the commit-ish
+    reading peels the tag before anything else sees it.
+
+    Both spellings a tag answers to are tried, the ref and a raw id,
+    and anything that is not a tag object reads as no tag: a lightweight
+    tag names a commit directly, which is why git refuses ``^{tag}`` on
+    one.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        stem (str): the revision before the peel.
+    """
+    ref = Ref(f"{TAG_PREFIX}{stem}".encode())
+    try:
+        found = (repo.object_store[ObjectID(repo.refs[ref])]
+                 if ref in repo.refs.allkeys() else object_at(repo, stem))
+    except (KeyError, ValueError):
+        return None
+    return found if isinstance(found, Tag) else None
+
+
 def resolve_object(repo: BaseRepo, revision: str) -> ShaFile:
     """The object a revision names, whatever type it turns out to be.
 
@@ -279,4 +317,8 @@ def resolve_object(repo: BaseRepo, revision: str) -> ShaFile:
                 return object_at(repo, revision)
             except (KeyError, ValueError) as exc:
                 raise AmbiguousArgumentError(revision) from exc
+    if want == TAG:
+        found = _tag_object(repo, stem)
+        if found is not None:
+            return found
     return _peeled(repo, resolve_object(repo, stem), want or "", revision)

--- a/python/mirage/commands/cli/builtin/git/revparse.py
+++ b/python/mirage/commands/cli/builtin/git/revparse.py
@@ -205,6 +205,28 @@ def _object_by_id(repo: BaseRepo, sha: ObjectID, revision: str) -> ShaFile:
         raise AmbiguousArgumentError(revision) from exc
 
 
+def unwrapped(repo: BaseRepo, obj: ShaFile, revision: str) -> ShaFile:
+    """What an object stands for once every tag wrapper is off.
+
+    An annotated tag can point at another one, so this is a walk rather
+    than a single hop. Anything that is no tag is already what it
+    stands for and comes back untouched.
+
+    Every reading that wants a particular kind of object goes through
+    this: a bare id names the tag itself, so a caller asking for a
+    tree-ish or for the tree behind ``<rev>:<path>`` has one to take
+    off, and git takes it off in both places.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        obj (ShaFile): the object to unwrap.
+        revision (str): the whole revision, for error attribution.
+    """
+    while isinstance(obj, Tag):
+        obj = _object_by_id(repo, obj.object[1], revision)
+    return obj
+
+
 def _peeled(repo: BaseRepo, obj: ShaFile, want: str, revision: str) -> ShaFile:
     """Follow a ``^{<type>}`` peel from the object the stem named.
 
@@ -227,8 +249,8 @@ def _peeled(repo: BaseRepo, obj: ShaFile, want: str, revision: str) -> ShaFile:
         want (str): the type word inside the braces, empty for ``^{}``.
         revision (str): the whole revision, for error attribution.
     """
-    while isinstance(obj, Tag) and want != TAG:
-        obj = _object_by_id(repo, obj.object[1], revision)
+    if want != TAG:
+        obj = unwrapped(repo, obj, revision)
     if want == "":
         return obj
     if want == TREE and isinstance(obj, Commit):
@@ -247,7 +269,10 @@ def _at_path(repo: BaseRepo, rev: str, path: str, revision: str) -> ShaFile:
         path (str): the path after it, repository-relative.
         revision (str): the whole revision, for error attribution.
     """
-    holder = resolve_object(repo, rev)
+    # A tag is no tree and holds no path, so it comes off first: the
+    # rev half is a tree-ish, and ``<tag-id>:a.txt`` reads the blob
+    # through it exactly as ``v1:a.txt`` does.
+    holder = unwrapped(repo, resolve_object(repo, rev), revision)
     if isinstance(holder, Commit):
         holder = _object_by_id(repo, holder.tree, revision)
     if not isinstance(holder, Tree):
@@ -288,6 +313,30 @@ def _tag_object(repo: BaseRepo, stem: str) -> Tag | None:
     return found if isinstance(found, Tag) else None
 
 
+def _tag_at_id(repo: BaseRepo, revision: str) -> Tag | None:
+    """The tag object a bare id names, None when the id names no tag.
+
+    A tag is the one type whose bare-id reading differs from the
+    commit-ish one below, which is why this is scoped to it rather than
+    put in front of every resolution: every other type either is the
+    commit that reading returns or is not commit-ish at all, and
+    already falls through to the id.
+
+    A tag *name* is deliberately not read here. git splits the two, and
+    the split is observable: ``git tag nested v1`` records the tag
+    object while ``git restore --source=v1`` reads the tree behind it.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        revision (str): the revision as the user spelled it.
+    """
+    try:
+        found = object_at(repo, revision)
+    except (KeyError, ValueError):
+        return None
+    return found if isinstance(found, Tag) else None
+
+
 def resolve_object(repo: BaseRepo, revision: str) -> ShaFile:
     """The object a revision names, whatever type it turns out to be.
 
@@ -307,6 +356,14 @@ def resolve_object(repo: BaseRepo, revision: str) -> ShaFile:
         return _at_path(repo, rev or HEAD, path, revision)
     stem, want = split_peel(revision)
     if want is None:
+        # A bare id names that exact object, and for an annotated tag
+        # that is the tag rather than the commit behind it: the
+        # commit-ish reading below is a peel, and git does not peel an
+        # id. ``git tag nested <tag-id>`` records the tag, which is the
+        # nested tag git warns about rather than quietly flattens.
+        held = _tag_at_id(repo, revision)
+        if held is not None:
+            return held
         try:
             return resolve_commit(repo, revision)
         except AmbiguousArgumentError:

--- a/python/mirage/commands/cli/builtin/git/revparse.py
+++ b/python/mirage/commands/cli/builtin/git/revparse.py
@@ -33,6 +33,9 @@ PATH_MARK = ":"
 COMMIT = "commit"
 TREE = "tree"
 TAG = "tag"
+# Not a type any object reports: ``^{object}`` asks only that the name
+# resolve to something, and hands back whatever that is.
+OBJECT = "object"
 
 
 def split_peel(revision: str) -> tuple[str, str | None]:
@@ -153,7 +156,7 @@ def resolve_commit(repo: BaseRepo, revision: str) -> Commit:
         revision (str): revision as the user spelled it.
     """
     stem, want = split_peel(revision)
-    if want is not None and want not in ("", COMMIT):
+    if want is not None and want not in ("", COMMIT, OBJECT):
         raise AmbiguousArgumentError(revision)
     base, steps = split_revision(stem)
     try:
@@ -249,6 +252,13 @@ def _peeled(repo: BaseRepo, obj: ShaFile, want: str, revision: str) -> ShaFile:
         want (str): the type word inside the braces, empty for ``^{}``.
         revision (str): the whole revision, for error attribution.
     """
+    if want == OBJECT:
+        # An existence check, not a type. Every object reports a
+        # concrete type name, so comparing one against ``object``
+        # refuses every expression that spells it; gitrevisions(7) has
+        # it return the named object and nothing else, which for an
+        # annotated tag is the tag rather than the commit behind it.
+        return obj
     if want != TAG:
         obj = unwrapped(repo, obj, revision)
     if want == "":
@@ -374,7 +384,10 @@ def resolve_object(repo: BaseRepo, revision: str) -> ShaFile:
                 return object_at(repo, revision)
             except (KeyError, ValueError) as exc:
                 raise AmbiguousArgumentError(revision) from exc
-    if want == TAG:
+    if want in (TAG, OBJECT):
+        # The same reading ``^{tag}`` needs, for the same reason: the
+        # commit-ish route below peels an annotated tag before anything
+        # else sees it, and both spellings have to stop above it.
         found = _tag_object(repo, stem)
         if found is not None:
             return found

--- a/python/mirage/commands/cli/builtin/git/revparse.py
+++ b/python/mirage/commands/cli/builtin/git/revparse.py
@@ -21,7 +21,7 @@ from dulwich.repo import BaseRepo
 from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import AmbiguousArgumentError
 from mirage.commands.cli.builtin.git.refs import TAG_PREFIX
-from mirage.commands.cli.builtin.git.types import AncestryStep
+from mirage.commands.cli.builtin.git.types import AncestryStep, PeelStep, RevOp
 
 ANCESTOR = "~"
 PARENT = "^"
@@ -38,56 +38,41 @@ TAG = "tag"
 OBJECT = "object"
 
 
-def split_peel(revision: str) -> tuple[str, str | None]:
-    """Split a trailing ``^{<type>}`` off a revision.
+def split_operators(revision: str) -> tuple[str, tuple[RevOp, ...]]:
+    """Split a revision into its base and the operators applied to it.
 
-    ``HEAD^{tree}`` is a peel, not an ancestry step, and reading it as
-    one is silent rather than loud: ``^`` with no digits means "first
-    parent", so the suffix resolved to HEAD's parent commit and the
-    caller was handed a different object than it asked for without a
-    word. The braces tell the two apart, and git forbids both of them
-    in a ref name, so nothing else can end this way.
+    git reads a revision left to right: every ``~n``, ``^n`` and
+    ``^{<type>}`` applies to whatever the one before it produced, so
+    ``HEAD^{commit}~1`` is the parent of HEAD and ``HEAD~1^{tree}`` is
+    that parent's tree. Reading the peel as a trailing thing instead
+    refused every chain that did not end in one, and reading ``^{`` as
+    an ancestry step is worse than refusing: ``^`` with no digits means
+    "first parent", so ``HEAD^{tree}`` would answer with HEAD's parent
+    without a word. Splitting on the first ``~`` or ``^`` is safe
+    because git forbids both in a ref name, so neither can belong to
+    the base. Pinned against git 2.50.1.
 
     Args:
         revision (str): revision as the user spelled it.
 
     Returns:
-        tuple[str, str | None]: the revision without the peel, and the
-        type word inside it, empty for ``^{}`` and None when there is
-        no peel at all.
-    """
-    if not revision.endswith(PEEL_CLOSE):
-        return revision, None
-    index = revision.rfind(PEEL_OPEN)
-    if index < 0:
-        return revision, None
-    return revision[:index], revision[index + len(PEEL_OPEN):-1]
-
-
-def split_revision(revision: str) -> tuple[str, tuple[AncestryStep, ...]]:
-    """Split a revision into its base and its ancestry suffixes.
-
-    ``HEAD~2^2`` is a base plus two steps. Splitting on the first ``~``
-    or ``^`` is safe because git forbids both characters in ref names,
-    so neither can belong to the base.
-
-    Args:
-        revision (str): revision as the user spelled it.
+        tuple[str, tuple[RevOp, ...]]: the base, HEAD when the revision
+        is all operators, and the operators in the order they apply.
 
     Raises:
-        AmbiguousArgumentError: when the suffix holds anything but
-            ancestry steps.
+        AmbiguousArgumentError: when the rest holds anything but
+            operators.
     """
     index = next(
         (i for i, ch in enumerate(revision) if ch in SUFFIXES),
         len(revision),
     )
     base, rest = revision[:index], revision[index:]
-    steps: list[AncestryStep] = []
+    ops: list[RevOp] = []
     position = 0
     while position < len(rest):
         kind = rest[position]
-        # Only ``~`` and ``^`` are ancestry steps, and reading anything
+        # Only ``~`` and ``^`` open an operator, and reading anything
         # else as one is silent rather than loud: every other character
         # counted as another first-parent hop, so ``HEAD^x`` resolved to
         # ``HEAD^^`` and the caller was handed a commit it never named.
@@ -95,17 +80,21 @@ def split_revision(revision: str) -> tuple[str, tuple[AncestryStep, ...]]:
         # ``main~٣`` with it, since the digits it counts are ASCII.
         if kind not in SUFFIXES:
             raise AmbiguousArgumentError(revision)
+        if rest.startswith(PEEL_OPEN, position):
+            close = rest.find(PEEL_CLOSE, position)
+            if close < 0:
+                raise AmbiguousArgumentError(revision)
+            ops.append(PeelStep(rest[position + len(PEEL_OPEN):close]))
+            position = close + 1
+            continue
         position += 1
         digits = ""
         while position < len(rest) and rest[position] in "0123456789":
             digits += rest[position]
             position += 1
-        if digits == "":
-            count = 1
-        else:
-            count = int(digits)
-        steps.append(AncestryStep(first_parent=kind == ANCESTOR, count=count))
-    return base or HEAD, tuple(steps)
+        count = 1 if digits == "" else int(digits)
+        ops.append(AncestryStep(first_parent=kind == ANCESTOR, count=count))
+    return base or HEAD, tuple(ops)
 
 
 def _step(repo: BaseRepo, commit: Commit, step: AncestryStep,
@@ -167,16 +156,23 @@ def resolve_commit(repo: BaseRepo, revision: str) -> Commit:
         repo (BaseRepo): repository to resolve against.
         revision (str): revision as the user spelled it.
     """
-    stem, want = split_peel(revision)
-    if want is not None and want not in ("", COMMIT, OBJECT):
-        raise AmbiguousArgumentError(revision)
-    base, steps = split_revision(stem)
+    base, ops = split_operators(revision)
     try:
         commit = parse_commit(repo, base)
     except (KeyError, ValueError) as exc:
         raise AmbiguousArgumentError(revision) from exc
-    for step in steps:
-        commit = _step(repo, commit, step, revision)
+    for op in ops:
+        if isinstance(op, AncestryStep):
+            commit = _step(repo, commit, op, revision)
+            continue
+        # A peel this caller can use is one that lands back on a
+        # commit: ``^{}`` and ``^{commit}`` do, ``^{tree}`` does not,
+        # and refusing the object rather than the spelling is what lets
+        # a peel sit in the middle of a chain.
+        found = _peeled(repo, commit, op.want, revision)
+        if not isinstance(found, Commit):
+            raise AmbiguousArgumentError(revision)
+        commit = found
     return commit
 
 
@@ -376,8 +372,8 @@ def resolve_object(repo: BaseRepo, revision: str) -> ShaFile:
     if PATH_MARK in revision:
         rev, _, path = revision.partition(PATH_MARK)
         return _at_path(repo, rev or HEAD, path, revision)
-    stem, want = split_peel(revision)
-    if want is None:
+    base, ops = split_operators(revision)
+    if not ops:
         # A bare id names that exact object, and for an annotated tag
         # that is the tag rather than the commit behind it: the
         # commit-ish reading below is a peel, and git does not peel an
@@ -396,11 +392,18 @@ def resolve_object(repo: BaseRepo, revision: str) -> ShaFile:
                 return object_at(repo, revision)
             except (KeyError, ValueError) as exc:
                 raise AmbiguousArgumentError(revision) from exc
-    if want in (TAG, OBJECT):
-        # The same reading ``^{tag}`` needs, for the same reason: the
-        # commit-ish route below peels an annotated tag before anything
-        # else sees it, and both spellings have to stop above it.
-        found = _tag_object(repo, stem)
-        if found is not None:
-            return found
-    return _peeled(repo, resolve_object(repo, stem), want or "", revision)
+    # The base is resolved without peeling an annotated tag, because
+    # ``^{tag}`` and ``^{object}`` are the two spellings that have to
+    # stop above it; every other operator unwraps the tag itself, which
+    # is git's own rule and costs nothing here.
+    held = _tag_object(repo, base)
+    obj = held if held is not None else resolve_object(repo, base)
+    for op in ops:
+        if isinstance(op, PeelStep):
+            obj = _peeled(repo, obj, op.want, revision)
+            continue
+        commit = unwrapped(repo, obj, revision)
+        if not isinstance(commit, Commit):
+            raise AmbiguousArgumentError(revision)
+        obj = _step(repo, commit, op, revision)
+    return obj

--- a/python/mirage/commands/cli/builtin/git/rm.py
+++ b/python/mirage/commands/cli/builtin/git/rm.py
@@ -23,7 +23,7 @@ from mirage.commands.cli.builtin.git.changes import (MODIFIED, head_entries,
 from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     NoPathspecRemoveError, NotRecursiveError, NoWorkspaceError, PathspecError,
-    RemovalRefusedError, UnknownSwitchError)
+    RemovalRefusedError, RemovePathError, UnknownSwitchError)
 from mirage.commands.cli.builtin.git.index import read_index, write_index
 from mirage.commands.cli.builtin.git.io import (remove_empty_parents,
                                                 remove_file)
@@ -37,7 +37,9 @@ from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
+from mirage.ops.types import LinkView, StatPath
 from mirage.runtime.types import DispatchFn
+from mirage.types import FileType
 
 Tree = dict[bytes, tuple[int, bytes]]
 
@@ -154,6 +156,50 @@ async def refuse_lost_work(dispatch: DispatchFn, location: RepoLocation,
         raise RemovalRefusedError(both, staged, local)
 
 
+async def clear_worktree(dispatch: DispatchFn, stat_path: StatPath,
+                         location: RepoLocation, selected: list[str],
+                         lines: str, links: LinkView | None) -> None:
+    """Delete every selected path from the working tree.
+
+    A directory standing where a tracked file was is the one deletion a
+    mount cannot make: ``unlink`` is not the call that empties a tree,
+    and git reports the strerror rather than removing what it never
+    tracked. It reports it in index order and only while nothing has
+    been deleted yet; once one path is gone the rest of the loop
+    tolerates a failure and the line still succeeds. That is git's own
+    rule rather than a reading of it, and it is observable both ways:
+    ``git rm slot z.txt`` is fatal with the index untouched, while
+    ``git rm a.txt slot`` exits 0 with both entries unstaged and the
+    directory still on disk. Pinned against git 2.50.1.
+
+    A tracked symlink to a directory is not this case and must not be
+    read as one: it is removed as the link it is, which is why the
+    namespace is asked before the type.
+
+    Args:
+        dispatch (DispatchFn): workspace op dispatcher.
+        stat_path (StatPath): the data plane's stat, which dereferences.
+        location (RepoLocation): the discovered repository.
+        selected (list[str]): the paths to delete, in index order.
+        lines (str): the ``rm`` lines already printed, for a refusal to
+            carry on stdout the way git prints them anyway.
+        links (LinkView | None): the name plane's link facts, None when
+            no namespace is wired.
+    """
+    removed = False
+    for path in selected:
+        absolute = posixpath.join(location.worktree, path)
+        if links is None or links.stat_at(absolute) is None:
+            info = await stat_path(absolute)
+            if info is not None and info.type is FileType.DIRECTORY:
+                if not removed:
+                    raise RemovePathError(path, lines)
+                continue
+        await remove_file(dispatch, absolute)
+        await remove_empty_parents(dispatch, absolute, location.worktree)
+        removed = True
+
+
 async def rm(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
     """Remove paths from the index, and from the working tree too.
 
@@ -196,16 +242,19 @@ async def rm(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
             tree = await asyncio.to_thread(head_entries, repo) or {}
             await refuse_lost_work(dispatch, location, tree, state.entries,
                                    found, checkable, flags.cached)
+        lines = "" if flags.quiet else "".join(f"rm '{path}'\n"
+                                               for path in selected)
+        if not flags.cached:
+            await clear_worktree(dispatch, stat_path, location, selected,
+                                 lines, links_of(doors))
+        # Last, because the deletions above can fail: git writes the
+        # index only once the working tree is done with, so a refused
+        # deletion leaves the entry staged exactly as it stood rather
+        # than staging a removal that never happened.
         for path in selected:
             state.entries.pop(path.encode(), None)
             state.conflicts.pop(path.encode(), None)
         await write_index(dispatch, location.gitdir, state)
-        if not flags.cached:
-            for path in selected:
-                absolute = posixpath.join(location.worktree, path)
-                await remove_file(dispatch, absolute)
-                await remove_empty_parents(dispatch, absolute,
-                                           location.worktree)
     except GitError as exc:
         return fatal(exc)
     if flags.quiet:

--- a/python/mirage/commands/cli/builtin/git/rm.py
+++ b/python/mirage/commands/cli/builtin/git/rm.py
@@ -1,0 +1,214 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import posixpath
+from dataclasses import dataclass
+
+from dulwich.index import IndexEntry
+
+from mirage.commands.cli.builtin.git.changes import (MODIFIED, head_entries,
+                                                     work_changes)
+from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
+from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
+    NoPathspecRemoveError, NotRecursiveError, NoWorkspaceError, PathspecError,
+    RemovalRefusedError, UnknownSwitchError)
+from mirage.commands.cli.builtin.git.index import read_index, write_index
+from mirage.commands.cli.builtin.git.io import (remove_empty_parents,
+                                                remove_file)
+from mirage.commands.cli.builtin.git.pathspec import matched, repo_relative
+from mirage.commands.cli.builtin.git.session import opened
+from mirage.commands.cli.builtin.git.types import RepoLocation, WorkTree
+from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
+                                                  links_of, start_point)
+from mirage.commands.cli.builtin.git.worktree import UNTRACKED_NO, scan
+from mirage.commands.cli.types import CLIDoors, CLIInvocation
+from mirage.commands.spec.types import FlagView
+from mirage.io.stream import yield_bytes
+from mirage.io.types import ByteSource, IOResult
+from mirage.runtime.types import DispatchFn
+
+Tree = dict[bytes, tuple[int, bytes]]
+
+
+@dataclass(frozen=True, slots=True)
+class RmFlags:
+    """The parsed shape of a ``git rm`` invocation.
+
+    Args:
+        recursive (bool): ``-r``, allow a directory operand.
+        cached (bool): ``--cached``, unstage only and keep the file.
+        force (bool): ``-f``, remove even over uncommitted changes.
+        quiet (bool): ``-q``, print no ``rm`` line per path.
+        ignore_unmatch (bool): ``--ignore-unmatch``, an operand naming
+            nothing is not an error.
+    """
+    recursive: bool
+    cached: bool
+    force: bool
+    quiet: bool
+    ignore_unmatch: bool
+
+
+def parse_flags(fl: FlagView) -> RmFlags:
+    """Read the raw rm flag kwargs into a frozen struct.
+
+    Args:
+        fl (FlagView): spec-validated view over the raw flag kwargs.
+    """
+    return RmFlags(recursive=fl.as_bool("r"),
+                   cached=fl.as_bool("cached"),
+                   force=fl.as_bool("force"),
+                   quiet=fl.as_bool("quiet"),
+                   ignore_unmatch=fl.as_bool("ignore_unmatch"))
+
+
+def select(location: RepoLocation, start: str, operands: tuple[str, ...],
+           tracked: set[str], flags: RmFlags) -> list[str]:
+    """Which tracked paths the operands remove, in index order.
+
+    Every operand is checked before anything is removed, which is git's
+    order too: a line with one bad operand removes nothing. A directory
+    is refused without ``-r`` rather than expanded, and an operand that
+    names nothing tracked is a fatal unless ``--ignore-unmatch`` says
+    otherwise. An untracked file is "nothing tracked": git has nothing
+    to remove it from.
+
+    Args:
+        location (RepoLocation): the discovered repository.
+        start (str): absolute virtual path git is running in.
+        operands (tuple[str, ...]): the pathspecs as typed.
+        tracked (set[str]): repository-relative paths the index holds.
+        flags (RmFlags): the parsed flags.
+    """
+    selected: set[str] = set()
+    for operand in operands:
+        target = repo_relative(location, start, operand)
+        if target in tracked:
+            selected.add(target)
+            continue
+        hits = matched(tracked, target)
+        if not hits:
+            if flags.ignore_unmatch:
+                continue
+            raise PathspecError(operand)
+        if not flags.recursive:
+            raise NotRecursiveError(operand)
+        selected |= hits
+    return sorted(selected)
+
+
+async def refuse_lost_work(dispatch: DispatchFn, location: RepoLocation,
+                           tree: Tree, entries: dict[bytes, IndexEntry],
+                           found: WorkTree, paths: list[str],
+                           cached: bool) -> None:
+    """Refuse a removal that would throw away uncommitted work.
+
+    git's own three-way test per path: whether the index differs from
+    HEAD, and whether the working tree differs from the index. A path
+    that differs both ways is refused outright; one that differs one
+    way is refused unless ``--cached`` keeps the file. A file already
+    gone from the working tree has no local change to lose, which is
+    what makes ``git rm <deleted>`` the way to stage a deletion. Pinned
+    against git 2.50.1.
+
+    Args:
+        dispatch (DispatchFn): workspace op dispatcher.
+        location (RepoLocation): the discovered repository.
+        tree (Tree): HEAD's tree, empty before the first commit.
+        entries (dict[bytes, IndexEntry]): the index.
+        found (WorkTree): what the walk of the working tree found.
+        paths (list[str]): the selected paths that hold an index entry.
+        cached (bool): whether ``--cached`` was given.
+    """
+    chosen = {path.encode(): entries[path.encode()] for path in paths}
+    unstaged = await work_changes(dispatch, location.worktree, chosen, found)
+    both: list[str] = []
+    staged: list[str] = []
+    local: list[str] = []
+    for path in paths:
+        entry = chosen[path.encode()]
+        recorded = tree.get(path.encode())
+        staged_changes = (recorded is None or recorded[1] != entry.sha
+                          or recorded[0] != entry.mode)
+        local_changes = unstaged.get(path) == MODIFIED
+        if local_changes and staged_changes:
+            both.append(path)
+        elif not cached:
+            if staged_changes:
+                staged.append(path)
+            if local_changes:
+                local.append(path)
+    if both or staged or local:
+        raise RemovalRefusedError(both, staged, local)
+
+
+async def rm(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
+    """Remove paths from the index, and from the working tree too.
+
+    ``--cached`` leaves the file where it is and only stops tracking it.
+    Without ``-f`` a path carrying uncommitted work is refused rather
+    than deleted, which is the one check that makes the verb safe to
+    hand an agent: there is no reflog here to recover a file from.
+
+    Args:
+        inv (CLIInvocation[None]): the line's invocation record.
+            git declares no config_model; the planes it reads
+            (data through ``dispatch``, names through ``ns``) ride
+            ``inv.doors``.
+    """
+    doors = inv.doors or CLIDoors()
+    dispatch = doors.dispatch
+    stat_path = doors.stat_path
+    texts = inv.texts
+    fl = FlagView(inv.flags)
+    try:
+        if dispatch is None or stat_path is None:
+            raise NoWorkspaceError()
+        check_operands(texts, UnknownSwitchError)
+        flags = parse_flags(fl)
+        if not texts:
+            raise NoPathspecRemoveError()
+        repo, location = await opened(fl, doors)
+        state = await read_index(dispatch, location.gitdir)
+        tracked = {
+            path.decode("utf-8", errors="replace")
+            for path in (set(state.entries) | set(state.conflicts))
+        }
+        selected = select(location, start_point(fl), texts, tracked, flags)
+        if not flags.force:
+            checkable = [
+                path for path in selected if path.encode() in state.entries
+            ]
+            found = await scan(dispatch, stat_path, location, tracked,
+                               UNTRACKED_NO, links_of(doors))
+            tree = await asyncio.to_thread(head_entries, repo) or {}
+            await refuse_lost_work(dispatch, location, tree, state.entries,
+                                   found, checkable, flags.cached)
+        for path in selected:
+            state.entries.pop(path.encode(), None)
+            state.conflicts.pop(path.encode(), None)
+        await write_index(dispatch, location.gitdir, state)
+        if not flags.cached:
+            for path in selected:
+                absolute = posixpath.join(location.worktree, path)
+                await remove_file(dispatch, absolute)
+                await remove_empty_parents(dispatch, absolute,
+                                           location.worktree)
+    except GitError as exc:
+        return fatal(exc)
+    if flags.quiet:
+        return None, IOResult()
+    lines = "".join(f"rm '{path}'\n" for path in selected)
+    return yield_bytes(lines.encode()), IOResult()

--- a/python/mirage/commands/cli/builtin/git/rm.py
+++ b/python/mirage/commands/cli/builtin/git/rm.py
@@ -18,7 +18,8 @@ from dataclasses import dataclass
 
 from dulwich.index import IndexEntry
 
-from mirage.commands.cli.builtin.git.changes import (MODIFIED, head_entries,
+from mirage.commands.cli.builtin.git.changes import (DELETED, MODIFIED,
+                                                     head_entries,
                                                      work_changes)
 from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
@@ -31,13 +32,13 @@ from mirage.commands.cli.builtin.git.pathspec import matched, repo_relative
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.types import RepoLocation, WorkTree
 from mirage.commands.cli.builtin.git.util import (  # yapf: disable
-    check_operands, escaped, fatal, links_of, start_point)
+    check_operands, escaped, fatal, links_of, mounts_of, start_point)
 from mirage.commands.cli.builtin.git.worktree import UNTRACKED_NO, scan
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
-from mirage.ops.types import LinkView, StatPath
+from mirage.ops.types import LinkView, MountView, StatPath
 from mirage.runtime.types import DispatchFn
 from mirage.types import FileType
 
@@ -111,10 +112,46 @@ def select(location: RepoLocation, start: str, operands: tuple[str, ...],
     return sorted(selected)
 
 
+async def shadowed(links: LinkView | None, worktree: str, paths: list[str],
+                   missing: dict[str, str]) -> set[str]:
+    """Which absent paths a link above them is only hiding.
+
+    git lstats a tracked path to decide whether it still has local work
+    to lose, and that lstat resolves every component above the file, so
+    a symlink standing where a directory was does not hide the file: it
+    points the check at whatever lies at the other end, which is some
+    other file entirely and therefore a local change. The walk answers
+    the opposite way on purpose, because git's own diff refuses to
+    follow a leading link and reports the path deleted, which is why
+    ``git status`` says ``D`` here and ``git rm`` still refuses.
+    Nothing is compared: two files agreeing byte for byte are still two
+    files, and git refuses that case too. Pinned against git 2.50.1.
+
+    Args:
+        links (LinkView | None): the name plane's link facts, None when
+            no namespace is wired.
+        worktree (str): absolute virtual path of the working tree root.
+        paths (list[str]): the selected paths that hold an index entry.
+        missing (dict[str, str]): what the walk said about each path.
+    """
+    if links is None:
+        return set()
+    found: set[str] = set()
+    for path in paths:
+        if missing.get(path) != DELETED:
+            continue
+        absolute = posixpath.join(worktree, path)
+        if links.resolve(absolute) == absolute:
+            continue
+        if await links.exists(absolute):
+            found.add(path)
+    return found
+
+
 async def refuse_lost_work(dispatch: DispatchFn, location: RepoLocation,
                            tree: Tree, entries: dict[bytes, IndexEntry],
-                           found: WorkTree, paths: list[str],
-                           cached: bool) -> None:
+                           found: WorkTree, paths: list[str], cached: bool,
+                           links: LinkView | None) -> None:
     """Refuse a removal that would throw away uncommitted work.
 
     git's own three-way test per path: whether the index differs from
@@ -133,9 +170,12 @@ async def refuse_lost_work(dispatch: DispatchFn, location: RepoLocation,
         found (WorkTree): what the walk of the working tree found.
         paths (list[str]): the selected paths that hold an index entry.
         cached (bool): whether ``--cached`` was given.
+        links (LinkView | None): the name plane's link facts, None when
+            no namespace is wired.
     """
     chosen = {path.encode(): entries[path.encode()] for path in paths}
     unstaged = await work_changes(dispatch, location.worktree, chosen, found)
+    hidden = await shadowed(links, location.worktree, paths, unstaged)
     both: list[str] = []
     staged: list[str] = []
     local: list[str] = []
@@ -144,7 +184,7 @@ async def refuse_lost_work(dispatch: DispatchFn, location: RepoLocation,
         recorded = tree.get(path.encode())
         staged_changes = (recorded is None or recorded[1] != entry.sha
                           or recorded[0] != entry.mode)
-        local_changes = unstaged.get(path) == MODIFIED
+        local_changes = unstaged.get(path) == MODIFIED or path in hidden
         if local_changes and staged_changes:
             both.append(path)
         elif not cached:
@@ -158,7 +198,8 @@ async def refuse_lost_work(dispatch: DispatchFn, location: RepoLocation,
 
 async def clear_worktree(dispatch: DispatchFn, stat_path: StatPath,
                          location: RepoLocation, selected: list[str],
-                         lines: str, links: LinkView | None) -> None:
+                         lines: str, links: LinkView | None,
+                         mounts: MountView | None) -> None:
     """Delete every selected path from the working tree.
 
     A directory standing where a tracked file was is the one deletion a
@@ -185,6 +226,8 @@ async def clear_worktree(dispatch: DispatchFn, stat_path: StatPath,
             carry on stdout the way git prints them anyway.
         links (LinkView | None): the name plane's link facts, None when
             no namespace is wired.
+        mounts (MountView | None): the name plane's mount boundaries,
+            None when no namespace is wired.
     """
     removed = False
     for path in selected:
@@ -196,7 +239,8 @@ async def clear_worktree(dispatch: DispatchFn, stat_path: StatPath,
                     raise RemovePathError(path, lines)
                 continue
         await remove_file(dispatch, absolute)
-        await remove_empty_parents(dispatch, absolute, location.worktree)
+        await remove_empty_parents(dispatch, absolute, location.worktree,
+                                   mounts)
         removed = True
 
 
@@ -241,12 +285,13 @@ async def rm(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
                                UNTRACKED_NO, links_of(doors))
             tree = await asyncio.to_thread(head_entries, repo) or {}
             await refuse_lost_work(dispatch, location, tree, state.entries,
-                                   found, checkable, flags.cached)
+                                   found, checkable, flags.cached,
+                                   links_of(doors))
         lines = "" if flags.quiet else "".join(f"rm '{path}'\n"
                                                for path in selected)
         if not flags.cached:
             await clear_worktree(dispatch, stat_path, location, selected,
-                                 lines, links_of(doors))
+                                 lines, links_of(doors), mounts_of(doors))
         # Last, because the deletions above can fail: git writes the
         # index only once the working tree is done with, so a refused
         # deletion leaves the entry staged exactly as it stood rather

--- a/python/mirage/commands/cli/builtin/git/rm.py
+++ b/python/mirage/commands/cli/builtin/git/rm.py
@@ -30,8 +30,8 @@ from mirage.commands.cli.builtin.git.io import (remove_empty_parents,
 from mirage.commands.cli.builtin.git.pathspec import matched, repo_relative
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.types import RepoLocation, WorkTree
-from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
-                                                  links_of, start_point)
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal, links_of, start_point)
 from mirage.commands.cli.builtin.git.worktree import UNTRACKED_NO, scan
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
@@ -176,7 +176,7 @@ async def rm(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
     try:
         if dispatch is None or stat_path is None:
             raise NoWorkspaceError()
-        check_operands(texts, UnknownSwitchError)
+        check_operands(texts, UnknownSwitchError, escaped(inv.argv))
         flags = parse_flags(fl)
         if not texts:
             raise NoPathspecRemoveError()

--- a/python/mirage/commands/cli/builtin/git/show.py
+++ b/python/mirage/commands/cli/builtin/git/show.py
@@ -32,8 +32,8 @@ from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.summary import (diffstat, stat_table,
                                                      tree_entries)
-from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
-                                                  revision_arg)
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal, revision_arg)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
@@ -189,7 +189,7 @@ async def show(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
     try:
         if dispatch is None:
             raise NoWorkspaceError()
-        check_operands(texts)
+        check_operands(texts, marked=escaped(inv.argv))
         parsed = parse_show_flags(fl)
         repo, _location = await opened(fl, doors)
         rendered = await asyncio.to_thread(_render, repo, revision_arg(texts),

--- a/python/mirage/commands/cli/builtin/git/switch.py
+++ b/python/mirage/commands/cli/builtin/git/switch.py
@@ -113,7 +113,9 @@ async def switch(
             raise DetachWithCreateError()
         if len(texts) > 1:
             raise OneReferenceError()
-        if not creating and not texts:
+        # A detach takes HEAD when nothing is named, which is git's
+        # own default; only an attaching switch needs a branch to name.
+        if not creating and not texts and not flags.detach:
             raise MissingBranchArgumentError()
         repo, location = await opened(fl, doors)
         head = await read_head(dispatch, location.gitdir)
@@ -137,7 +139,7 @@ async def switch(
                 raise InvalidBranchNameError(target)
             attached = True
         else:
-            target = texts[0]
+            target = texts[0] if texts else HEAD
             ref = Ref(f"{BRANCH_PREFIX}{target}".encode())
             if not flags.detach and target == head.branch:
                 return None, IOResult(

--- a/python/mirage/commands/cli/builtin/git/switch.py
+++ b/python/mirage/commands/cli/builtin/git/switch.py
@@ -21,12 +21,12 @@ from mirage.commands.cli.builtin.git.checkout import (move_head,
 from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     BranchExistsError, BranchExpectedError, DetachWithCreateError, GitError,
-    InvalidReferenceError, MissingBranchArgumentError, NoWorkspaceError,
-    OneReferenceError, UnknownSwitchError)
+    InvalidBranchNameError, InvalidReferenceError, MissingBranchArgumentError,
+    NoWorkspaceError, OneReferenceError, UnknownSwitchError)
 from mirage.commands.cli.builtin.git.format import short, subject
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, TAG_PREFIX,
-                                                  read_head)
+                                                  read_head, valid_ref_name)
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
@@ -128,6 +128,13 @@ async def switch(
                 commit = resolve_commit(repo, start)
             except GitError as exc:
                 raise InvalidReferenceError(start) from exc
+            # After the start point and before anything is written,
+            # which is git's own order. A ref is a path below .git, so
+            # an unchecked name reaches write_ref as one: -c
+            # ../../config would land on the repository's own
+            # configuration rather than on a branch.
+            if not valid_ref_name(target):
+                raise InvalidBranchNameError(target)
             attached = True
         else:
             target = texts[0]

--- a/python/mirage/commands/cli/builtin/git/switch.py
+++ b/python/mirage/commands/cli/builtin/git/switch.py
@@ -29,8 +29,8 @@ from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, TAG_PREFIX,
                                                   read_head, valid_ref_name)
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
-from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
-                                                  links_of)
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal, links_of)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
@@ -106,7 +106,7 @@ async def switch(
     try:
         if dispatch is None or stat_path is None:
             raise NoWorkspaceError()
-        check_operands(texts, UnknownSwitchError)
+        check_operands(texts, UnknownSwitchError, escaped(inv.argv))
         flags = parse_flags(fl)
         creating = flags.create is not None
         if creating and flags.detach:

--- a/python/mirage/commands/cli/builtin/git/switch.py
+++ b/python/mirage/commands/cli/builtin/git/switch.py
@@ -26,7 +26,8 @@ from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
 from mirage.commands.cli.builtin.git.format import short, subject
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, TAG_PREFIX,
-                                                  read_head, valid_ref_name)
+                                                  read_head, set_head,
+                                                  valid_ref_name)
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.util import (  # yapf: disable
@@ -126,10 +127,21 @@ async def switch(
             if ref in known:
                 raise BranchExistsError(target)
             start = texts[0] if texts else None
-            try:
-                commit = resolve_commit(repo, start or HEAD)
-            except GitError as exc:
-                raise InvalidReferenceError(start or HEAD) from exc
+            # Before the first commit there is nothing for HEAD to
+            # resolve to, and git makes the branch anyway: the line
+            # only repoints symbolic HEAD, writing neither the ref nor
+            # a reflog line, because a branch with no commit is a name
+            # and nothing else. A start point is a different line and
+            # stays unresolvable (``fatal: invalid reference: main``),
+            # so this reads the shape of the line rather than probing
+            # HEAD. Pinned against git 2.50.1.
+            unborn = (start is None and head.ref is not None
+                      and Ref(head.ref.encode()) not in known)
+            if not unborn:
+                try:
+                    commit = resolve_commit(repo, start or HEAD)
+                except GitError as exc:
+                    raise InvalidReferenceError(start or HEAD) from exc
             # After the start point and before anything is written,
             # which is git's own order. A ref is a path below .git, so
             # an unchecked name reaches write_ref as one: -c
@@ -138,6 +150,10 @@ async def switch(
             if not valid_ref_name(target):
                 raise InvalidBranchNameError(target)
             attached = True
+            if unborn:
+                await set_head(dispatch, location.gitdir, ref.decode())
+                return yield_bytes(b""), IOResult(
+                    stderr=f"Switched to a new branch '{target}'\n".encode())
         else:
             start = None
             target = texts[0] if texts else HEAD
@@ -152,13 +168,14 @@ async def switch(
             attached = not flags.detach and ref in known
             if not flags.detach and not attached:
                 raise BranchExpectedError(expected_kind(known, target), target)
-        dirty = await move_head(dispatch, stat_path, links_of(doors), repo,
+        moved = await move_head(dispatch, stat_path, links_of(doors), repo,
                                 location, head, commit, target,
                                 ref if attached else None, creating, creating
                                 and start is None)
     except GitError as exc:
         return fatal(exc)
-    carried = "".join(f"M\t{path}\n" for path in sorted(dirty))
+    carried = "".join(f"{letter}\t{path}\n"
+                      for path, letter in sorted(moved.items()))
     note = previous_position(repo, head)
     if attached:
         verb = "Switched to a new branch" if creating else "Switched to branch"

--- a/python/mirage/commands/cli/builtin/git/switch.py
+++ b/python/mirage/commands/cli/builtin/git/switch.py
@@ -194,8 +194,11 @@ async def switch(
     except GitError as exc:
         return fatal(exc)
     carried = "".join(f"{letter}\t{path}\n"
-                      for path, letter in sorted(moved.items()))
-    note = previous_position(repo, head)
+                      for path, letter in sorted(moved.carried.items()))
+    # Above everything the move says about itself, which is where git
+    # puts it: what could not be removed is a fact about the working
+    # tree rather than about where HEAD went.
+    note = moved.warnings + previous_position(repo, head)
     if attached:
         verb = "Switched to a new branch" if creating else "Switched to branch"
         note += f"{verb} '{target}'\n"

--- a/python/mirage/commands/cli/builtin/git/switch.py
+++ b/python/mirage/commands/cli/builtin/git/switch.py
@@ -24,6 +24,7 @@ from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     InvalidBranchNameError, InvalidReferenceError, MissingBranchArgumentError,
     NoWorkspaceError, OneReferenceError, RefLockError, UnknownSwitchError)
 from mirage.commands.cli.builtin.git.format import short, subject
+from mirage.commands.cli.builtin.git.index import read_index, refuse_unresolved
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, TAG_PREFIX,
                                                   blocking_ref, read_head,
@@ -172,6 +173,11 @@ async def switch(
             # what leaves ``switch -c`` as the only line an unborn HEAD
             # accepts. Pinned against git 2.50.1.
             if (not flags.detach and target == head.branch and ref in known):
+                # Moving nothing is not the same as having nothing to
+                # check: git dies on an unresolved index here too, so
+                # the shortcut reads it before it answers. Every ref
+                # check above comes first, which is git's own order.
+                refuse_unresolved(await read_index(dispatch, location.gitdir))
                 return None, IOResult(
                     stderr=f"Already on '{target}'\n".encode())
             try:

--- a/python/mirage/commands/cli/builtin/git/switch.py
+++ b/python/mirage/commands/cli/builtin/git/switch.py
@@ -158,7 +158,14 @@ async def switch(
             start = None
             target = texts[0] if texts else HEAD
             ref = Ref(f"{BRANCH_PREFIX}{target}".encode())
-            if not flags.detach and target == head.branch:
+            # The ref has to exist, not just be the name HEAD carries.
+            # A fresh repository's HEAD names a branch that has never
+            # been written, and reading the name alone answered
+            # ``Already on 'main'`` at exit 0 for a branch with no
+            # commit to be on. git resolves it first and dies, which is
+            # what leaves ``switch -c`` as the only line an unborn HEAD
+            # accepts. Pinned against git 2.50.1.
+            if (not flags.detach and target == head.branch and ref in known):
                 return None, IOResult(
                     stderr=f"Already on '{target}'\n".encode())
             try:

--- a/python/mirage/commands/cli/builtin/git/switch.py
+++ b/python/mirage/commands/cli/builtin/git/switch.py
@@ -31,7 +31,7 @@ from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, TAG_PREFIX,
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.util import (  # yapf: disable
-    check_operands, escaped, fatal, links_of)
+    check_operands, escaped, fatal, links_of, mounts_of)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
@@ -181,10 +181,10 @@ async def switch(
             attached = not flags.detach and ref in known
             if not flags.detach and not attached:
                 raise BranchExpectedError(expected_kind(known, target), target)
-        moved = await move_head(dispatch, stat_path, links_of(doors), repo,
-                                location, head, commit, target,
-                                ref if attached else None, creating, creating
-                                and start is None)
+        moved = await move_head(dispatch, stat_path, links_of(doors),
+                                mounts_of(doors), repo, location, head, commit,
+                                target, ref if attached else None, creating,
+                                creating and start is None)
     except GitError as exc:
         return fatal(exc)
     carried = "".join(f"{letter}\t{path}\n"

--- a/python/mirage/commands/cli/builtin/git/switch.py
+++ b/python/mirage/commands/cli/builtin/git/switch.py
@@ -1,0 +1,158 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from dataclasses import dataclass
+
+from dulwich.refs import Ref
+
+from mirage.commands.cli.builtin.git.checkout import (move_head,
+                                                      previous_position)
+from mirage.commands.cli.builtin.git.constants import HEAD
+from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
+    BranchExistsError, BranchExpectedError, DetachWithCreateError, GitError,
+    InvalidReferenceError, MissingBranchArgumentError, NoWorkspaceError,
+    OneReferenceError, UnknownSwitchError)
+from mirage.commands.cli.builtin.git.format import short, subject
+from mirage.commands.cli.builtin.git.objects import abbrev_for
+from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, TAG_PREFIX,
+                                                  read_head)
+from mirage.commands.cli.builtin.git.revparse import resolve_commit
+from mirage.commands.cli.builtin.git.session import opened
+from mirage.commands.cli.builtin.git.util import (check_operands, fatal,
+                                                  links_of)
+from mirage.commands.cli.types import CLIDoors, CLIInvocation
+from mirage.commands.spec.types import FlagView
+from mirage.io.stream import yield_bytes
+from mirage.io.types import ByteSource, IOResult
+
+REMOTES_PREFIX = "refs/remotes/"
+COMMIT = "commit"
+TAG = "tag"
+REMOTE_BRANCH = "remote branch"
+
+
+@dataclass(frozen=True, slots=True)
+class SwitchFlags:
+    """The parsed shape of a ``git switch`` invocation.
+
+    Args:
+        create (str | None): ``-c``, the branch to create and switch to.
+        detach (bool): ``--detach``, leave HEAD on the commit itself.
+    """
+    create: str | None
+    detach: bool
+
+
+def parse_flags(fl: FlagView) -> SwitchFlags:
+    """Read the raw switch flag kwargs into a frozen struct.
+
+    Args:
+        fl (FlagView): spec-validated view over the raw flag kwargs.
+    """
+    return SwitchFlags(create=fl.as_str("create"), detach=fl.as_bool("detach"))
+
+
+def expected_kind(known: set[Ref], name: str) -> str:
+    """What a non-branch operand named, for the refusal that says so.
+
+    git tells a tag and a remote-tracking branch apart from a bare
+    commit in the same sentence, so the refusal can say which one the
+    caller reached for.
+
+    Args:
+        known (set[Ref]): every ref the repository publishes.
+        name (str): the operand as the user spelled it.
+    """
+    if Ref(f"{TAG_PREFIX}{name}".encode()) in known:
+        return TAG
+    if Ref(f"{REMOTES_PREFIX}{name}".encode()) in known:
+        return REMOTE_BRANCH
+    return COMMIT
+
+
+async def switch(
+        inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
+    """Switch to a branch, creating it under ``-c``.
+
+    The same move ``checkout`` makes, with a narrower grammar: only a
+    branch is accepted, so a commit, tag or remote-tracking name is
+    refused unless ``--detach`` says that a detached HEAD is what was
+    meant. That is the whole reason git split the verb off, and it
+    holds here for the same reason: a detached HEAD is the state an
+    agent loses commits in.
+
+    Args:
+        inv (CLIInvocation[None]): the line's invocation record.
+            git declares no config_model; the planes it reads
+            (data through ``dispatch``, names through ``ns``) ride
+            ``inv.doors``.
+    """
+    doors = inv.doors or CLIDoors()
+    dispatch = doors.dispatch
+    stat_path = doors.stat_path
+    texts = inv.texts
+    fl = FlagView(inv.flags)
+    try:
+        if dispatch is None or stat_path is None:
+            raise NoWorkspaceError()
+        check_operands(texts, UnknownSwitchError)
+        flags = parse_flags(fl)
+        creating = flags.create is not None
+        if creating and flags.detach:
+            raise DetachWithCreateError()
+        if len(texts) > 1:
+            raise OneReferenceError()
+        if not creating and not texts:
+            raise MissingBranchArgumentError()
+        repo, location = await opened(fl, doors)
+        head = await read_head(dispatch, location.gitdir)
+        known = repo.refs.allkeys()
+        if flags.create is not None:
+            target = flags.create
+            ref = Ref(f"{BRANCH_PREFIX}{target}".encode())
+            if ref in known:
+                raise BranchExistsError(target)
+            start = texts[0] if texts else HEAD
+            try:
+                commit = resolve_commit(repo, start)
+            except GitError as exc:
+                raise InvalidReferenceError(start) from exc
+            attached = True
+        else:
+            target = texts[0]
+            ref = Ref(f"{BRANCH_PREFIX}{target}".encode())
+            if not flags.detach and target == head.branch:
+                return None, IOResult(
+                    stderr=f"Already on '{target}'\n".encode())
+            try:
+                commit = resolve_commit(repo, target)
+            except GitError as exc:
+                raise InvalidReferenceError(target) from exc
+            attached = not flags.detach and ref in known
+            if not flags.detach and not attached:
+                raise BranchExpectedError(expected_kind(known, target), target)
+        dirty = await move_head(dispatch, stat_path, links_of(doors), repo,
+                                location, head, commit, target,
+                                ref if attached else None, creating)
+    except GitError as exc:
+        return fatal(exc)
+    carried = "".join(f"M\t{path}\n" for path in sorted(dirty))
+    note = previous_position(repo, head)
+    if attached:
+        verb = "Switched to a new branch" if creating else "Switched to branch"
+        note += f"{verb} '{target}'\n"
+    else:
+        note += (f"HEAD is now at {short(commit.id, abbrev_for(repo))} "
+                 f"{subject(commit)}\n")
+    return yield_bytes(carried.encode()), IOResult(stderr=note.encode())

--- a/python/mirage/commands/cli/builtin/git/switch.py
+++ b/python/mirage/commands/cli/builtin/git/switch.py
@@ -125,11 +125,11 @@ async def switch(
             ref = Ref(f"{BRANCH_PREFIX}{target}".encode())
             if ref in known:
                 raise BranchExistsError(target)
-            start = texts[0] if texts else HEAD
+            start = texts[0] if texts else None
             try:
-                commit = resolve_commit(repo, start)
+                commit = resolve_commit(repo, start or HEAD)
             except GitError as exc:
-                raise InvalidReferenceError(start) from exc
+                raise InvalidReferenceError(start or HEAD) from exc
             # After the start point and before anything is written,
             # which is git's own order. A ref is a path below .git, so
             # an unchecked name reaches write_ref as one: -c
@@ -139,6 +139,7 @@ async def switch(
                 raise InvalidBranchNameError(target)
             attached = True
         else:
+            start = None
             target = texts[0] if texts else HEAD
             ref = Ref(f"{BRANCH_PREFIX}{target}".encode())
             if not flags.detach and target == head.branch:
@@ -153,7 +154,8 @@ async def switch(
                 raise BranchExpectedError(expected_kind(known, target), target)
         dirty = await move_head(dispatch, stat_path, links_of(doors), repo,
                                 location, head, commit, target,
-                                ref if attached else None, creating)
+                                ref if attached else None, creating, creating
+                                and start is None)
     except GitError as exc:
         return fatal(exc)
     carried = "".join(f"M\t{path}\n" for path in sorted(dirty))

--- a/python/mirage/commands/cli/builtin/git/switch.py
+++ b/python/mirage/commands/cli/builtin/git/switch.py
@@ -22,12 +22,12 @@ from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     BranchExistsError, BranchExpectedError, DetachWithCreateError, GitError,
     InvalidBranchNameError, InvalidReferenceError, MissingBranchArgumentError,
-    NoWorkspaceError, OneReferenceError, UnknownSwitchError)
+    NoWorkspaceError, OneReferenceError, RefLockError, UnknownSwitchError)
 from mirage.commands.cli.builtin.git.format import short, subject
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.refs import (BRANCH_PREFIX, TAG_PREFIX,
-                                                  read_head, set_head,
-                                                  valid_ref_name)
+                                                  blocking_ref, read_head,
+                                                  set_head, valid_ref_name)
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.util import (  # yapf: disable
@@ -149,6 +149,12 @@ async def switch(
             # configuration rather than on a branch.
             if not valid_ref_name(target):
                 raise InvalidBranchNameError(target)
+            # And before the working tree moves: git takes the ref lock
+            # first, so a name whose path another ref holds refuses with
+            # nothing checked out.
+            held = blocking_ref(known, ref.decode())
+            if held is not None:
+                raise RefLockError(ref.decode(), held)
             attached = True
             if unborn:
                 await set_head(dispatch, location.gitdir, ref.decode())

--- a/python/mirage/commands/cli/builtin/git/tag.py
+++ b/python/mirage/commands/cli/builtin/git/tag.py
@@ -1,0 +1,290 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import asyncio
+import fnmatch
+import time
+from dataclasses import dataclass
+
+from dulwich.objects import Commit, ObjectID, ShaFile, Tag
+from dulwich.refs import Ref
+from dulwich.repo import BaseRepo
+
+from mirage.commands.cli.builtin.git.commit import identity
+from mirage.commands.cli.builtin.git.constants import HEAD
+from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
+from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
+    IncompatibleOptionsError, InvalidTagNameError, MissingTagMessageError,
+    NoWorkspaceError, TagExistsError, TagNotFoundError, TooManyArgumentsError,
+    UnknownSwitchError, UnresolvedRefError)
+from mirage.commands.cli.builtin.git.format import short
+from mirage.commands.cli.builtin.git.objects import abbrev_for
+from mirage.commands.cli.builtin.git.refs import (TAG_PREFIX, delete_ref,
+                                                  valid_ref_name, write_ref)
+from mirage.commands.cli.builtin.git.revparse import resolve_commit
+from mirage.commands.cli.builtin.git.session import opened
+from mirage.commands.cli.builtin.git.util import check_operands, fatal
+from mirage.commands.cli.types import CLIDoors, CLIInvocation
+from mirage.commands.spec.types import FlagView
+from mirage.io.stream import yield_bytes
+from mirage.io.types import ByteSource, IOResult
+
+# git pads a tag name to this width before the message under -n.
+NAME_WIDTH = 15
+CONTINUATION = "    "
+UTC = 0
+
+
+@dataclass(frozen=True, slots=True)
+class TagFlags:
+    """The parsed shape of a ``git tag`` invocation.
+
+    Args:
+        listing (bool): ``-l``, list tags, the operands being patterns.
+        delete (bool): ``-d``, delete the named tags.
+        annotate (bool): ``-a``, write a tag object; implied by ``-m``.
+        message (str | None): ``-m``, the tag message.
+        force (bool): ``-f``, replace a tag that exists.
+        lines (int | None): ``-n[<num>]``, how many message lines to
+            print per tag when listing; None when not listing that way.
+    """
+    listing: bool
+    delete: bool
+    annotate: bool
+    message: str | None
+    force: bool
+    lines: int | None
+
+
+def parse_flags(fl: FlagView) -> TagFlags:
+    """Read the raw tag flag kwargs into a frozen struct.
+
+    ``-n`` carries its count attached or not at all, and a bare one
+    means one line, which is why the value is read as an integer first
+    and only then as a boolean. ``-m`` may repeat, each occurrence a
+    paragraph of its own.
+
+    Args:
+        fl (FlagView): spec-validated view over the raw flag kwargs.
+    """
+    lines = fl.as_int("n")
+    if lines is None and fl.as_bool("n"):
+        lines = 1
+    # Several -m are several paragraphs, joined the way git joins them.
+    paragraphs = fl.as_list("message")
+    message = "\n\n".join(paragraphs) if paragraphs else None
+    return TagFlags(listing=fl.as_bool("list"),
+                    delete=fl.as_bool("delete"),
+                    annotate=fl.as_bool("annotate") or message is not None,
+                    message=message,
+                    force=fl.as_bool("force"),
+                    lines=lines)
+
+
+def tag_names(known: set[Ref]) -> list[str]:
+    """Every tag name the repository publishes, in git's listing order.
+
+    Args:
+        known (set[Ref]): every ref the repository publishes.
+    """
+    prefix = TAG_PREFIX.encode()
+    return sorted(ref[len(prefix):].decode("utf-8", errors="replace")
+                  for ref in known if ref.startswith(prefix))
+
+
+def selected_names(names: list[str], patterns: tuple[str, ...]) -> list[str]:
+    """The names a ``-l`` pattern list keeps: any pattern, or all.
+
+    Args:
+        names (list[str]): every tag name, already ordered.
+        patterns (tuple[str, ...]): shell patterns as typed.
+    """
+    if not patterns:
+        return names
+    return [
+        name for name in names if any(
+            fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
+    ]
+
+
+def message_lines(repo: BaseRepo, sha: bytes) -> list[str]:
+    """The message ``-n`` prints for a tag: its own, or its commit's.
+
+    An annotated tag carries a message; a lightweight one is a bare
+    pointer, so git shows the message of what it points at. Read on a
+    worker thread, since the objects come through the dispatcher.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        sha (bytes): what the tag ref holds.
+    """
+    obj = repo.object_store[ObjectID(sha)]
+    if not isinstance(obj, (Tag, Commit)):
+        return []
+    text: str = obj.message.decode("utf-8", errors="replace")
+    return text.splitlines()
+
+
+def render_listing(names: list[str], messages: dict[str, list[str]] | None,
+                   count: int) -> bytes:
+    """One line per tag, with up to ``count`` message lines under -n.
+
+    Args:
+        names (list[str]): the tag names to print, in order.
+        messages (dict[str, list[str]] | None): each tag's message
+            lines, None when ``-n`` was not given.
+        count (int): how many message lines to print per tag.
+    """
+    lines: list[str] = []
+    for name in names:
+        if messages is None:
+            lines.append(name)
+            continue
+        body = messages[name][:count]
+        lines.append(f"{name:<{NAME_WIDTH}} {body[0] if body else ''}")
+        lines.extend(f"{CONTINUATION}{line}" for line in body[1:])
+    return "".join(f"{line}\n" for line in lines).encode()
+
+
+def resolve_target(repo: BaseRepo, known: set[Ref], revision: str) -> ShaFile:
+    """The object a new tag points at.
+
+    A tag made from another tag points at the tag object itself rather
+    than at what it peels to, which is git's own rule; anything else
+    resolves as a commit, ancestry suffixes included.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        known (set[Ref]): every ref the repository publishes.
+        revision (str): the operand as the user spelled it.
+    """
+    ref = Ref(f"{TAG_PREFIX}{revision}".encode())
+    if ref in known:
+        return repo.object_store[ObjectID(repo.refs[ref])]
+    try:
+        return resolve_commit(repo, revision)
+    except GitError as exc:
+        raise UnresolvedRefError(revision) from exc
+
+
+def build_tag(repo: BaseRepo, name: str, target: ShaFile, message: str,
+              tagger: bytes, when: int) -> Tag:
+    """Write an annotated tag object and return it.
+
+    Synchronous, and called on a worker thread: the object goes back
+    through the dispatcher.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        name (str): the tag name.
+        target (ShaFile): the object tagged.
+        message (str): the tag message, possibly empty.
+        tagger (bytes): the identity to record.
+        when (int): the timestamp, in epoch seconds.
+    """
+    tag = Tag()
+    tag.name = name.encode()
+    tag.object = (type(target), target.id)
+    tag.tagger = tagger
+    tag.tag_time = when
+    tag.tag_timezone = UTC
+    tag.message = f"{message}\n".encode() if message else b""
+    repo.object_store.add_object(tag)
+    return tag
+
+
+async def tag(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
+    """List, create or delete tags.
+
+    No operand lists them, a name creates one, ``-d`` deletes. A bare
+    name is a lightweight tag, a pointer and nothing more; ``-a`` or
+    ``-m`` writes a tag object carrying a message and a tagger, and
+    ``-a`` without ``-m`` is refused for the reason ``commit`` refuses
+    a missing message: there is no editor to open.
+
+    Args:
+        inv (CLIInvocation[None]): the line's invocation record.
+            git declares no config_model; the planes it reads
+            (data through ``dispatch``, names through ``ns``) ride
+            ``inv.doors``.
+    """
+    doors = inv.doors or CLIDoors()
+    dispatch = doors.dispatch
+    texts = inv.texts
+    fl = FlagView(inv.flags)
+    try:
+        if dispatch is None:
+            raise NoWorkspaceError()
+        check_operands(texts, UnknownSwitchError)
+        flags = parse_flags(fl)
+        if flags.listing and flags.delete:
+            raise IncompatibleOptionsError("-l", "-d")
+        repo, location = await opened(fl, doors)
+        known = repo.refs.allkeys()
+        if flags.delete:
+            out: list[str] = []
+            err: list[str] = []
+            for name in texts:
+                ref = Ref(f"{TAG_PREFIX}{name}".encode())
+                if ref not in known:
+                    err.append(f"error: {TagNotFoundError(name)}\n")
+                    continue
+                sha = repo.refs[ref]
+                await delete_ref(dispatch, location.commondir, ref.decode())
+                out.append(f"Deleted tag '{name}' "
+                           f"(was {short(sha, abbrev_for(repo))})\n")
+            return yield_bytes("".join(out).encode()), IOResult(
+                exit_code=1 if err else 0, stderr="".join(err).encode())
+        if flags.listing or flags.lines is not None or not texts:
+            names = selected_names(tag_names(known), texts)
+            messages = None
+            if flags.lines is not None:
+                messages = {
+                    name:
+                    await asyncio.to_thread(
+                        message_lines, repo,
+                        repo.refs[Ref(f"{TAG_PREFIX}{name}".encode())])
+                    for name in names
+                }
+            return yield_bytes(
+                render_listing(names, messages, flags.lines or 0)), IOResult()
+        if len(texts) > 2:
+            raise TooManyArgumentsError()
+        name = texts[0]
+        if not valid_ref_name(name):
+            raise InvalidTagNameError(name)
+        ref = Ref(f"{TAG_PREFIX}{name}".encode())
+        if ref in known and not flags.force:
+            raise TagExistsError(name)
+        if flags.annotate and flags.message is None:
+            raise MissingTagMessageError()
+        target = resolve_target(repo, known,
+                                texts[1] if len(texts) > 1 else HEAD)
+        if flags.annotate:
+            written = await asyncio.to_thread(build_tag, repo, name, target,
+                                              flags.message or "",
+                                              identity(fl, doors.session_view),
+                                              int(time.time()))
+            pointed = written.id
+        else:
+            pointed = target.id
+        was = repo.refs[ref] if ref in known else None
+        await write_ref(dispatch, location.commondir, ref.decode(), pointed)
+    except GitError as exc:
+        return fatal(exc)
+    if was is None:
+        return None, IOResult()
+    return yield_bytes(
+        f"Updated tag '{name}' "
+        f"(was {short(was, abbrev_for(repo))})\n".encode()), IOResult()

--- a/python/mirage/commands/cli/builtin/git/tag.py
+++ b/python/mirage/commands/cli/builtin/git/tag.py
@@ -15,6 +15,7 @@
 import asyncio
 import fnmatch
 import time
+from collections import Counter
 from dataclasses import dataclass
 
 from dulwich.objects import Commit, ObjectID, ShaFile, Tag
@@ -25,9 +26,10 @@ from mirage.commands.cli.builtin.git.commit import identity
 from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
-    IncompatibleOptionsError, InvalidTagNameError, MissingTagMessageError,
-    NoWorkspaceError, TagExistsError, TagNotFoundError, TagUsageError,
-    TooManyArgumentsError, UnknownSwitchError, UnresolvedRefError)
+    IncompatibleOptionsError, InvalidTagNameError, ListModeOnlyError,
+    MissingTagMessageError, NoWorkspaceError, RefUpdateConflictError,
+    TagExistsError, TagNotFoundError, TagUsageError, TooManyArgumentsError,
+    UnknownSwitchError, UnresolvedRefError)
 from mirage.commands.cli.builtin.git.format import short
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.refs import (TAG_PREFIX, delete_ref,
@@ -244,16 +246,37 @@ async def tag(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
                    or not texts)
         if creating and reading:
             raise TagUsageError()
+        # After the two usage refusals above, which git reaches first:
+        # ``-l -d -n1`` is the incompatible pair and ``-d -f -n1`` the
+        # usage, both exiting 129, where ``-d -n1`` alone dies here.
+        if flags.delete and flags.lines is not None:
+            raise ListModeOnlyError()
         repo, location = await opened(fl, doors)
         known = repo.refs.allkeys()
         if flags.delete:
             out: list[str] = []
             err: list[str] = []
+            doomed: list[tuple[str, Ref]] = []
             for name in texts:
                 ref = Ref(f"{TAG_PREFIX}{name}".encode())
                 if ref not in known:
                     err.append(f"error: {TagNotFoundError(name)}\n")
                     continue
+                doomed.append((name, ref))
+            # Every deletion on the line is one ref transaction, and a
+            # name given twice makes two updates for one ref, which the
+            # transaction refuses before applying any of them: the whole
+            # line deletes nothing. A name that is not there never
+            # reaches the transaction, so ``-d nosuch nosuch`` is two
+            # ordinary reports rather than this refusal.
+            seen = Counter(ref for _name, ref in doomed)
+            repeated = sorted(ref for ref, count in seen.items() if count > 1)
+            if repeated:
+                blamed = RefUpdateConflictError(repeated[0].decode())
+                err.append(f"error: {blamed}\n")
+                return None, IOResult(exit_code=1,
+                                      stderr="".join(err).encode())
+            for name, ref in doomed:
                 sha = repo.refs[ref]
                 await delete_ref(dispatch, location.commondir, ref.decode())
                 out.append(f"Deleted tag '{name}' "

--- a/python/mirage/commands/cli/builtin/git/tag.py
+++ b/python/mirage/commands/cli/builtin/git/tag.py
@@ -26,8 +26,8 @@ from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     IncompatibleOptionsError, InvalidTagNameError, MissingTagMessageError,
-    NoWorkspaceError, TagExistsError, TagNotFoundError, TooManyArgumentsError,
-    UnknownSwitchError, UnresolvedRefError)
+    NoWorkspaceError, TagExistsError, TagNotFoundError, TagUsageError,
+    TooManyArgumentsError, UnknownSwitchError, UnresolvedRefError)
 from mirage.commands.cli.builtin.git.format import short
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.refs import (TAG_PREFIX, delete_ref,
@@ -230,6 +230,16 @@ async def tag(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
         flags = parse_flags(fl)
         if flags.listing and flags.delete:
             raise IncompatibleOptionsError("-l", "-d")
+        # -a, -m and -f create a tag, so a line that lists or deletes
+        # instead has nothing for them to do: git prints its usage and
+        # exits 129, where the same line without them lists or deletes
+        # and exits 0. No operand at all is a listing, which is why it
+        # counts here too.
+        creating = flags.annotate or flags.force
+        reading = (flags.listing or flags.delete or flags.lines is not None
+                   or not texts)
+        if creating and reading:
+            raise TagUsageError()
         repo, location = await opened(fl, doors)
         known = repo.refs.allkeys()
         if flags.delete:

--- a/python/mirage/commands/cli/builtin/git/tag.py
+++ b/python/mirage/commands/cli/builtin/git/tag.py
@@ -32,7 +32,7 @@ from mirage.commands.cli.builtin.git.format import short
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.refs import (TAG_PREFIX, delete_ref,
                                                   valid_ref_name, write_ref)
-from mirage.commands.cli.builtin.git.revparse import resolve_commit
+from mirage.commands.cli.builtin.git.revparse import resolve_object
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.util import (  # yapf: disable
     check_operands, escaped, fatal)
@@ -158,39 +158,15 @@ def render_listing(names: list[str], messages: dict[str, list[str]] | None,
     return "".join(f"{line}\n" for line in lines).encode()
 
 
-def object_at(repo: BaseRepo, revision: str) -> ShaFile:
-    """The object one id names, whatever its type.
-
-    Only an id, full or abbreviated: a ref and an ancestry suffix have
-    already been tried as a commit by the caller, and this is what is
-    left for the tree or blob id git also takes as a tag target. An
-    abbreviation is expanded through the store rather than looked up,
-    since a store answers only a whole id.
-
-    Args:
-        repo (BaseRepo): the opened repository.
-        revision (str): the id as the user spelled it.
-
-    Raises:
-        KeyError: when no object carries that id.
-    """
-    wanted = revision.encode()
-    try:
-        return repo[ObjectID(wanted)]
-    except KeyError:
-        found = list(repo.object_store.iter_prefix(wanted))
-        if len(found) != 1:
-            raise
-        return repo[found[0]]
-
-
 def resolve_target(repo: BaseRepo, known: set[Ref], revision: str) -> ShaFile:
     """The object a new tag points at.
 
     A tag made from another tag points at the tag object itself rather
-    than at what it peels to, which is git's own rule; anything else
-    resolves as a commit first, ancestry suffixes included, and then as
-    a bare object, so a blob or a tree id is a legal target.
+    than at what it peels to, which is git's own rule. Anything else is
+    resolved as an object expression, because git tags any object and
+    its usage line says so: ``HEAD^{tree}`` and ``HEAD:a.txt`` are as
+    good a target as a branch, and the type resolution lands on is what
+    the tag records.
 
     Args:
         repo (BaseRepo): the opened repository.
@@ -201,16 +177,9 @@ def resolve_target(repo: BaseRepo, known: set[Ref], revision: str) -> ShaFile:
     if ref in known:
         return repo.object_store[ObjectID(repo.refs[ref])]
     try:
-        return resolve_commit(repo, revision)
-    except GitError:
-        # git tags any object and its usage line says so, so a blob or
-        # a tree id is read as itself before the revision is called
-        # unresolved; the type is kept, since it is what the tag
-        # records.
-        try:
-            return object_at(repo, revision)
-        except (KeyError, ValueError) as exc:
-            raise UnresolvedRefError(revision) from exc
+        return resolve_object(repo, revision)
+    except GitError as exc:
+        raise UnresolvedRefError(revision) from exc
 
 
 def build_tag(repo: BaseRepo, name: str, target: ShaFile, message: str,

--- a/python/mirage/commands/cli/builtin/git/tag.py
+++ b/python/mirage/commands/cli/builtin/git/tag.py
@@ -34,7 +34,8 @@ from mirage.commands.cli.builtin.git.refs import (TAG_PREFIX, delete_ref,
                                                   valid_ref_name, write_ref)
 from mirage.commands.cli.builtin.git.revparse import resolve_commit
 from mirage.commands.cli.builtin.git.session import opened
-from mirage.commands.cli.builtin.git.util import check_operands, fatal
+from mirage.commands.cli.builtin.git.util import (  # yapf: disable
+    check_operands, escaped, fatal)
 from mirage.commands.cli.types import CLIDoors, CLIInvocation
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
@@ -260,7 +261,7 @@ async def tag(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
     try:
         if dispatch is None:
             raise NoWorkspaceError()
-        check_operands(texts, UnknownSwitchError)
+        check_operands(texts, UnknownSwitchError, escaped(inv.argv))
         flags = parse_flags(fl)
         if flags.listing and flags.delete:
             raise IncompatibleOptionsError("-l", "-d")

--- a/python/mirage/commands/cli/builtin/git/tag.py
+++ b/python/mirage/commands/cli/builtin/git/tag.py
@@ -28,8 +28,9 @@ from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     IncompatibleOptionsError, InvalidTagNameError, ListModeOnlyError,
     MissingTagMessageError, NoWorkspaceError, RefLockError,
-    RefUpdateConflictError, TagExistsError, TagNotFoundError, TagUsageError,
-    TooManyArgumentsError, UnknownSwitchError, UnresolvedRefError)
+    RefUpdateConflictError, TagExistsError, TagLinesError, TagNotFoundError,
+    TagUsageError, TooManyArgumentsError, UnknownSwitchError,
+    UnresolvedRefError)
 from mirage.commands.cli.builtin.git.format import short
 from mirage.commands.cli.builtin.git.objects import abbrev_for
 from mirage.commands.cli.builtin.git.refs import (TAG_PREFIX, blocking_ref,
@@ -61,7 +62,8 @@ class TagFlags:
         message (str | None): ``-m``, the tag message.
         force (bool): ``-f``, replace a tag that exists.
         lines (int | None): ``-n[<num>]``, how many message lines to
-            print per tag when listing; None when not listing that way.
+            print per tag when listing; None when ``-n`` was not given,
+            which ``-n-1`` also means.
     """
     listing: bool
     delete: bool
@@ -85,6 +87,11 @@ def parse_flags(fl: FlagView) -> TagFlags:
     lines = fl.as_int("n")
     if lines is None and fl.as_bool("n"):
         lines = 1
+    # -1 is where git's own parser starts the count, so it reads as
+    # "-n was never given" rather than as a count of -1: ``-n-1``
+    # deletes and creates where any real ``-n`` refuses both.
+    if lines == -1:
+        lines = None
     # Several -m are several paragraphs, joined the way git joins them.
     paragraphs = fl.as_list("message")
     message = "\n\n".join(paragraphs) if paragraphs else None
@@ -252,6 +259,11 @@ async def tag(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
         # usage, both exiting 129, where ``-d -n1`` alone dies here.
         if flags.delete and flags.lines is not None:
             raise ListModeOnlyError()
+        # git reads the count while parsing the format it lists with,
+        # which is after both usage refusals above and before any ref
+        # is read: a repository holding no tags refuses this one too.
+        if flags.lines is not None and flags.lines < 0:
+            raise TagLinesError(flags.lines)
         repo, location = await opened(fl, doors)
         known = repo.refs.allkeys()
         if flags.delete:

--- a/python/mirage/commands/cli/builtin/git/tag.py
+++ b/python/mirage/commands/cli/builtin/git/tag.py
@@ -157,12 +157,39 @@ def render_listing(names: list[str], messages: dict[str, list[str]] | None,
     return "".join(f"{line}\n" for line in lines).encode()
 
 
+def object_at(repo: BaseRepo, revision: str) -> ShaFile:
+    """The object one id names, whatever its type.
+
+    Only an id, full or abbreviated: a ref and an ancestry suffix have
+    already been tried as a commit by the caller, and this is what is
+    left for the tree or blob id git also takes as a tag target. An
+    abbreviation is expanded through the store rather than looked up,
+    since a store answers only a whole id.
+
+    Args:
+        repo (BaseRepo): the opened repository.
+        revision (str): the id as the user spelled it.
+
+    Raises:
+        KeyError: when no object carries that id.
+    """
+    wanted = revision.encode()
+    try:
+        return repo[ObjectID(wanted)]
+    except KeyError:
+        found = list(repo.object_store.iter_prefix(wanted))
+        if len(found) != 1:
+            raise
+        return repo[found[0]]
+
+
 def resolve_target(repo: BaseRepo, known: set[Ref], revision: str) -> ShaFile:
     """The object a new tag points at.
 
     A tag made from another tag points at the tag object itself rather
     than at what it peels to, which is git's own rule; anything else
-    resolves as a commit, ancestry suffixes included.
+    resolves as a commit first, ancestry suffixes included, and then as
+    a bare object, so a blob or a tree id is a legal target.
 
     Args:
         repo (BaseRepo): the opened repository.
@@ -174,8 +201,15 @@ def resolve_target(repo: BaseRepo, known: set[Ref], revision: str) -> ShaFile:
         return repo.object_store[ObjectID(repo.refs[ref])]
     try:
         return resolve_commit(repo, revision)
-    except GitError as exc:
-        raise UnresolvedRefError(revision) from exc
+    except GitError:
+        # git tags any object and its usage line says so, so a blob or
+        # a tree id is read as itself before the revision is called
+        # unresolved; the type is kept, since it is what the tag
+        # records.
+        try:
+            return object_at(repo, revision)
+        except (KeyError, ValueError) as exc:
+            raise UnresolvedRefError(revision) from exc
 
 
 def build_tag(repo: BaseRepo, name: str, target: ShaFile, message: str,
@@ -259,7 +293,9 @@ async def tag(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
         if flags.listing or flags.lines is not None or not texts:
             names = selected_names(tag_names(known), texts)
             messages = None
-            if flags.lines is not None:
+            # -n0 (and any other count that prints no line) is a plain
+            # listing in git, so nothing is read and nothing is padded.
+            if flags.lines is not None and flags.lines > 0:
                 messages = {
                     name:
                     await asyncio.to_thread(

--- a/python/mirage/commands/cli/builtin/git/tag.py
+++ b/python/mirage/commands/cli/builtin/git/tag.py
@@ -27,13 +27,14 @@ from mirage.commands.cli.builtin.git.constants import HEAD
 from mirage.commands.cli.builtin.git.errors import GitError  # yapf: disable
 from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
     IncompatibleOptionsError, InvalidTagNameError, ListModeOnlyError,
-    MissingTagMessageError, NoWorkspaceError, RefUpdateConflictError,
-    TagExistsError, TagNotFoundError, TagUsageError, TooManyArgumentsError,
-    UnknownSwitchError, UnresolvedRefError)
+    MissingTagMessageError, NoWorkspaceError, RefLockError,
+    RefUpdateConflictError, TagExistsError, TagNotFoundError, TagUsageError,
+    TooManyArgumentsError, UnknownSwitchError, UnresolvedRefError)
 from mirage.commands.cli.builtin.git.format import short
 from mirage.commands.cli.builtin.git.objects import abbrev_for
-from mirage.commands.cli.builtin.git.refs import (TAG_PREFIX, delete_ref,
-                                                  valid_ref_name, write_ref)
+from mirage.commands.cli.builtin.git.refs import (TAG_PREFIX, blocking_ref,
+                                                  delete_ref, valid_ref_name,
+                                                  write_ref)
 from mirage.commands.cli.builtin.git.revparse import resolve_object
 from mirage.commands.cli.builtin.git.session import opened
 from mirage.commands.cli.builtin.git.util import (  # yapf: disable
@@ -319,6 +320,12 @@ async def tag(inv: CLIInvocation[None]) -> tuple[ByteSource | None, IOResult]:
         else:
             pointed = target.id
         was = repo.refs[ref] if ref in known else None
+        # After the object is built, which is git's order: an annotated
+        # tag whose ref cannot be locked has already been written to the
+        # database and is left there unreferenced.
+        held = blocking_ref(known, ref.decode())
+        if held is not None:
+            raise RefLockError(ref.decode(), held)
         await write_ref(dispatch, location.commondir, ref.decode(), pointed)
     except GitError as exc:
         return fatal(exc)

--- a/python/mirage/commands/cli/builtin/git/types.py
+++ b/python/mirage/commands/cli/builtin/git/types.py
@@ -67,6 +67,25 @@ class HeadRef:
 
 
 @dataclass(frozen=True, slots=True)
+class HeadMove:
+    """What moving HEAD carried across, and what it could not do.
+
+    Two things rather than one because git writes both: the paths whose
+    uncommitted change survived the move go to stdout with their status
+    letters, and a submodule directory the move could not remove is a
+    warning on stderr above the line saying the branch changed.
+
+    Args:
+        carried (dict[str, str]): each path whose uncommitted change was
+            carried across, against the status letter git prints for it.
+        warnings (str): the warning lines to write before the note,
+            empty when there are none.
+    """
+    carried: dict[str, str]
+    warnings: str
+
+
+@dataclass(frozen=True, slots=True)
 class AncestryStep:
     """One ``~`` or ``^`` suffix of a revision.
 
@@ -77,6 +96,19 @@ class AncestryStep:
     """
     first_parent: bool
     count: int
+
+
+@dataclass(frozen=True, slots=True)
+class PeelStep:
+    """One ``^{<type>}`` suffix of a revision.
+
+    Args:
+        want (str): the type word inside the braces, empty for ``^{}``.
+    """
+    want: str
+
+
+RevOp = AncestryStep | PeelStep
 
 
 @dataclass(frozen=True, slots=True)

--- a/python/mirage/commands/cli/builtin/git/util.py
+++ b/python/mirage/commands/cli/builtin/git/util.py
@@ -158,6 +158,11 @@ def fatal(exc: GitError) -> tuple[ByteSource | None, IOResult]:
     and a refusal that is really a report ("nothing to commit") carries
     no prefix and goes to stdout.
 
+    An error carrying a ``report`` puts that on stdout beside the
+    stderr line, because git writes some refusals to both streams at
+    once: ``<path>: needs merge`` is the diagnosis and "you need to
+    resolve your current index first" is the refusal.
+
     Args:
         exc (GitError): the error to render.
     """
@@ -165,4 +170,5 @@ def fatal(exc: GitError) -> tuple[ByteSource | None, IOResult]:
     data = body.encode()
     if exc.stream == STDOUT:
         return yield_bytes(data), IOResult(exit_code=exc.code)
-    return None, IOResult(exit_code=exc.code, stderr=data)
+    told = yield_bytes(exc.report.encode()) if exc.report else None
+    return told, IOResult(exit_code=exc.code, stderr=data)

--- a/python/mirage/commands/cli/builtin/git/util.py
+++ b/python/mirage/commands/cli/builtin/git/util.py
@@ -19,10 +19,12 @@ from mirage.commands.cli.types import CLIDoors
 from mirage.commands.spec.types import FlagView
 from mirage.io.stream import yield_bytes
 from mirage.io.types import ByteSource, IOResult
-from mirage.ops.types import LinkView
+from mirage.ops.types import LinkView, MountView
 
 ROOT = "/"
 STDOUT = "stdout"
+# The end-of-options marker, which the parser consumes.
+MARKER = "--"
 
 
 def links_of(doors: CLIDoors) -> LinkView | None:
@@ -37,6 +39,21 @@ def links_of(doors: CLIDoors) -> LinkView | None:
         doors (CLIDoors): the invocation's doors, one per state plane.
     """
     return doors.ns.links if doors.ns is not None else None
+
+
+def mounts_of(doors: CLIDoors) -> MountView | None:
+    """The name plane's mount boundaries, None when no namespace is wired.
+
+    A mount nested inside the repository is served by another resource
+    entirely, so the backend holding the parent path cannot see it and
+    cannot carry it along in a rename. A verb that moves a directory has
+    to ask here or it silently leaves the mount at its old prefix with
+    the index pointing at files that never moved.
+
+    Args:
+        doors (CLIDoors): the invocation's doors, one per state plane.
+    """
+    return doors.ns.mounts if doors.ns is not None else None
 
 
 def start_point(fl: FlagView) -> str:
@@ -68,8 +85,34 @@ def revision_arg(texts: tuple[str, ...], default: str = HEAD) -> str:
     return texts[0] if texts else default
 
 
-def check_operands(texts: tuple[str, ...],
-                   error: type[GitError] = UnrecognizedArgumentError) -> None:
+def escaped(argv: tuple[str, ...]) -> frozenset[str]:
+    """The words a ``--`` on the line marked as operands, not options.
+
+    ``--`` is exactly how a caller names a file whose name begins with a
+    dash, and git says so in every synopsis that ends
+    ``[--] [<pathspec>...]``: ``git rm -draft`` is a refused switch and
+    ``git rm -- -draft`` removes the file. The parser consumes the
+    marker, so the words themselves are what carries the fact forward,
+    read back off the verbatim argv the record already holds.
+
+    A set is enough. A dash word before the marker was read as an
+    option and never reached the operands, so a word that is here and
+    also spelled earlier on the line is still the escaped one.
+
+    Args:
+        argv (tuple[str, ...]): the line's verbatim tokens after the
+            head word, subcommand words included.
+    """
+    if MARKER not in argv:
+        return frozenset()
+    return frozenset(argv[argv.index(MARKER) + 1:])
+
+
+def check_operands(
+    texts: tuple[str, ...],
+    error: type[GitError] = UnrecognizedArgumentError,
+    marked: frozenset[str] = frozenset()
+) -> None:
     """Refuse an operand that is really an option this build lacks.
 
     A verb taking a revision accepts free text, so every flag mirage
@@ -79,14 +122,17 @@ def check_operands(texts: tuple[str, ...],
     has no such flag. Refused here, before any object is read, so the
     message names the real problem.
 
-    A pathspec is not checked for and cannot be: the shared parser
-    consumes ``--`` as its end-of-options marker, so ``log -- a.txt``
-    and ``log a.txt`` reach a leaf identically. Both resolve the operand
-    as a revision and fail with git's own "unknown revision or path"
-    wording, which is exactly right for an untracked path and a
-    deliberate divergence for a tracked one, where git would narrow the
-    walk instead. Erring is the safe half of that trade: limiting by
-    nothing would print every commit and look like an answer.
+    Unless the caller said otherwise. A word after ``--`` is an operand
+    by the caller's own instruction whatever it starts with, so it is
+    never read as an option here; see ``escaped``, which is where the
+    marker survives the parser.
+
+    Which side of the marker an operand fell on says nothing about what
+    it *means*: a verb taking a revision reads an escaped word as one
+    and fails with git's own "unknown revision or path" wording, where
+    git would narrow the walk by it instead. That divergence is
+    unchanged and deliberate, because limiting by nothing would print
+    every commit and look like an answer.
 
     Which refusal to raise is the caller's, because git words this
     differently per verb and means each one: see ``UnknownSwitchError``
@@ -95,9 +141,10 @@ def check_operands(texts: tuple[str, ...],
     Args:
         texts (tuple[str, ...]): positional text operands, as typed.
         error (type[GitError]): the refusal this verb words it with.
+        marked (frozenset[str]): operands a ``--`` on the line escaped.
     """
     for text in texts:
-        if text.startswith("-"):
+        if text.startswith("-") and text not in marked:
             raise error(text)
 
 

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -300,6 +300,17 @@ class Dispatcher:
                     and await self._moved_source_is_dir(path)):
                 raise PermissionError(errno.EACCES, os.strerror(errno.EACCES),
                                       path.virtual)
+        if (op == "rename" and isinstance(dst, PathSpec)
+                and self._namespace.link_stats_below(dst.virtual)):
+            # rename(2) replaces a destination directory only when it
+            # is empty, and the node table is half of what empty means
+            # here: a link is invisible to every backend, so a
+            # destination the backend reads as empty can still hold
+            # one. Left to the backend the rename succeeded and the
+            # purge below then deleted the link with it, losing
+            # namespace state silently where POSIX promises ENOTEMPTY.
+            raise OSError(errno.ENOTEMPTY, os.strerror(errno.ENOTEMPTY),
+                          dst.virtual)
         if self._table_answers(op, path.virtual, kwargs):
             return (await self._namespace_table_op(op, path, kwargs,
                                                    report), IOResult())

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -461,6 +461,16 @@ class Dispatcher:
                 # rename has emptied. The destination's own subtree is
                 # replaced first, as rename(2) replaces what it lands on.
                 await self._namespace.purge_under(kwargs["dst"].virtual)
+                # The node at the source itself is not part of the
+                # subtree below it, so re-anchoring that subtree leaves
+                # it behind: the mode or ownership a chmod recorded
+                # stayed at the emptied name, never reached the
+                # landing, and was inherited by whatever was created at
+                # the old name next. Shell mv compensates for this in
+                # its own prepare step; a verb reaching the dispatcher
+                # directly, as git mv does, had nothing to.
+                await self._namespace.rename(path.virtual,
+                                             kwargs["dst"].virtual)
                 await self._namespace.rename_under(path.virtual,
                                                    kwargs["dst"].virtual)
         bound = await post_ops_gate(policies, op, path, write, mount.prefix,

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -443,6 +443,15 @@ class Dispatcher:
                 # followed the old link, and the moved content was
                 # reachable under no name at all.
                 await self._namespace.unlink(kwargs["dst"].virtual)
+                # The subtree moves with it, and only the node table can
+                # move the part of it no backend holds: a link or an
+                # attr overlay below the source is addressed by absolute
+                # path, so it would otherwise stay behind at a name the
+                # rename has emptied. The destination's own subtree is
+                # replaced first, as rename(2) replaces what it lands on.
+                await self._namespace.purge_under(kwargs["dst"].virtual)
+                await self._namespace.rename_under(path.virtual,
+                                                   kwargs["dst"].virtual)
         bound = await post_ops_gate(policies, op, path, write, mount.prefix,
                                     result)
         if bound is not None:

--- a/python/mirage/workspace/dispatcher/dispatcher.py
+++ b/python/mirage/workspace/dispatcher/dispatcher.py
@@ -435,7 +435,7 @@ class Dispatcher:
             observed = time.time() if op in STAMP_WRITE_OPS else None
             await self.invalidate_after_write(mount, path, observed=observed)
             if op == "rename" and isinstance(kwargs.get("dst"), PathSpec):
-                await self.invalidate_after_write(mount, kwargs["dst"])
+                await self.invalidate_after_rename(mount, path, kwargs["dst"])
                 # rename(2) replaces the destination, so a node the
                 # table holds at that name does not survive the move.
                 # A link left there shadowed the file that had just
@@ -926,14 +926,44 @@ class Dispatcher:
                 async with mount.use():
                     await mount.resource.index.clear()
 
+    def _manager_for(self, mount: MountEntry) -> CacheManager:
+        """The cache manager that owns a mount's listings and bodies.
+
+        Args:
+            mount (MountEntry): the mount that was written.
+        """
+        manager = mount.cache_manager
+        if manager is None:
+            manager = CacheManager(self._cache, mount.resource.index,
+                                   mount.prefix, mount.resource.caches_reads)
+        return manager
+
     async def invalidate_after_write(self,
                                      mount: MountEntry,
                                      path: PathSpec,
                                      observed: float | None = None) -> None:
         await self._namespace.clear_times(path.virtual, observed=observed)
-        manager = mount.cache_manager
-        if manager is None:
-            manager = CacheManager(self._cache, mount.resource.index,
-                                   mount.prefix, mount.resource.caches_reads)
+        manager = self._manager_for(mount)
         await manager.invalidate_after_write(path)
         await manager.invalidate_ancestors(path)
+
+    async def invalidate_after_rename(self, mount: MountEntry,
+                                      source: PathSpec, dst: PathSpec) -> None:
+        """Drop everything cached below both ends of a rename.
+
+        A rename re-anchors the whole subtree under its source, so the
+        listings and bodies cached one level down under either name
+        are stale, not just the two paths and their parents. Evicting
+        only those left a moved directory's old name answering ``stat``
+        and ``ls`` from its cached children, so the next rename onto
+        that name saw a directory that was no longer there.
+
+        Args:
+            mount (MountEntry): the mount the rename ran on.
+            source (PathSpec): the name the subtree left.
+            dst (PathSpec): the name it now lives under.
+        """
+        manager = self._manager_for(mount)
+        await manager.invalidate_subtree(source)
+        await manager.invalidate_subtree(dst)
+        await manager.invalidate_ancestors(dst)

--- a/python/mirage/workspace/executor/builtins/links/links.py
+++ b/python/mirage/workspace/executor/builtins/links/links.py
@@ -15,7 +15,8 @@
 import dataclasses
 import posixpath
 
-from mirage.commands.spec import SPECS, parse_command
+from mirage.commands.spec import SPECS, parse_command, parse_to_kwargs
+from mirage.commands.spec.types import FlagView
 from mirage.runtime.types import DispatchFn
 from mirage.types import FileStat, FileType, PathSpec
 from mirage.utils.errors import FS_ERRORS, ReadOnlyError, fs_strerror
@@ -278,6 +279,8 @@ async def prepare_mv(
     namespace: Namespace,
     dispatch: DispatchFn,
     items: list[str | PathSpec],
+    args: tuple[str, ...],
+    cwd: str,
 ) -> tuple[list[str | PathSpec], str | None, tuple[str, str] | None, Result
            | None]:
     """Adjust a two-operand ``mv`` for node-meta operands.
@@ -286,13 +289,26 @@ async def prepare_mv(
     (a link to) a directory receives the move inside it (rename(2)
     preceded by mv's dst stat); any other destination is replaced, so its
     node entry, link or overlay attrs alike, drops once the backend move
-    succeeds. A plain source that carries overlay attributes has its meta
-    travel with the file once the backend move succeeds.
+    succeeds. A plain source hands back the pair to re-anchor once the
+    backend move succeeds, so whatever the node table holds at it and
+    below it travels with the bytes.
+
+    The pair is where this can be done at all: a single-mount ``mv``
+    renames through the backend op bound to the accessor rather than
+    through the dispatcher, so the re-anchoring the dispatcher does for
+    every other caller has to be repeated here. Only a two-operand line
+    qualifies, because a path-shaped word is classified into a PathSpec
+    whether it filled an operand slot or a flag's value, and nothing
+    here can tell ``mv a b dst`` from ``mv -t dst a b``.
 
     Args:
         namespace (Namespace): addressing authority holding the node table.
         dispatch (DispatchFn): op dispatcher used to stat the destination.
         items (list[str | PathSpec]): classified command parts.
+        args (tuple[str, ...]): the line's words after the name, read
+            for the two options that move the destination.
+        cwd (str): session working directory, which the parser resolves
+            path operands against.
 
     Returns:
         tuple: (possibly rewritten parts, node entry to drop after a
@@ -303,6 +319,16 @@ async def prepare_mv(
     paths = [p for p in items if isinstance(p, PathSpec)]
     if len(paths) != 2:
         return items, None, None, None
+    # ``-t`` makes every positional a source and the flag's value the
+    # destination, which is the many-source shape above; ``-T`` names
+    # the destination outright, so no basename is appended to it. Both
+    # are read off the parsed line rather than guessed from the parts,
+    # since a path-shaped flag value is classified into a PathSpec there
+    # exactly as an operand is.
+    fl = FlagView(parse_to_kwargs(parse_command(SPECS["mv"], list(args), cwd)),
+                  spec=SPECS["mv"])
+    if fl.raw("target_directory") is not None:
+        return items, None, None, None
     src, dst = paths
 
     # Where the move lands: inside a directory destination (followed, so
@@ -310,7 +336,8 @@ async def prepare_mv(
     # the destination itself, replaced like rename(2).
     followed = namespace.follow(dst.virtual)
     stat = await stat_or_none(dispatch, PathSpec.from_str_path(followed))
-    into_dir = stat is not None and stat.type == FileType.DIRECTORY
+    into_dir = (not fl.as_bool("no_target_directory") and stat is not None
+                and stat.type == FileType.DIRECTORY)
     if into_dir:
         target_dst = (followed.rstrip("/") + "/" +
                       posixpath.basename(src.virtual))
@@ -351,9 +378,12 @@ async def prepare_mv(
                 f"'{dst.raw_path}': {fs_strerror(exc)}\n")
         return items, None, None, ok("mv")
 
-    post_rename: tuple[str, str] | None = None
-    if namespace.meta_for(src.virtual) is not None:
-        post_rename = (src.virtual, target_dst)
+    # Unconditional: a directory source carries a whole subtree of node
+    # entries that no exact-path lookup at the source can see, and a
+    # symlink below it is destroyed rather than merely forgotten when
+    # they are left behind. Both halves are no-ops when the table holds
+    # nothing there.
+    post_rename = (src.virtual, target_dst)
 
     rewritten = items
     if into_dir and namespace.is_link(dst.virtual):

--- a/python/mirage/workspace/mount/namespace/namespace.py
+++ b/python/mirage/workspace/mount/namespace/namespace.py
@@ -495,6 +495,37 @@ class Namespace:
                 if meta.target is not None and path.startswith(base)
                 and "/" not in path[len(base):]]
 
+    async def rename_under(self, src: str, dst: str) -> int:
+        """Re-anchor every node below one directory onto another.
+
+        A rename moves a whole subtree, and the node table addresses its
+        entries by absolute path, so a link or an attr overlay below the
+        source names a path that no longer exists once the backend has
+        moved the bytes. No backend can report those entries, which is
+        why nothing below the dispatcher can do this.
+
+        Args:
+            src (str): absolute virtual path being renamed.
+            dst (str): absolute virtual path it becomes.
+
+        Returns:
+            int: number of entries re-anchored.
+        """
+        base = src.rstrip("/") + "/"
+        moved = [(path, meta) for path, meta in self._nodes.items()
+                 if path.startswith(base)]
+        if not moved:
+            return 0
+        landing = dst.rstrip("/")
+        for path, meta in moved:
+            del self._nodes[path]
+        for path, meta in moved:
+            target = f"{landing}/{path[len(base):]}"
+            self._nodes[target] = meta
+            await self._store.set(target, meta.to_fields())
+        await self._store.delete([path for path, _meta in moved])
+        return len(moved)
+
     async def purge_under(self, directory: str) -> int:
         """Drop every node entry under a directory (``rm -r`` semantics).
 

--- a/python/mirage/workspace/node/command_dispatch.py
+++ b/python/mirage/workspace/node/command_dispatch.py
@@ -615,7 +615,7 @@ async def _route_argv(
                                                                 stderr=err)
             elif name == "mv":
                 operands, post_unlink, post_rename, early = await prepare_mv(
-                    namespace, dispatch, operands)
+                    namespace, dispatch, operands, argv.args, session.cwd)
                 if early is not None:
                     return early
         except CycleError as exc:
@@ -668,9 +668,15 @@ async def _route_argv(
                     await namespace.unlink(item.virtual)
                     await namespace.purge_under(item.virtual)
         if post_unlink is not None:
+            # The landing is replaced the way rename(2) replaces it,
+            # node and subtree alike, and then the source's own node and
+            # subtree land on it. The same four steps the dispatcher
+            # takes for a rename it forwards itself.
             await namespace.unlink(post_unlink)
+            await namespace.purge_under(post_unlink)
         if post_rename is not None:
             await namespace.rename(post_rename[0], post_rename[1])
+            await namespace.rename_under(post_rename[0], post_rename[1])
     if link_errors:
         # A refused link operand fails the line the way a refused
         # backend operand does: its lines lead (they were reported

--- a/python/tests/commands/cli/builtin/git/conftest.py
+++ b/python/tests/commands/cli/builtin/git/conftest.py
@@ -148,6 +148,22 @@ def mounted(repo_path: Path):
         yield ws
 
 
+@contextlib.contextmanager
+def mounted_rw(repo_path: Path):
+    """Mount a repository writably at /repo, with ``git`` installed.
+
+    The writable twin of ``mounted``, for a test that has to reshape the
+    repository on disk between two runs of a verb that writes.
+
+    Args:
+        repo_path (Path): the repository's working tree.
+    """
+    with Workspace({MOUNT: DiskResource(root=str(repo_path))},
+                   mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        yield ws
+
+
 @pytest.fixture
 def workspace(repo_path: Path):
     """A workspace with the fixture repository mounted at /repo.

--- a/python/tests/commands/cli/builtin/git/conftest.py
+++ b/python/tests/commands/cli/builtin/git/conftest.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 from dulwich import porcelain
+from dulwich.index import ConflictedIndexEntry, Index, IndexEntry
 from dulwich.repo import Repo
 
 from mirage.commands.cli.builtin.git import GIT
@@ -131,6 +132,26 @@ def make_branch(repo_path: Path, name: str) -> None:
         name (str): branch name, e.g. ``feat/git-cli``.
     """
     porcelain.branch_create(str(repo_path), name.encode())
+
+
+def conflict_index(repo_path: Path, name: str) -> None:
+    """Turn one staged path into an unmerged one, stages 1 to 3.
+
+    Written straight into the index because reaching this state through
+    the CLI would need a merge, and what the callers exercise is what a
+    verb does to a path that is already conflicted.
+
+    Args:
+        repo_path (Path): the repository's working tree.
+        name (str): the path to conflict, repository-relative.
+    """
+    index = Index(str(repo_path / ".git" / "index"))
+    entry = index[name.encode()]
+    assert isinstance(entry, IndexEntry)
+    index[name.encode()] = ConflictedIndexEntry(ancestor=entry,
+                                                this=entry,
+                                                other=entry)
+    index.write()
 
 
 @contextlib.contextmanager

--- a/python/tests/commands/cli/builtin/git/conftest.py
+++ b/python/tests/commands/cli/builtin/git/conftest.py
@@ -19,9 +19,11 @@ from pathlib import Path
 import pytest
 from dulwich import porcelain
 from dulwich.index import ConflictedIndexEntry, Index, IndexEntry
+from dulwich.objects import Commit, Tree
 from dulwich.repo import Repo
 
 from mirage.commands.cli.builtin.git import GIT
+from mirage.commands.cli.builtin.git.constants import GITLINK
 from mirage.commands.cli.types import CLIDoors
 from mirage.resource.disk import DiskResource
 from mirage.types import MountMode
@@ -132,6 +134,67 @@ def make_branch(repo_path: Path, name: str) -> None:
         name (str): branch name, e.g. ``feat/git-cli``.
     """
     porcelain.branch_create(str(repo_path), name.encode())
+
+
+def commit_gitlink(repo_path: Path, name: str) -> None:
+    """Record a gitlink at a path and commit it.
+
+    Written straight into the index because reaching this state through
+    the CLI would need a submodule, and what the callers exercise is
+    what a verb does to a 160000 entry. It points at this repository's
+    own HEAD so the commit it names resolves here: an ordinary
+    submodule's does not, and the two failure modes differ.
+
+    Args:
+        repo_path (Path): the repository's working tree.
+        name (str): the path to record, repository-relative.
+    """
+    with Repo(str(repo_path)) as repo:
+        head = repo.refs[b"HEAD"]
+        index = repo.open_index()
+        index[name.encode()] = IndexEntry(ctime=0,
+                                          mtime=0,
+                                          dev=0,
+                                          ino=0,
+                                          mode=GITLINK,
+                                          uid=0,
+                                          gid=0,
+                                          size=0,
+                                          sha=head)
+        index.write()
+    porcelain.commit(str(repo_path),
+                     message=b"gitlink",
+                     author=AUTHOR,
+                     committer=AUTHOR)
+
+
+def branch_with_gitlink(repo_path: Path, branch: str, name: str) -> None:
+    """Write a branch whose tree records a gitlink, leaving HEAD alone.
+
+    The index is untouched on purpose: a branch switch onto a gitlink
+    is only reachable while the current branch does not carry one, and
+    committing it here would put it in HEAD's tree as well.
+
+    Args:
+        repo_path (Path): the repository's working tree.
+        branch (str): the branch to write, created from HEAD.
+        name (str): the path to record, repository-relative.
+    """
+    with Repo(str(repo_path)) as repo:
+        head = repo.refs[b"HEAD"]
+        tree = repo[repo[head].tree]
+        assert isinstance(tree, Tree)
+        tree.add(name.encode(), GITLINK, head)
+        repo.object_store.add_object(tree)
+        commit = Commit()
+        commit.tree = tree.id
+        commit.parents = [head]
+        commit.author = commit.committer = AUTHOR
+        commit.commit_time = commit.author_time = 0
+        commit.commit_timezone = commit.author_timezone = 0
+        commit.message = b"gitlink"
+        repo.object_store.add_object(commit)
+        repo.refs[f"refs/heads/{branch}".encode()] = commit.id
 
 
 def conflict_index(repo_path: Path, name: str) -> None:

--- a/python/tests/commands/cli/builtin/git/conftest.py
+++ b/python/tests/commands/cli/builtin/git/conftest.py
@@ -254,3 +254,33 @@ def repo_doors(ws) -> CLIDoors:
                     ns=namespace_view_of(ws._registry, ws._namespace,
                                          ws.dispatch),
                     session_view=session_view(Session(session_id="test")))
+
+
+@pytest.fixture
+def unborn_path(tmp_path: Path) -> Path:
+    """A repository before its first commit.
+
+    HEAD is symbolic and the branch it names has no ref, which is the
+    state git calls unborn. Several verbs answer differently here than
+    they do anywhere else, so it is a fixture rather than a setup step.
+
+    Args:
+        tmp_path (Path): pytest temporary directory.
+    """
+    path = tmp_path / "fresh"
+    path.mkdir()
+    Repo.init(str(path), default_branch=b"refs/heads/main").close()
+    return path
+
+
+@pytest.fixture
+def unborn_rw(unborn_path: Path):
+    """A writable workspace on a repository before its first commit.
+
+    Args:
+        unborn_path (Path): the repository's working tree.
+    """
+    with Workspace({MOUNT: DiskResource(root=str(unborn_path))},
+                   mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        yield ws

--- a/python/tests/commands/cli/builtin/git/test_branch.py
+++ b/python/tests/commands/cli/builtin/git/test_branch.py
@@ -222,3 +222,22 @@ async def test_an_unknown_switch_is_not_read_as_a_branch_name(git_rw):
     code, _out, err = await _run(git_rw, "branch -Z")
     assert code == 129
     assert err == b"error: unknown switch `Z'\n"
+
+
+@pytest.mark.asyncio
+async def test_branch_refuses_a_name_that_escapes_the_ref_tree(
+        git_rw, repo_path: Path):
+    before = (repo_path / ".git" / "config").read_bytes()
+    result = await git_rw.execute("git -C /repo branch ../../config")
+    err = result.stderr or b""
+    assert result.exit_code == 128
+    assert err.startswith(b"fatal: '../../config' is not a valid branch name")
+    assert (repo_path / ".git" / "config").read_bytes() == before
+
+
+@pytest.mark.asyncio
+async def test_a_bad_branch_name_is_named_before_its_start_point(git_rw):
+    result = await git_rw.execute(
+        "git -C /repo branch ../../config nosuchstart")
+    err = result.stderr or b""
+    assert err.startswith(b"fatal: '../../config' is not a valid branch name")

--- a/python/tests/commands/cli/builtin/git/test_branch.py
+++ b/python/tests/commands/cli/builtin/git/test_branch.py
@@ -241,3 +241,22 @@ async def test_a_bad_branch_name_is_named_before_its_start_point(git_rw):
         "git -C /repo branch ../../config nosuchstart")
     err = result.stderr or b""
     assert err.startswith(b"fatal: '../../config' is not a valid branch name")
+
+
+@pytest.mark.asyncio
+async def test_a_branch_cannot_be_made_below_one_that_exists(git_rw):
+    assert (await git_rw.execute("git -C /repo branch bb")).exit_code == 0
+    result = await git_rw.execute("git -C /repo branch bb/cc")
+    assert result.exit_code == 128
+    assert result.stderr == (b"fatal: cannot lock ref 'refs/heads/bb/cc': "
+                             b"'refs/heads/bb' exists; cannot create "
+                             b"'refs/heads/bb/cc'\n")
+
+
+@pytest.mark.asyncio
+async def test_a_bad_start_point_outranks_the_collision(git_rw):
+    assert (await git_rw.execute("git -C /repo branch bb")).exit_code == 0
+    # The lock is taken last, so a start point that resolves to nothing
+    # is reported first.
+    result = await git_rw.execute("git -C /repo branch bb/cc nosuchrev")
+    assert b"cannot lock ref" not in (result.stderr or b"")

--- a/python/tests/commands/cli/builtin/git/test_checkout.py
+++ b/python/tests/commands/cli/builtin/git/test_checkout.py
@@ -682,3 +682,40 @@ async def test_a_branch_that_adds_a_gitlink_makes_a_directory_for_it(
     branch_with_gitlink(repo_path, "linked", "sub")
     assert (await run(git_rw, "checkout linked"))[0] == 0
     assert (repo_path / "sub").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_an_unmerged_index_stops_a_checkout_of_the_current_branch(
+        git_rw, repo_path: Path):
+    conflict_index(repo_path, "a.txt")
+    code, out, err = await run(git_rw, "checkout main")
+    assert code == 1
+    assert out == b"a.txt: needs merge\n"
+    assert err == b"error: you need to resolve your current index first\n"
+
+
+@pytest.mark.asyncio
+async def test_a_gitlink_lands_over_a_directory_of_untracked_files(
+        git_rw, repo_path: Path):
+    # A gitlink asks for a directory, so the one already standing is
+    # what it asked for and nothing in it is lost. The collision check
+    # read it as a file replacing the directory and aborted a switch
+    # git takes.
+    branch_with_gitlink(repo_path, "linked", "sub")
+    await git_rw.execute("mkdir /repo/sub && echo keep > /repo/sub/keep.txt")
+    assert (await run(git_rw, "checkout linked"))[0] == 0
+    assert (repo_path / "sub" /
+            "keep.txt").read_text(encoding="utf-8") == "keep\n"
+
+
+@pytest.mark.asyncio
+async def test_an_untracked_file_where_a_gitlink_lands_is_still_refused(
+        git_rw, repo_path: Path):
+    # The other half of git's rule: the directory cannot be made
+    # without deleting the file, so this one is named and refused.
+    branch_with_gitlink(repo_path, "linked", "sub")
+    await git_rw.execute("printf 'mine\n' > /repo/sub")
+    code, _out, err = await run(git_rw, "checkout linked")
+    assert code == 1
+    assert b"would be overwritten by checkout:\n\tsub\n" in err
+    assert (repo_path / "sub").read_text(encoding="utf-8") == "mine\n"

--- a/python/tests/commands/cli/builtin/git/test_checkout.py
+++ b/python/tests/commands/cli/builtin/git/test_checkout.py
@@ -19,6 +19,7 @@ import pytest
 from dulwich.repo import Repo
 
 from mirage.commands.cli.builtin.git.checkout import (_blocked_ancestors,
+                                                      _blocked_descendants,
                                                       _conflicts)
 from tests.commands.cli.builtin.git.conftest import conflict_index
 
@@ -564,3 +565,60 @@ async def test_a_switch_puts_the_executable_bit_back(git_rw):
     listed = await git_rw.execute("ls -l /repo/s.sh")
     assert (listed.stdout or b"").startswith(b"-rwxr-xr-x")
     assert (await run(git_rw, "status --short"))[1] == b""
+
+
+def test_a_staged_file_under_a_written_file_blocks():
+    # The target records the file ``slot``; the index holds a staged
+    # ``slot/child`` that is in neither tree, so the exact-key
+    # comparison cannot see it and the directory would have to go.
+    writing = {b"slot": (MODE, b"a" * 40)}
+    assert _blocked_descendants(writing, {"slot/child"}) == ["slot/child"]
+    # The other direction is the ancestor check's, not this one's.
+    assert _blocked_descendants({b"slot/child": (MODE, b"a" * 40)},
+                                {"slot"}) == []
+    assert _blocked_descendants(writing, {"other/child"}) == []
+
+
+@pytest.mark.asyncio
+async def test_a_staged_file_inside_a_directory_the_branch_replaces(
+        git_rw, repo_path: Path):
+    assert (await run(git_rw, "checkout -b filebranch"))[0] == 0
+    await git_rw.execute("printf 'FILE\\n' > /repo/slot")
+    assert (await run(git_rw, "add slot"))[0] == 0
+    assert (await run(git_rw, "commit -m file"))[0] == 0
+    assert (await run(git_rw, "checkout main"))[0] == 0
+    await git_rw.execute("mkdir -p /repo/slot && printf 'c\\n' > "
+                         "/repo/slot/child")
+    assert (await run(git_rw, "add slot/child"))[0] == 0
+    code, _out, err = await run(git_rw, "checkout filebranch")
+    assert code == 1
+    assert b"slot/child" in err
+    # Nothing moved: the staged blob is still the only copy there is.
+    assert (repo_path / "slot" / "child").exists()
+
+
+@pytest.mark.asyncio
+async def test_replacing_a_directory_does_not_follow_a_link_out_of_it(
+        git_rw, repo_path: Path):
+    # git takes the link away with the directory and leaves what it
+    # pointed at exactly as it was. The link has to be ignored rather
+    # than untracked to get this far: an untracked one inside the
+    # directory is refused by name. What the walk does on the way is
+    # pinned in test_io, since the delete it used to attempt through
+    # the link is spelled with the link in the middle and the
+    # dispatcher does not resolve one there.
+    (repo_path / "outside").mkdir()
+    (repo_path / "outside" / "keep.txt").write_text("keep\n", encoding="utf-8")
+    assert (await run(git_rw, "checkout -b slotfile"))[0] == 0
+    await git_rw.execute("printf 'FILE\\n' > /repo/slot")
+    assert (await run(git_rw, "add slot"))[0] == 0
+    assert (await run(git_rw, "commit -m file"))[0] == 0
+    assert (await run(git_rw, "checkout main"))[0] == 0
+    await git_rw.execute("rm /repo/slot")
+    await git_rw.execute("printf 'link\\n' > /repo/.gitignore")
+    await git_rw.execute("mkdir -p /repo/slot")
+    await git_rw.execute("ln -s /repo/outside /repo/slot/link")
+    assert (await run(git_rw, "checkout slotfile"))[0] == 0
+    assert (repo_path / "outside" / "keep.txt").exists()
+    gone = await git_rw.execute("readlink /repo/slot/link")
+    assert gone.exit_code != 0

--- a/python/tests/commands/cli/builtin/git/test_checkout.py
+++ b/python/tests/commands/cli/builtin/git/test_checkout.py
@@ -18,7 +18,8 @@ from pathlib import Path
 import pytest
 from dulwich.repo import Repo
 
-from mirage.commands.cli.builtin.git.checkout import _conflicts
+from mirage.commands.cli.builtin.git.checkout import (_blocked_ancestors,
+                                                      _conflicts)
 from tests.commands.cli.builtin.git.conftest import conflict_index
 
 MODE = 0o100644
@@ -422,3 +423,92 @@ async def test_branching_here_survives_an_unmerged_index(
     assert (await run(git_rw, "checkout -b topic"))[0] == 0
     with Repo(str(repo_path)) as repo:
         assert repo.open_index().has_conflicts()
+
+
+def test_an_uncommitted_path_above_a_written_entry_is_blocked():
+    writing = {b"slot/child": (MODE, b"0" * 40)}
+    assert _blocked_ancestors(writing, {"slot"}) == ["slot"]
+    # The entry itself is not its own ancestor, and an unrelated
+    # uncommitted path is in nobody's way.
+    assert _blocked_ancestors(writing, {"slot/child"}) == []
+    assert _blocked_ancestors(writing, {"other"}) == []
+
+
+async def branch_holding_a_child(ws) -> None:
+    """Put ``slot/child`` on a branch ``other`` and come back.
+
+    Args:
+        ws (Workspace): workspace with the repository and CLI.
+    """
+    assert (await run(ws, "switch -c other"))[0] == 0
+    await ws.execute("mkdir -p /repo/slot && echo kid > /repo/slot/child")
+    assert (await run(ws, "add -f slot/child"))[0] == 0
+    assert (await run(ws, "commit -m child"))[0] == 0
+    assert (await run(ws, "switch main"))[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_staged_file_where_the_target_records_a_directory(git_rw):
+    # git allows this and discards the staged addition in silence; this
+    # refuses and names it, the same trade _conflicts makes for a staged
+    # change. What must not happen either way is the old answer: a raw
+    # ENOTDIR after the earlier entries were already written.
+    await branch_holding_a_child(git_rw)
+    await git_rw.execute("echo staged > /repo/slot")
+    assert (await run(git_rw, "add slot"))[0] == 0
+    code, _out, err = await run(git_rw, "switch other")
+    assert code == 1
+    assert err == (b"error: Your local changes to the following files would "
+                   b"be overwritten by checkout:\n\tslot\n"
+                   b"Please commit your changes or stash them before you "
+                   b"switch branches.\nAborting\n")
+    # Nothing moved: still on main with the addition still staged.
+    assert (await run(git_rw, "status --short"))[1] == b"A  slot\n"
+
+
+@pytest.mark.asyncio
+async def test_an_ignored_link_where_the_target_records_a_directory(git_rw):
+    # An ignored path is in neither tree and in no collision list, so it
+    # reaches the write. Writing through the link landed the blob in the
+    # link's target, corrupting a path no branch named while the link
+    # itself survived; git replaces the link instead.
+    await git_rw.execute("printf 'slot\\n' > /repo/.gitignore")
+    assert (await run(git_rw, "add .gitignore"))[0] == 0
+    assert (await run(git_rw, "commit -m ignore"))[0] == 0
+    await branch_holding_a_child(git_rw)
+    await git_rw.execute(
+        "mkdir -p /repo/away && echo outside > /repo/away/child")
+    await git_rw.execute("ln -s /repo/away /repo/slot")
+    assert (await run(git_rw, "switch other"))[0] == 0
+    assert (await git_rw.execute("cat /repo/slot/child")).stdout == b"kid\n"
+    # The link's target tree is untouched, and the link itself is gone.
+    assert (await
+            git_rw.execute("cat /repo/away/child")).stdout == b"outside\n"
+    assert (await git_rw.execute("readlink /repo/slot")).exit_code != 0
+
+
+@pytest.mark.asyncio
+async def test_an_ignored_file_where_the_target_records_a_directory(git_rw):
+    await git_rw.execute("printf 'slot\\n' > /repo/.gitignore")
+    assert (await run(git_rw, "add .gitignore"))[0] == 0
+    assert (await run(git_rw, "commit -m ignore"))[0] == 0
+    await branch_holding_a_child(git_rw)
+    await git_rw.execute("echo ignored > /repo/slot")
+    assert (await run(git_rw, "switch other"))[0] == 0
+    assert (await git_rw.execute("cat /repo/slot/child")).stdout == b"kid\n"
+    assert (await run(git_rw, "status --short"))[1] == b""
+
+
+@pytest.mark.asyncio
+async def test_an_untracked_file_there_is_still_refused(git_rw):
+    # Untracked and not ignored is the case git does refuse, and the
+    # wording is its own: the replacement above must not reach it.
+    await branch_holding_a_child(git_rw)
+    await git_rw.execute("echo untracked > /repo/slot")
+    code, _out, err = await run(git_rw, "switch other")
+    assert code == 1
+    assert err == (b"error: The following untracked working tree files would "
+                   b"be overwritten by checkout:\n\tslot\n"
+                   b"Please move or remove them before you switch "
+                   b"branches.\nAborting\n")
+    assert (await git_rw.execute("cat /repo/slot")).stdout == b"untracked\n"

--- a/python/tests/commands/cli/builtin/git/test_checkout.py
+++ b/python/tests/commands/cli/builtin/git/test_checkout.py
@@ -19,6 +19,7 @@ import pytest
 from dulwich.repo import Repo
 
 from mirage.commands.cli.builtin.git.checkout import _conflicts
+from tests.commands.cli.builtin.git.conftest import conflict_index
 
 MODE = 0o100644
 
@@ -402,3 +403,22 @@ async def test_checking_out_a_link_that_moved_retargets_it(git_rw):
     assert (await git_rw.execute("readlink /repo/lk")).stdout == b"a.txt\n"
     assert (await run(git_rw, "checkout second"))[0] == 0
     assert (await git_rw.execute("readlink /repo/lk")).stdout == b"b.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_an_unmerged_index_stops_a_checkout(git_rw, repo_path: Path):
+    assert (await run(git_rw, "branch topic"))[0] == 0
+    conflict_index(repo_path, "a.txt")
+    code, out, err = await run(git_rw, "checkout topic")
+    assert code == 1
+    assert out == b"a.txt: needs merge\n"
+    assert err == b"error: you need to resolve your current index first\n"
+
+
+@pytest.mark.asyncio
+async def test_branching_here_survives_an_unmerged_index(
+        git_rw, repo_path: Path):
+    conflict_index(repo_path, "a.txt")
+    assert (await run(git_rw, "checkout -b topic"))[0] == 0
+    with Repo(str(repo_path)) as repo:
+        assert repo.open_index().has_conflicts()

--- a/python/tests/commands/cli/builtin/git/test_checkout.py
+++ b/python/tests/commands/cli/builtin/git/test_checkout.py
@@ -26,6 +26,7 @@ from mirage.resource.disk import DiskResource
 from mirage.types import MountMode
 from mirage.workspace import Workspace
 from tests.commands.cli.builtin.git.conftest import (branch_with_gitlink,
+                                                     commit_gitlink,
                                                      conflict_index)
 
 MODE = 0o100644
@@ -719,3 +720,29 @@ async def test_an_untracked_file_where_a_gitlink_lands_is_still_refused(
     assert code == 1
     assert b"would be overwritten by checkout:\n\tsub\n" in err
     assert (repo_path / "sub").read_text(encoding="utf-8") == "mine\n"
+
+
+@pytest.mark.asyncio
+async def test_a_branch_that_drops_a_gitlink_rmdirs_it(git_rw,
+                                                       repo_path: Path):
+    assert (await run(git_rw, "branch plain"))[0] == 0
+    await git_rw.execute("mkdir /repo/sub")
+    commit_gitlink(repo_path, "sub")
+    code, _out, err = await run(git_rw, "checkout plain")
+    assert code == 0
+    assert err.endswith(b"Switched to branch 'plain'\n")
+    assert not (repo_path / "sub").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_gitlink_directory_that_is_not_empty_is_kept_with_a_warning(
+        git_rw, repo_path: Path):
+    assert (await run(git_rw, "branch plain"))[0] == 0
+    await git_rw.execute("mkdir /repo/sub && echo keep > /repo/sub/keep.txt")
+    commit_gitlink(repo_path, "sub")
+    code, _out, err = await run(git_rw, "checkout plain")
+    assert code == 0
+    assert err == (b"warning: unable to rmdir 'sub': Directory not empty\n"
+                   b"Switched to branch 'plain'\n")
+    assert (repo_path / "sub" /
+            "keep.txt").read_text(encoding="utf-8") == "keep\n"

--- a/python/tests/commands/cli/builtin/git/test_checkout.py
+++ b/python/tests/commands/cli/builtin/git/test_checkout.py
@@ -512,3 +512,55 @@ async def test_an_untracked_file_there_is_still_refused(git_rw):
                    b"Please move or remove them before you switch "
                    b"branches.\nAborting\n")
     assert (await git_rw.execute("cat /repo/slot")).stdout == b"untracked\n"
+
+
+@pytest.mark.asyncio
+async def test_an_ignored_directory_where_the_target_records_a_file(git_rw):
+    # The ancestor cases' other half: the directory stands on the name
+    # itself. It holds only ignored files, so the check that refuses a
+    # directory is silent (it is about the untracked files one would
+    # lose), and git updates ignored files by default and takes the
+    # whole directory with it.
+    await git_rw.execute("printf 'slot/\n' > /repo/.gitignore")
+    assert (await run(git_rw, "add .gitignore"))[0] == 0
+    assert (await run(git_rw, "commit -m ignore"))[0] == 0
+    assert (await run(git_rw, "switch -c other"))[0] == 0
+    await git_rw.execute("echo asfile > /repo/slot")
+    assert (await run(git_rw, "add -f slot"))[0] == 0
+    assert (await run(git_rw, "commit -m file"))[0] == 0
+    assert (await run(git_rw, "switch main"))[0] == 0
+    await git_rw.execute("mkdir -p /repo/slot && echo keep > /repo/slot/keep")
+    assert (await run(git_rw, "switch other"))[0] == 0
+    assert (await git_rw.execute("cat /repo/slot")).stdout == b"asfile\n"
+
+
+@pytest.mark.asyncio
+async def test_a_directory_holding_untracked_files_is_still_refused(git_rw):
+    # The other side of the same split, and the reason the removal
+    # above cannot be unconditional: an untracked file inside is one
+    # git will not lose, and it names the directory rather than the file.
+    assert (await run(git_rw, "switch -c other"))[0] == 0
+    await git_rw.execute("echo asfile > /repo/slot")
+    assert (await run(git_rw, "add slot"))[0] == 0
+    assert (await run(git_rw, "commit -m file"))[0] == 0
+    assert (await run(git_rw, "switch main"))[0] == 0
+    await git_rw.execute("mkdir -p /repo/slot && echo keep > /repo/slot/keep")
+    code, _out, err = await run(git_rw, "switch other")
+    assert code == 1
+    assert err == (b"error: Updating the following directories would lose "
+                   b"untracked files in them:\n\tslot\n\nAborting\n")
+    assert (await git_rw.execute("cat /repo/slot/keep")).stdout == b"keep\n"
+
+
+@pytest.mark.asyncio
+async def test_a_switch_puts_the_executable_bit_back(git_rw):
+    assert (await run(git_rw, "switch -c other"))[0] == 0
+    await git_rw.execute("printf '#!/bin/sh\n' > /repo/s.sh")
+    await git_rw.execute("chmod 755 /repo/s.sh")
+    assert (await run(git_rw, "add s.sh"))[0] == 0
+    assert (await run(git_rw, "commit -m script"))[0] == 0
+    assert (await run(git_rw, "switch main"))[0] == 0
+    assert (await run(git_rw, "switch other"))[0] == 0
+    listed = await git_rw.execute("ls -l /repo/s.sh")
+    assert (listed.stdout or b"").startswith(b"-rwxr-xr-x")
+    assert (await run(git_rw, "status --short"))[1] == b""

--- a/python/tests/commands/cli/builtin/git/test_checkout.py
+++ b/python/tests/commands/cli/builtin/git/test_checkout.py
@@ -18,9 +18,13 @@ from pathlib import Path
 import pytest
 from dulwich.repo import Repo
 
+from mirage.commands.cli.builtin.git import GIT
 from mirage.commands.cli.builtin.git.checkout import (_blocked_ancestors,
                                                       _blocked_descendants,
                                                       _conflicts)
+from mirage.resource.disk import DiskResource
+from mirage.types import MountMode
+from mirage.workspace import Workspace
 from tests.commands.cli.builtin.git.conftest import conflict_index
 
 MODE = 0o100644
@@ -622,3 +626,45 @@ async def test_replacing_a_directory_does_not_follow_a_link_out_of_it(
     assert (repo_path / "outside" / "keep.txt").exists()
     gone = await git_rw.execute("readlink /repo/slot/link")
     assert gone.exit_code != 0
+
+
+@pytest.mark.asyncio
+async def test_a_mount_further_down_the_switch_stops_it_before_it_starts(
+        repo_path: Path, tmp_path: Path):
+    # The refusal lives in the removal that meets the mount, which the
+    # write loop reaches one entry at a time. A branch that changes an
+    # earlier path as well would have had that path written already, so
+    # the fatal left the working tree on the target's content with HEAD
+    # and the index still on the branch being left.
+    inner = tmp_path / "held"
+    inner.mkdir()
+    with Workspace(
+        {
+            "/repo/": DiskResource(root=str(repo_path)),
+            "/repo/slot/data/": DiskResource(root=str(inner)),
+        },
+            mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        await ws.execute("printf 'ignored.txt\n' > /repo/.gitignore")
+        assert (await run(ws, "add .gitignore"))[0] == 0
+        assert (await run(ws, "commit -m ignores"))[0] == 0
+        assert (await run(ws, "checkout -b slotted"))[0] == 0
+        await ws.execute("printf 'edited\n' > /repo/a.txt")
+        await ws.execute("printf 'v2\n' > /repo/slot")
+        assert (await run(ws, "add a.txt slot"))[0] == 0
+        assert (await run(ws, "commit -m two"))[0] == 0
+        assert (await run(ws, "checkout main"))[0] == 0
+        # Only ignored content, so no collision list names the
+        # directory and the write loop is what would meet the mount.
+        await ws.execute("mkdir -p /repo/slot")
+        await ws.execute("printf 'x\n' > /repo/slot/ignored.txt")
+        before = (repo_path / "a.txt").read_text(encoding="utf-8")
+        code, _out, err = await run(ws, "checkout slotted")
+        assert code == 128
+        assert err == (b"fatal: cannot remove '/repo/slot': "
+                       b"'/repo/slot/data' is a mount root\n")
+        # Nothing moved: the earlier path still holds what it held, and
+        # the branch is the one the line started on.
+        assert (repo_path / "a.txt").read_text(encoding="utf-8") == before
+        assert (await run(ws, "status --short"))[1] == b""
+    assert inner.is_dir()

--- a/python/tests/commands/cli/builtin/git/test_checkout.py
+++ b/python/tests/commands/cli/builtin/git/test_checkout.py
@@ -25,7 +25,8 @@ from mirage.commands.cli.builtin.git.checkout import (_blocked_ancestors,
 from mirage.resource.disk import DiskResource
 from mirage.types import MountMode
 from mirage.workspace import Workspace
-from tests.commands.cli.builtin.git.conftest import conflict_index
+from tests.commands.cli.builtin.git.conftest import (branch_with_gitlink,
+                                                     conflict_index)
 
 MODE = 0o100644
 
@@ -668,3 +669,16 @@ async def test_a_mount_further_down_the_switch_stops_it_before_it_starts(
         assert (repo_path / "a.txt").read_text(encoding="utf-8") == before
         assert (await run(ws, "status --short"))[1] == b""
     assert inner.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_a_branch_that_adds_a_gitlink_makes_a_directory_for_it(
+        git_rw, repo_path: Path):
+    # The same rule the write loop follows for restore: a 160000 entry
+    # asks only that a directory stand at the name, so a branch adding
+    # one must not read it as a blob and write an empty file. Reached
+    # with nothing at the name, which is the one shape no collision
+    # check refuses first.
+    branch_with_gitlink(repo_path, "linked", "sub")
+    assert (await run(git_rw, "checkout linked"))[0] == 0
+    assert (repo_path / "sub").is_dir()

--- a/python/tests/commands/cli/builtin/git/test_io.py
+++ b/python/tests/commands/cli/builtin/git/test_io.py
@@ -14,8 +14,9 @@
 
 import pytest
 
-from mirage.commands.cli.builtin.git.io import (read_file, read_names,
-                                                read_optional)
+from mirage.commands.cli.builtin.git.io import (blocking_ancestor, read_file,
+                                                read_names, read_optional)
+from mirage.types import FileStat, FileType
 
 
 @pytest.mark.asyncio
@@ -52,3 +53,66 @@ async def test_read_names_lists_a_directory(workspace):
 @pytest.mark.asyncio
 async def test_read_names_is_empty_for_a_missing_directory(workspace):
     assert await read_names(workspace.dispatch, "/repo/nodir") == []
+
+
+class Links:
+    """A link view holding one link, at ``/repo/slot``."""
+
+    def stat_at(self, path: str) -> FileStat | None:
+        """What the namespace holds at a path, None when no link.
+
+        Args:
+            path (str): absolute virtual path.
+        """
+        if path != "/repo/slot":
+            return None
+        return FileStat(name="slot", type=FileType.SYMLINK)
+
+
+async def only_dirs(path: str) -> FileStat | None:
+    """A data plane in which every component is a directory.
+
+    Args:
+        path (str): absolute virtual path.
+    """
+    return FileStat(name=path.rsplit("/", 1)[-1], type=FileType.DIRECTORY)
+
+
+async def file_at_slot(path: str) -> FileStat | None:
+    """A data plane holding a regular file at ``/repo/slot``.
+
+    Args:
+        path (str): absolute virtual path.
+    """
+    kind = FileType.FILE if path == "/repo/slot" else FileType.DIRECTORY
+    return FileStat(name=path.rsplit("/", 1)[-1], type=kind)
+
+
+@pytest.mark.asyncio
+async def test_a_link_above_the_entry_is_found():
+    found = await blocking_ancestor(only_dirs, "/repo", "slot/child", Links())
+    assert found == "/repo/slot"
+    # The component itself is not an ancestor of itself, and a path with
+    # nothing but directories above it has none.
+    assert await blocking_ancestor(only_dirs, "/repo", "slot", Links()) is None
+    assert await blocking_ancestor(only_dirs, "/repo", "other/child",
+                                   Links()) is None
+
+
+@pytest.mark.asyncio
+async def test_a_regular_file_above_the_entry_is_found_too():
+    # No link anywhere: what is in the way is an ordinary file, which
+    # only the data plane can report.
+    found = await blocking_ancestor(file_at_slot, "/repo", "slot/child", None)
+    assert found == "/repo/slot"
+    assert await blocking_ancestor(only_dirs, "/repo", "slot/child",
+                                   None) is None
+
+
+@pytest.mark.asyncio
+async def test_the_namespace_is_asked_before_the_data_plane():
+    # stat_path dereferences, so a link to a directory stats as a
+    # directory: asking it first would walk straight through the link.
+    found = await blocking_ancestor(only_dirs, "/repo", "slot/deep/child",
+                                    Links())
+    assert found == "/repo/slot"

--- a/python/tests/commands/cli/builtin/git/test_io.py
+++ b/python/tests/commands/cli/builtin/git/test_io.py
@@ -14,9 +14,13 @@
 
 import pytest
 
+from mirage.commands.cli.builtin.git.errors import MountInWayError
 from mirage.commands.cli.builtin.git.io import (blocking_ancestor, read_file,
                                                 read_names, read_optional,
+                                                refuse_mount,
+                                                remove_empty_parents,
                                                 remove_tree)
+from mirage.ops.types import MountView
 from mirage.types import FileStat, FileType
 
 
@@ -168,7 +172,7 @@ class Recorder:
 @pytest.mark.asyncio
 async def test_removing_a_tree_unlinks_a_link_without_descending():
     calls = Recorder()
-    await remove_tree(calls, "/repo/slot", TreeLinks())
+    await remove_tree(calls, "/repo/slot", TreeLinks(), None)
     assert ("unlink", "/repo/slot/link") in calls.ops
     # The whole point: readdir dereferences, so listing the link at all
     # is the walk stepping outside the directory being replaced.
@@ -182,5 +186,109 @@ async def test_without_a_namespace_the_walk_has_nothing_to_ask():
     # Outside a workspace there is no name plane, so a link cannot be
     # told from a directory and the walk is the old one.
     calls = Recorder()
-    await remove_tree(calls, "/repo/slot", None)
+    await remove_tree(calls, "/repo/slot", None, None)
     assert ("readdir", "/repo/slot/link") in calls.ops
+
+
+def mounts(roots: list[str], hidden: list[str] | None = None) -> MountView:
+    """A mount view over a fixed list of roots.
+
+    Args:
+        roots (list[str]): every mount root, without a trailing slash.
+        hidden (list[str] | None): the ones this session may not be
+            told about, a subset of ``roots``.
+    """
+    unseen = set(hidden or [])
+    return MountView(descendants=lambda path:
+                     [root for root in roots if root.startswith(f"{path}/")],
+                     visible_descendants=lambda path: [
+                         root for root in roots
+                         if root.startswith(f"{path}/") and root not in unseen
+                     ],
+                     is_root=lambda path: path in roots,
+                     root_of=lambda path: None)
+
+
+def test_a_mount_root_is_refused_as_itself():
+    with pytest.raises(MountInWayError) as caught:
+        refuse_mount(mounts(["/repo/slot"]), "/repo/slot")
+    assert str(caught.value) == ("cannot remove '/repo/slot': it is a "
+                                 "mount root")
+
+
+def test_a_nested_mount_is_named():
+    with pytest.raises(MountInWayError) as caught:
+        refuse_mount(mounts(["/repo/slot/data"]), "/repo/slot")
+    assert str(caught.value) == ("cannot remove '/repo/slot': "
+                                 "'/repo/slot/data' is a mount root")
+
+
+def test_the_first_nested_mount_in_order_is_the_one_named():
+    with pytest.raises(MountInWayError) as caught:
+        refuse_mount(mounts(["/repo/slot/z", "/repo/slot/a"]), "/repo/slot")
+    assert "'/repo/slot/a'" in str(caught.value)
+
+
+def test_a_hidden_mount_blocks_the_removal_without_being_named():
+    # Avoiding a boundary and naming one are two different questions,
+    # and a hidden mount's name is what the hide exists to withhold.
+    view = mounts(["/repo/slot/data"], hidden=["/repo/slot/data"])
+    with pytest.raises(MountInWayError) as caught:
+        refuse_mount(view, "/repo/slot")
+    assert str(caught.value) == ("cannot remove '/repo/slot': it holds a "
+                                 "mount root")
+
+
+def test_nothing_in_the_way_is_no_refusal():
+    refuse_mount(mounts(["/other/mount"]), "/repo/slot")
+    refuse_mount(None, "/repo/slot")
+
+
+@pytest.mark.asyncio
+async def test_a_tree_holding_a_mount_is_refused_before_anything_is_deleted():
+    calls = Recorder()
+    with pytest.raises(MountInWayError):
+        await remove_tree(calls, "/repo/slot", TreeLinks(),
+                          mounts(["/repo/slot/data"]))
+    # Nothing at all: the refusal is the first thing the walk does, so
+    # the directory is still whole when the caller hears about it.
+    assert calls.ops == []
+
+
+class Parents:
+    """A dispatcher whose directories are all empty."""
+
+    def __init__(self) -> None:
+        self.ops: list[tuple[str, str]] = []
+
+    async def __call__(self, op: str, path, **kwargs):
+        """Record one op and answer an empty listing.
+
+        Args:
+            op (str): the op name.
+            path (PathSpec): the path it is asked for.
+            **kwargs (object): ignored.
+        """
+        self.ops.append((op, path.virtual))
+        if op == "readdir":
+            return [], None
+        return None, None
+
+
+@pytest.mark.asyncio
+async def test_pruning_empty_parents_stops_at_a_mount_root():
+    calls = Parents()
+    await remove_empty_parents(calls, "/repo/slot/data/x.txt", "/repo",
+                               mounts(["/repo/slot/data"]))
+    assert ("rmdir", "/repo/slot/data") not in calls.ops
+    # And it stops rather than skipping: the directories above the
+    # mount are the mount's parents, not git's to tidy either.
+    assert ("rmdir", "/repo/slot") not in calls.ops
+
+
+@pytest.mark.asyncio
+async def test_pruning_empty_parents_takes_an_ordinary_directory():
+    calls = Parents()
+    await remove_empty_parents(calls, "/repo/docs/x.txt", "/repo",
+                               mounts(["/repo/slot/data"]))
+    assert ("rmdir", "/repo/docs") in calls.ops

--- a/python/tests/commands/cli/builtin/git/test_io.py
+++ b/python/tests/commands/cli/builtin/git/test_io.py
@@ -15,7 +15,8 @@
 import pytest
 
 from mirage.commands.cli.builtin.git.io import (blocking_ancestor, read_file,
-                                                read_names, read_optional)
+                                                read_names, read_optional,
+                                                remove_tree)
 from mirage.types import FileStat, FileType
 
 
@@ -116,3 +117,70 @@ async def test_the_namespace_is_asked_before_the_data_plane():
     found = await blocking_ancestor(only_dirs, "/repo", "slot/deep/child",
                                     Links())
     assert found == "/repo/slot"
+
+
+class TreeLinks:
+    """A link view holding one link, at ``/repo/slot/link``."""
+
+    def stat_at(self, path: str) -> FileStat | None:
+        """What the namespace holds at a path, None when no link.
+
+        Args:
+            path (str): absolute virtual path.
+        """
+        if path != "/repo/slot/link":
+            return None
+        return FileStat(name="link", type=FileType.SYMLINK)
+
+
+class Recorder:
+    """A dispatcher that lists one link and records every op it is asked for.
+
+    ``readdir`` answers through the link the way the real one does: the
+    name plane owns links, so the data plane resolves the path and
+    lists what it points at.
+    """
+
+    def __init__(self) -> None:
+        self.ops: list[tuple[str, str]] = []
+
+    async def __call__(self, op: str, path, **kwargs):
+        """Record one op and answer the listings.
+
+        Args:
+            op (str): the op name.
+            path (PathSpec): the path it is asked for.
+            **kwargs (object): ignored.
+        """
+        where = path.virtual
+        self.ops.append((op, where))
+        if op == "readdir":
+            if where == "/repo/slot":
+                return ["/repo/slot/link"], None
+            if where == "/repo/slot/link":
+                return ["/repo/outside/keep.txt"], None
+            return [], None
+        if op == "rmdir" and where != "/repo/slot":
+            raise NotADirectoryError(where)
+        return None, None
+
+
+@pytest.mark.asyncio
+async def test_removing_a_tree_unlinks_a_link_without_descending():
+    calls = Recorder()
+    await remove_tree(calls, "/repo/slot", TreeLinks())
+    assert ("unlink", "/repo/slot/link") in calls.ops
+    # The whole point: readdir dereferences, so listing the link at all
+    # is the walk stepping outside the directory being replaced.
+    assert ("readdir", "/repo/slot/link") not in calls.ops
+    assert not any(
+        where.startswith("/repo/outside") for _op, where in calls.ops)
+
+
+@pytest.mark.asyncio
+async def test_without_a_namespace_the_walk_has_nothing_to_ask():
+    # Outside a workspace there is no name plane, so a link cannot be
+    # told from a directory and the walk is the old one.
+    calls = Recorder()
+    await remove_tree(calls, "/repo/slot", None)
+    assert ("readdir", "/repo/slot/link") in calls.ops

--- a/python/tests/commands/cli/builtin/git/test_mv.py
+++ b/python/tests/commands/cli/builtin/git/test_mv.py
@@ -18,6 +18,7 @@ import pytest
 
 from mirage.commands.cli.builtin.git.mv import Move, moved_path, parse_flags
 from mirage.commands.spec.types import FlagView
+from tests.commands.cli.builtin.git.conftest import conflict_index
 
 
 async def run(ws, line: str) -> tuple[int, bytes, bytes]:
@@ -190,3 +191,59 @@ async def test_k_skips_the_source_that_would_collide(git_rw, repo_path: Path):
     assert await run(git_rw, "mv -k a/x b/x dest") == (0, b"", b"")
     assert (repo_path / "dest" / "x").read_text() == "ax\n"
     assert (repo_path / "b" / "x").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_conflicted_source_is_refused(git_rw, repo_path: Path):
+    conflict_index(repo_path, "a.txt")
+    code, _out, err = await run(git_rw, "mv a.txt c.txt")
+    assert code == 128
+    assert err == b"fatal: conflicted, source=a.txt, destination=c.txt\n"
+    assert (repo_path / "a.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_conflicted_source_outranks_an_occupied_destination(
+        git_rw, repo_path: Path):
+    conflict_index(repo_path, "a.txt")
+    _code, _out, err = await run(git_rw, "mv a.txt b.txt")
+    assert err == b"fatal: conflicted, source=a.txt, destination=b.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_a_directory_holding_a_conflict_is_refused_by_that_path(
+        git_rw, repo_path: Path):
+    await git_rw.execute("mkdir /repo/docs && echo x > /repo/docs/one.md")
+    await run(git_rw, "add docs")
+    await run(git_rw, "commit -m docs")
+    conflict_index(repo_path, "docs/one.md")
+    code, _out, err = await run(git_rw, "mv docs notes")
+    assert code == 128
+    assert err == (b"fatal: conflicted, source=docs/one.md, "
+                   b"destination=notes/one.md\n")
+    assert (repo_path / "docs" / "one.md").exists()
+    assert not (repo_path / "notes").exists()
+
+
+@pytest.mark.asyncio
+async def test_k_skips_a_conflicted_source(git_rw, repo_path: Path):
+    conflict_index(repo_path, "a.txt")
+    assert await run(git_rw, "mv -k a.txt c.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_directory_carries_its_symlinks(git_rw):
+    await git_rw.execute("mkdir /repo/docs && echo x > /repo/docs/one.md")
+    await git_rw.execute("ln -s one.md /repo/docs/link")
+    await run(git_rw, "add docs")
+    await run(git_rw, "commit -m docs")
+    assert await run(git_rw, "mv docs notes") == (0, b"", b"")
+    # The link lives in the namespace, not on the disk the mount serves,
+    # so it is read back through the workspace rather than off the path.
+    moved = await git_rw.execute("readlink /repo/notes/link")
+    left = await git_rw.execute("readlink /repo/docs/link")
+    assert moved.stdout == b"one.md\n"
+    assert left.exit_code != 0
+    assert (await run(git_rw, "status --porcelain"))[1] == (
+        b"R  docs/link -> notes/link\nR  docs/one.md -> notes/one.md\n")

--- a/python/tests/commands/cli/builtin/git/test_mv.py
+++ b/python/tests/commands/cli/builtin/git/test_mv.py
@@ -378,3 +378,27 @@ async def test_a_dashed_operand_is_still_a_switch_unescaped(git_rw):
     code, _out, err = await run(git_rw, "mv -draft kept.txt")
     assert code == 129
     assert err == b"error: unknown switch `draft'\n"
+
+
+@pytest.mark.asyncio
+async def test_the_overlay_travels_with_a_moved_file(git_rw):
+    # git mv renames through the dispatcher, which is where the node
+    # table's own bookkeeping lives. A mode the inode cannot hold is
+    # recorded in the namespace overlay, and leaving it at the emptied
+    # name both lost it at the landing and left it to be inherited by
+    # whatever was written at the old name next.
+    assert (await git_rw.execute("chmod 400 /repo/a.txt")).exit_code == 0
+    assert await run(git_rw, "mv a.txt c.txt") == (0, b"", b"")
+    listed = await git_rw.execute("ls -l /repo/c.txt")
+    assert (listed.stdout or b"").startswith(b"-r--------")
+    assert git_rw.namespace.meta_for("/repo/a.txt") is None
+
+
+@pytest.mark.asyncio
+async def test_a_link_below_a_moved_directory_travels_too(git_rw):
+    await git_rw.execute("mkdir -p /repo/d && echo t > /repo/t.txt")
+    await git_rw.execute("ln -s /repo/t.txt /repo/d/link")
+    assert (await run(git_rw, "add d"))[0] == 0
+    assert await run(git_rw, "mv d notes") == (0, b"", b"")
+    read = await git_rw.execute("readlink /repo/notes/link")
+    assert (read.exit_code, read.stdout) == (0, b"/repo/t.txt\n")

--- a/python/tests/commands/cli/builtin/git/test_mv.py
+++ b/python/tests/commands/cli/builtin/git/test_mv.py
@@ -470,3 +470,23 @@ async def test_k_taking_a_source_out_takes_it_out_of_the_overlap(
     # is looked at and the directory moves on its own.
     assert await run(git_rw, "mv -k dir dir/other dest") == (0, b"", b"")
     assert (repo_path / "dest" / "dir" / "file").exists()
+
+
+@pytest.mark.asyncio
+async def test_f_takes_the_destinations_conflict_stages_with_it(
+        repo_path: Path):
+    # -f is the only way to reach an occupied destination, and git's
+    # answer there is one stage-0 entry holding the source: ls-files -u
+    # is empty afterwards. Leaving the stages is the worse divergence,
+    # since write_index lays them back over the entry and the moved
+    # blob is the copy that disappears.
+    conflict_index(repo_path, "b.txt")
+    with Workspace({MOUNT: DiskResource(root=str(repo_path))},
+                   mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        assert (await run(ws, "status --short"))[1].startswith(b"UU b.txt\n")
+        assert await run(ws, "mv -f a.txt b.txt") == (0, b"", b"")
+        assert (await run(ws, "status --short"))[1] == (b"D  a.txt\n"
+                                                        b"M  b.txt\n")
+    assert (repo_path / "b.txt").read_text(encoding="utf-8") == "one changed\n"
+    assert not (repo_path / "a.txt").exists()

--- a/python/tests/commands/cli/builtin/git/test_mv.py
+++ b/python/tests/commands/cli/builtin/git/test_mv.py
@@ -16,9 +16,14 @@ from pathlib import Path
 
 import pytest
 
+from mirage.commands.cli.builtin.git import GIT
 from mirage.commands.cli.builtin.git.mv import Move, moved_path, parse_flags
 from mirage.commands.spec.types import FlagView
-from tests.commands.cli.builtin.git.conftest import conflict_index
+from mirage.resource.disk import DiskResource
+from mirage.resource.ram import RAMResource
+from mirage.types import MountMode
+from mirage.workspace import Workspace
+from tests.commands.cli.builtin.git.conftest import MOUNT, conflict_index
 
 
 async def run(ws, line: str) -> tuple[int, bytes, bytes]:
@@ -247,3 +252,71 @@ async def test_a_directory_carries_its_symlinks(git_rw):
     assert left.exit_code != 0
     assert (await run(git_rw, "status --porcelain"))[1] == (
         b"R  docs/link -> notes/link\nR  docs/one.md -> notes/one.md\n")
+
+
+@pytest.mark.asyncio
+async def test_a_directory_holding_a_mount_will_not_move(repo_path: Path):
+    with Workspace(
+        {
+            MOUNT: DiskResource(root=str(repo_path)),
+            "/repo/docs/inner/": RAMResource(),
+        },
+            mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        await ws.execute("mkdir -p /repo/docs && echo x > /repo/docs/one.md")
+        await run(ws, "add docs")
+        code, _out, err = await run(ws, "mv docs notes")
+        assert code == 128
+        assert err == (b"fatal: renaming 'docs' failed: Device or resource "
+                       b"busy\n")
+        assert (repo_path / "docs" / "one.md").exists()
+        assert not (repo_path / "notes").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_mount_root_itself_will_not_move(repo_path: Path):
+    with Workspace(
+        {
+            MOUNT: DiskResource(root=str(repo_path)),
+            "/repo/inner/": RAMResource(),
+        },
+            mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        await ws.execute("echo x > /repo/inner/one.md")
+        await run(ws, "add inner")
+        code, _out, err = await run(ws, "mv inner elsewhere")
+        assert code == 128
+        assert err == (b"fatal: renaming 'inner' failed: Device or resource "
+                       b"busy\n")
+
+
+@pytest.mark.asyncio
+async def test_k_skips_a_source_that_holds_a_mount(repo_path: Path):
+    with Workspace(
+        {
+            MOUNT: DiskResource(root=str(repo_path)),
+            "/repo/docs/inner/": RAMResource(),
+        },
+            mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        await ws.execute("mkdir -p /repo/docs && echo x > /repo/docs/one.md")
+        await run(ws, "add docs")
+        assert await run(ws, "mv -k docs notes") == (0, b"", b"")
+        assert (repo_path / "docs" / "one.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_dashed_pathspec_moves_when_the_line_escapes_it(
+        git_rw, repo_path: Path):
+    (repo_path / "-draft").write_text("x\n", encoding="utf-8")
+    await run(git_rw, "add -- -draft")
+    assert await run(git_rw, "mv -- -draft kept.txt") == (0, b"", b"")
+    assert (repo_path / "kept.txt").read_text() == "x\n"
+    assert not (repo_path / "-draft").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_dashed_operand_is_still_a_switch_unescaped(git_rw):
+    code, _out, err = await run(git_rw, "mv -draft kept.txt")
+    assert code == 129
+    assert err == b"error: unknown switch `draft'\n"

--- a/python/tests/commands/cli/builtin/git/test_mv.py
+++ b/python/tests/commands/cli/builtin/git/test_mv.py
@@ -1,0 +1,145 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from pathlib import Path
+
+import pytest
+
+from mirage.commands.cli.builtin.git.mv import Move, moved_path, parse_flags
+from mirage.commands.spec.types import FlagView
+
+
+async def run(ws, line: str) -> tuple[int, bytes, bytes]:
+    """Run one git line against the mounted repository.
+
+    Args:
+        ws (Workspace): workspace with the repository and CLI.
+        line (str): the command line, without the leading directory.
+    """
+    result = await ws.execute(f"git -C /repo {line}")
+    return result.exit_code, result.stdout or b"", result.stderr or b""
+
+
+def test_dry_run_implies_verbose():
+    parsed = parse_flags(FlagView({"dry_run": True}))
+    assert parsed.dry_run and parsed.verbose
+
+
+def test_a_file_lands_at_its_destination():
+    move = Move("a.txt", "b/c.txt", ("a.txt", ), False)
+    assert moved_path(move, "a.txt") == "b/c.txt"
+
+
+def test_a_directory_keeps_the_path_below_it():
+    move = Move("docs", "notes", ("docs/one.md", "docs/sub/two.md"), True)
+    assert moved_path(move, "docs/sub/two.md") == "notes/sub/two.md"
+
+
+@pytest.mark.asyncio
+async def test_mv_renames_and_stages_the_rename(git_rw, repo_path: Path):
+    assert await run(git_rw, "mv a.txt c.txt") == (0, b"", b"")
+    assert (repo_path / "c.txt").exists()
+    assert not (repo_path / "a.txt").exists()
+    assert (await run(git_rw,
+                      "status --porcelain"))[1] == b"R  a.txt -> c.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_verbose_names_the_move(git_rw):
+    assert await run(git_rw, "mv -v a.txt c.txt") == (0, b"Renaming a.txt to "
+                                                      b"c.txt\n", b"")
+
+
+@pytest.mark.asyncio
+async def test_a_missing_source_is_fatal(git_rw):
+    code, _out, err = await run(git_rw, "mv nosuch c.txt")
+    assert code == 128
+    assert err == b"fatal: bad source, source=nosuch, destination=c.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_an_untracked_source_is_fatal(git_rw):
+    await git_rw.execute("echo u > /repo/u.txt")
+    _code, _out, err = await run(git_rw, "mv u.txt c.txt")
+    assert err == (b"fatal: not under version control, source=u.txt, "
+                   b"destination=c.txt\n")
+
+
+@pytest.mark.asyncio
+async def test_an_existing_destination_is_refused_unless_forced(
+        git_rw, repo_path: Path):
+    _code, _out, err = await run(git_rw, "mv a.txt b.txt")
+    assert err == (b"fatal: destination exists, source=a.txt, "
+                   b"destination=b.txt\n")
+    assert await run(git_rw, "mv -f a.txt b.txt") == (0, b"", b"")
+    assert (repo_path / "b.txt").read_text() == "one changed\n"
+    assert (await run(git_rw, "status --porcelain"))[1] == (b"D  a.txt\n"
+                                                            b"M  b.txt\n")
+
+
+@pytest.mark.asyncio
+async def test_a_directory_destination_takes_the_basename(git_rw):
+    await git_rw.execute("mkdir /repo/into")
+    await run(git_rw, "mv a.txt into")
+    assert (await run(git_rw,
+                      "status --porcelain"))[1] == b"R  a.txt -> into/a.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_several_sources_need_a_directory(git_rw):
+    _code, _out, err = await run(git_rw, "mv a.txt b.txt nowhere")
+    assert err == b"fatal: destination 'nowhere' is not a directory\n"
+
+
+@pytest.mark.asyncio
+async def test_a_directory_moves_with_everything_under_it(
+        git_rw, repo_path: Path):
+    await git_rw.execute("mkdir /repo/docs && echo x > /repo/docs/one.md")
+    await run(git_rw, "add docs")
+    await run(git_rw, "commit -m docs")
+    await git_rw.execute("echo u > /repo/docs/untracked.md")
+    assert await run(git_rw, "mv docs notes") == (0, b"", b"")
+    assert (repo_path / "notes" / "untracked.md").exists()
+    assert (await run(git_rw, "status --porcelain"))[1] == (
+        b"R  docs/one.md -> notes/one.md\n?? notes/untracked.md\n")
+
+
+@pytest.mark.asyncio
+async def test_one_operand_prints_the_usage(git_rw):
+    code, _out, err = await run(git_rw, "mv a.txt")
+    assert code == 129
+    assert err.startswith(b"usage: git mv [-v] [-f] [-n] [-k] <source> "
+                          b"<destination>\n")
+
+
+@pytest.mark.asyncio
+async def test_dry_run_moves_nothing(git_rw, repo_path: Path):
+    code, out, _err = await run(git_rw, "mv -n a.txt c.txt")
+    assert code == 0
+    assert out == (b"Checking rename of 'a.txt' to 'c.txt'\n"
+                   b"Renaming a.txt to c.txt\n")
+    assert (repo_path / "a.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_k_skips_a_source_that_cannot_move(git_rw):
+    assert await run(git_rw, "mv -k nosuch c.txt") == (0, b"", b"")
+
+
+@pytest.mark.asyncio
+async def test_a_missing_destination_directory_is_the_renames_failure(git_rw):
+    code, _out, err = await run(git_rw, "mv a.txt nodir/c.txt")
+    assert code == 128
+    assert err == (b"fatal: renaming 'a.txt' failed: No such file or "
+                   b"directory\n")

--- a/python/tests/commands/cli/builtin/git/test_mv.py
+++ b/python/tests/commands/cli/builtin/git/test_mv.py
@@ -291,6 +291,64 @@ async def test_a_mount_root_itself_will_not_move(repo_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_a_file_will_not_move_into_another_mount(repo_path: Path):
+    # The source is an ordinary tracked file, so neither "is a mount
+    # root" nor "holds one" catches it. The rename op binds to the
+    # backend serving the source, so the write would land in the
+    # repository's own mount at a path the inner one serves: the file
+    # ends up hidden behind that mount while the index names the new
+    # path.
+    with Workspace(
+        {
+            MOUNT: DiskResource(root=str(repo_path)),
+            "/repo/inner/": RAMResource(),
+        },
+            mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        await ws.execute("echo x > /repo/one.md")
+        await run(ws, "add one.md")
+        code, _out, err = await run(ws, "mv one.md inner/one.md")
+        assert code == 128
+        assert err == (b"fatal: renaming 'one.md' failed: Device or resource "
+                       b"busy\n")
+        assert (repo_path / "one.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_file_will_not_move_out_of_a_nested_mount(repo_path: Path):
+    with Workspace(
+        {
+            MOUNT: DiskResource(root=str(repo_path)),
+            "/repo/inner/": RAMResource(),
+        },
+            mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        await ws.execute("echo x > /repo/inner/one.md")
+        await run(ws, "add inner/one.md")
+        code, _out, err = await run(ws, "mv inner/one.md one.md")
+        assert code == 128
+        assert err == (b"fatal: renaming 'inner/one.md' failed: Device or "
+                       b"resource busy\n")
+
+
+@pytest.mark.asyncio
+async def test_a_move_inside_one_mount_still_goes(repo_path: Path):
+    # The destination check compares the two ends, so an ordinary move
+    # that never leaves the repository's own mount is untouched by it.
+    with Workspace(
+        {
+            MOUNT: DiskResource(root=str(repo_path)),
+            "/repo/inner/": RAMResource(),
+        },
+            mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        await ws.execute("mkdir -p /repo/docs && echo x > /repo/one.md")
+        await run(ws, "add one.md")
+        assert await run(ws, "mv one.md docs/one.md") == (0, b"", b"")
+        assert (repo_path / "docs" / "one.md").exists()
+
+
+@pytest.mark.asyncio
 async def test_k_skips_a_source_that_holds_a_mount(repo_path: Path):
     with Workspace(
         {

--- a/python/tests/commands/cli/builtin/git/test_mv.py
+++ b/python/tests/commands/cli/builtin/git/test_mv.py
@@ -402,3 +402,71 @@ async def test_a_link_below_a_moved_directory_travels_too(git_rw):
     assert await run(git_rw, "mv d notes") == (0, b"", b"")
     read = await git_rw.execute("readlink /repo/notes/link")
     assert (read.exit_code, read.stdout) == (0, b"/repo/t.txt\n")
+
+
+@pytest.mark.asyncio
+async def test_a_directory_and_something_inside_it_cannot_both_move(
+        git_rw, repo_path: Path):
+    await git_rw.execute("mkdir -p /repo/dir /repo/dest")
+    await git_rw.execute("echo z > /repo/dir/file")
+    await run(git_rw, "add dir")
+    await run(git_rw, "commit -m dir")
+    code, _out, err = await run(git_rw, "mv dir dir/file dest")
+    assert code == 128
+    assert err == (b"fatal: cannot move both 'dir/file' and its parent "
+                   b"directory 'dir'\n")
+    # Refused before anything moves, which is the whole point: moving
+    # the directory first is what makes the other source disappear.
+    assert (repo_path / "dir" / "file").exists()
+    assert not (repo_path / "dest" / "dir").exists()
+
+
+@pytest.mark.asyncio
+async def test_the_child_is_named_first_whatever_the_order(git_rw):
+    await git_rw.execute("mkdir -p /repo/dir /repo/dest")
+    await git_rw.execute("echo z > /repo/dir/file")
+    await run(git_rw, "add dir")
+    await run(git_rw, "commit -m dir")
+    _code, _out, err = await run(git_rw, "mv dir/file dir dest")
+    assert err == (b"fatal: cannot move both 'dir/file' and its parent "
+                   b"directory 'dir'\n")
+
+
+@pytest.mark.asyncio
+async def test_k_does_not_skip_an_overlapping_source(git_rw, repo_path: Path):
+    await git_rw.execute("mkdir -p /repo/dir /repo/dest")
+    await git_rw.execute("echo z > /repo/dir/file")
+    await run(git_rw, "add dir")
+    await run(git_rw, "commit -m dir")
+    code, _out, err = await run(git_rw, "mv -k dir dir/file dest")
+    assert code == 128
+    assert err == (b"fatal: cannot move both 'dir/file' and its parent "
+                   b"directory 'dir'\n")
+    assert (repo_path / "dir" / "file").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_sources_own_fault_outranks_the_overlap(git_rw):
+    await git_rw.execute("mkdir -p /repo/dir /repo/dest")
+    await git_rw.execute("echo z > /repo/dir/file")
+    await run(git_rw, "add dir")
+    await run(git_rw, "commit -m dir")
+    # The overlap is read off the whole line once every source has
+    # passed its own checks, so a later bad source is reported first.
+    _code, _out, err = await run(git_rw, "mv dir dir/file nosuch dest")
+    assert err == (b"fatal: bad source, source=nosuch, "
+                   b"destination=dest/nosuch\n")
+
+
+@pytest.mark.asyncio
+async def test_k_taking_a_source_out_takes_it_out_of_the_overlap(
+        git_rw, repo_path: Path):
+    await git_rw.execute("mkdir -p /repo/dir /repo/dest")
+    await git_rw.execute("echo z > /repo/dir/file")
+    await run(git_rw, "add dir")
+    await run(git_rw, "commit -m dir")
+    await git_rw.execute("echo o > /repo/dir/other")
+    # ``dir/other`` is untracked, so it is skipped before the overlap
+    # is looked at and the directory moves on its own.
+    assert await run(git_rw, "mv -k dir dir/other dest") == (0, b"", b"")
+    assert (repo_path / "dest" / "dir" / "file").exists()

--- a/python/tests/commands/cli/builtin/git/test_mv.py
+++ b/python/tests/commands/cli/builtin/git/test_mv.py
@@ -143,3 +143,50 @@ async def test_a_missing_destination_directory_is_the_renames_failure(git_rw):
     assert code == 128
     assert err == (b"fatal: renaming 'a.txt' failed: No such file or "
                    b"directory\n")
+
+
+@pytest.mark.asyncio
+async def test_two_sources_cannot_land_on_one_name(git_rw, repo_path: Path):
+    await git_rw.execute("mkdir -p /repo/a /repo/b /repo/dest")
+    await git_rw.execute("echo ax > /repo/a/x && echo bx > /repo/b/x")
+    await run(git_rw, "add a b")
+    await run(git_rw, "commit -m two")
+    code, _out, err = await run(git_rw, "mv a/x b/x dest")
+    assert code == 128
+    assert err == (b"fatal: multiple sources for the same target, "
+                   b"source=b/x, destination=dest/x\n")
+    assert (repo_path / "a" / "x").exists()
+    assert not (repo_path / "dest" / "x").exists()
+
+
+@pytest.mark.asyncio
+async def test_two_directories_collide_at_the_path_that_collides(git_rw):
+    await git_rw.execute("mkdir -p /repo/a/sub /repo/b/sub /repo/dest")
+    await git_rw.execute("echo 1 > /repo/a/sub/f && echo 2 > /repo/b/sub/f")
+    await run(git_rw, "add a b")
+    await run(git_rw, "commit -m dirs")
+    _code, _out, err = await run(git_rw, "mv a/sub b/sub dest")
+    assert err == (b"fatal: multiple sources for the same target, "
+                   b"source=b/sub/f, destination=dest/sub/f\n")
+
+
+@pytest.mark.asyncio
+async def test_a_sources_own_fault_outranks_the_collision(git_rw):
+    await git_rw.execute("mkdir -p /repo/a /repo/b /repo/dest")
+    await git_rw.execute("echo ax > /repo/a/x && echo bx > /repo/b/x")
+    await run(git_rw, "add a")
+    await run(git_rw, "commit -m one")
+    _code, _out, err = await run(git_rw, "mv a/x b/x dest")
+    assert err == (b"fatal: not under version control, source=b/x, "
+                   b"destination=dest/x\n")
+
+
+@pytest.mark.asyncio
+async def test_k_skips_the_source_that_would_collide(git_rw, repo_path: Path):
+    await git_rw.execute("mkdir -p /repo/a /repo/b /repo/dest")
+    await git_rw.execute("echo ax > /repo/a/x && echo bx > /repo/b/x")
+    await run(git_rw, "add a b")
+    await run(git_rw, "commit -m two")
+    assert await run(git_rw, "mv -k a/x b/x dest") == (0, b"", b"")
+    assert (repo_path / "dest" / "x").read_text() == "ax\n"
+    assert (repo_path / "b" / "x").exists()

--- a/python/tests/commands/cli/builtin/git/test_pathspec.py
+++ b/python/tests/commands/cli/builtin/git/test_pathspec.py
@@ -84,3 +84,8 @@ def test_a_directory_selects_its_whole_subtree():
 def test_the_root_selects_everything():
     paths = {"a.txt", "docs/b.md"}
     assert matched(paths, "") == paths
+
+
+def test_a_name_that_is_both_a_file_and_a_directory_selects_both():
+    paths = {"slot", "slot/child", "other"}
+    assert matched(paths, "slot") == {"slot", "slot/child"}

--- a/python/tests/commands/cli/builtin/git/test_refs.py
+++ b/python/tests/commands/cli/builtin/git/test_refs.py
@@ -13,9 +13,10 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import pytest
+from dulwich.refs import Ref
 
-from mirage.commands.cli.builtin.git.refs import (load_refs, read_head,
-                                                  valid_ref_name,
+from mirage.commands.cli.builtin.git.refs import (blocking_ref, load_refs,
+                                                  read_head, valid_ref_name,
                                                   without_packed)
 from mirage.io import IOResult
 
@@ -144,3 +145,26 @@ def test_dropping_the_last_ref_keeps_the_header():
 
 def test_a_ref_the_file_does_not_hold_rewrites_nothing():
     assert without_packed(PACKED.encode(), "refs/heads/other") is None
+
+
+def test_a_ref_above_the_new_one_blocks_it():
+    known = {Ref(b"refs/tags/foo"), Ref(b"refs/heads/main")}
+    assert blocking_ref(known, "refs/tags/foo/bar") == "refs/tags/foo"
+    # Every level above is searched, not just the parent.
+    assert blocking_ref(known, "refs/tags/foo/bar/baz") == "refs/tags/foo"
+
+
+def test_a_ref_below_the_new_one_blocks_it_too():
+    known = {Ref(b"refs/tags/foo/c"), Ref(b"refs/tags/foo/a")}
+    # git names one ref, and the walk that finds it is ordered, so the
+    # answer does not depend on how the set happens to iterate.
+    assert blocking_ref(known, "refs/tags/foo") == "refs/tags/foo/a"
+
+
+def test_a_ref_with_no_collision_is_free():
+    known = {Ref(b"refs/tags/foo"), Ref(b"refs/heads/main")}
+    assert blocking_ref(known, "refs/tags/other") is None
+    # A prefix that is not a whole path segment is not a collision.
+    assert blocking_ref(known, "refs/tags/foobar") is None
+    # And the ref itself existing is a different refusal, not this one.
+    assert blocking_ref(known, "refs/tags/foo") is None

--- a/python/tests/commands/cli/builtin/git/test_refs.py
+++ b/python/tests/commands/cli/builtin/git/test_refs.py
@@ -15,7 +15,8 @@
 import pytest
 
 from mirage.commands.cli.builtin.git.refs import (load_refs, read_head,
-                                                  valid_ref_name)
+                                                  valid_ref_name,
+                                                  without_packed)
 from mirage.io import IOResult
 
 from .conftest import make_branch, mounted, pack_refs
@@ -116,3 +117,30 @@ def test_names_git_accepts_are_valid(name: str):
 ])
 def test_names_git_refuses_are_invalid(name: str):
     assert not valid_ref_name(name)
+
+
+PACKED = ("# pack-refs with: peeled fully-peeled sorted \n"
+          "1111111111111111111111111111111111111111 refs/heads/main\n"
+          "2222222222222222222222222222222222222222 refs/tags/ann\n"
+          "^3333333333333333333333333333333333333333\n"
+          "4444444444444444444444444444444444444444 refs/tags/lw\n")
+
+
+def test_dropping_a_packed_tag_drops_its_peeled_line():
+    rewritten = without_packed(PACKED.encode(), "refs/tags/ann")
+    assert rewritten is not None
+    assert b"refs/tags/ann" not in rewritten
+    assert b"^3333" not in rewritten
+    assert b"refs/tags/lw" in rewritten
+    assert b"refs/heads/main" in rewritten
+
+
+def test_dropping_the_last_ref_keeps_the_header():
+    rewritten = without_packed(PACKED.encode(), "refs/tags/lw")
+    assert rewritten is not None
+    assert rewritten.startswith(b"# pack-refs with:")
+    assert b"^3333" in rewritten
+
+
+def test_a_ref_the_file_does_not_hold_rewrites_nothing():
+    assert without_packed(PACKED.encode(), "refs/heads/other") is None

--- a/python/tests/commands/cli/builtin/git/test_refs.py
+++ b/python/tests/commands/cli/builtin/git/test_refs.py
@@ -14,7 +14,8 @@
 
 import pytest
 
-from mirage.commands.cli.builtin.git.refs import load_refs, read_head
+from mirage.commands.cli.builtin.git.refs import (load_refs, read_head,
+                                                  valid_ref_name)
 from mirage.io import IOResult
 
 from .conftest import make_branch, mounted, pack_refs
@@ -100,3 +101,18 @@ async def test_load_refs_walks_nested_ref_names(repo_path, workspace):
 async def test_head_symref_resolves_through_the_container(workspace):
     refs = await load_refs(workspace.dispatch, "/repo/.git")
     assert refs[b"HEAD"] == refs[b"refs/heads/main"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["v1.0", "feat/git-cli", "a10", "B", "@", "x-y_z", "release-2026.01"])
+def test_names_git_accepts_are_valid(name: str):
+    assert valid_ref_name(name)
+
+
+@pytest.mark.parametrize("name", [
+    "", "bad name", "bad..name", "x.lock", ".x", "x/", "/x", "a//b", "x.",
+    "a@{b", "a~b", "a^b", "a:b", "a?b", "a*b", "a[b", "a\\b", "a\tb"
+])
+def test_names_git_refuses_are_invalid(name: str):
+    assert not valid_ref_name(name)

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -15,7 +15,7 @@
 from pathlib import Path
 
 import pytest
-from dulwich.index import IndexEntry
+from dulwich.index import ConflictedIndexEntry, Index, IndexEntry
 
 from mirage.commands.cli.builtin.git.restore import index_tree, parse_flags
 from mirage.commands.spec.types import FlagView
@@ -140,3 +140,33 @@ async def test_a_deleted_file_comes_back(git_rw, repo_path: Path):
     await git_rw.execute("ls /repo")
     assert await run(git_rw, "restore a.txt") == (0, b"", b"")
     assert (repo_path / "a.txt").read_text() == "one changed\n"
+
+
+def conflict_the_index(repo_path: Path, name: str) -> None:
+    """Turn one staged path into an unmerged one, stages 1 to 3.
+
+    Written straight into the index because reaching this state through
+    the CLI would need a merge, and what is under test is what
+    ``restore`` does to a path that is already conflicted.
+
+    Args:
+        repo_path (Path): the repository's working tree.
+        name (str): the path to conflict, repository-relative.
+    """
+    index = Index(str(repo_path / ".git" / "index"))
+    entry = index[name.encode()]
+    assert isinstance(entry, IndexEntry)
+    index[name.encode()] = ConflictedIndexEntry(ancestor=entry,
+                                                this=entry,
+                                                other=entry)
+    index.write()
+
+
+@pytest.mark.asyncio
+async def test_restoring_the_index_clears_the_conflict_stages(
+        git_rw, repo_path: Path):
+    conflict_the_index(repo_path, "a.txt")
+    assert await run(git_rw, "restore --staged a.txt") == (0, b"", b"")
+    index = Index(str(repo_path / ".git" / "index"))
+    assert not index.has_conflicts()
+    assert isinstance(index[b"a.txt"], IndexEntry)

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -1,0 +1,142 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from pathlib import Path
+
+import pytest
+from dulwich.index import IndexEntry
+
+from mirage.commands.cli.builtin.git.restore import index_tree, parse_flags
+from mirage.commands.spec.types import FlagView
+
+
+async def run(ws, line: str) -> tuple[int, bytes, bytes]:
+    """Run one git line against the mounted repository.
+
+    Args:
+        ws (Workspace): workspace with the repository and CLI.
+        line (str): the command line, without the leading directory.
+    """
+    result = await ws.execute(f"git -C /repo {line}")
+    return result.exit_code, result.stdout or b"", result.stderr or b""
+
+
+def test_the_worktree_is_the_default_target():
+    parsed = parse_flags(FlagView({}))
+    assert (parsed.staged, parsed.worktree) == (False, True)
+
+
+def test_staged_alone_leaves_the_worktree_out():
+    parsed = parse_flags(FlagView({"staged": True}))
+    assert (parsed.staged, parsed.worktree) == (True, False)
+
+
+def test_both_targets_can_be_named():
+    parsed = parse_flags(FlagView({"staged": True, "worktree": True}))
+    assert (parsed.staged, parsed.worktree) == (True, True)
+
+
+def test_the_index_reads_as_a_tree():
+    entry = IndexEntry(ctime=0,
+                       mtime=0,
+                       dev=0,
+                       ino=0,
+                       mode=0o100644,
+                       uid=0,
+                       gid=0,
+                       size=3,
+                       sha=b"a" * 40)
+    assert index_tree({b"a.txt": entry}) == {b"a.txt": (0o100644, b"a" * 40)}
+
+
+@pytest.mark.asyncio
+async def test_restore_puts_an_edit_back(git_rw, repo_path: Path):
+    await git_rw.execute("echo edited > /repo/a.txt")
+    assert await run(git_rw, "restore a.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt").read_text() == "one changed\n"
+    assert (await run(git_rw, "status --porcelain"))[1] == b""
+
+
+@pytest.mark.asyncio
+async def test_staged_unstages_and_keeps_the_edit(git_rw, repo_path: Path):
+    await git_rw.execute("echo edited > /repo/a.txt")
+    await run(git_rw, "add a.txt")
+    assert await run(git_rw, "restore --staged a.txt") == (0, b"", b"")
+    assert (await run(git_rw, "status --porcelain"))[1] == b" M a.txt\n"
+    assert (repo_path / "a.txt").read_text() == "edited\n"
+
+
+@pytest.mark.asyncio
+async def test_both_targets_go_back_to_head(git_rw, repo_path: Path):
+    await git_rw.execute("echo edited > /repo/a.txt")
+    await run(git_rw, "add a.txt")
+    await git_rw.execute("echo again > /repo/a.txt")
+    assert await run(git_rw, "restore -SW a.txt") == (0, b"", b"")
+    assert (await run(git_rw, "status --porcelain"))[1] == b""
+    assert (repo_path / "a.txt").read_text() == "one changed\n"
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_path_is_an_error_not_a_fatal(git_rw):
+    code, _out, err = await run(git_rw, "restore nosuch")
+    assert code == 1
+    assert err == (b"error: pathspec 'nosuch' did not match any file(s) "
+                   b"known to git\n")
+
+
+@pytest.mark.asyncio
+async def test_no_pathspec_is_fatal(git_rw):
+    code, _out, err = await run(git_rw, "restore")
+    assert code == 128
+    assert err == b"fatal: you must specify path(s) to restore\n"
+
+
+@pytest.mark.asyncio
+async def test_a_source_restores_from_that_tree(git_rw, repo_path: Path):
+    assert await run(git_rw, "restore --source HEAD~1 a.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt").read_text() == "one\n"
+    assert (await run(git_rw, "status --porcelain"))[1] == b" M a.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_a_bad_source_is_fatal(git_rw):
+    code, _out, err = await run(git_rw, "restore -s nosuch a.txt")
+    assert code == 128
+    assert err == b"fatal: could not resolve nosuch\n"
+
+
+@pytest.mark.asyncio
+async def test_staged_turns_a_new_file_back_into_untracked(git_rw):
+    await git_rw.execute("echo n > /repo/new.txt")
+    await run(git_rw, "add new.txt")
+    await run(git_rw, "restore --staged new.txt")
+    assert (await run(git_rw, "status --porcelain"))[1] == b"?? new.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_a_path_the_source_lacks_is_removed_from_the_target(
+        git_rw, repo_path: Path):
+    # b.txt arrived in the second commit, so the first tree lacks it, and
+    # restoring both targets from that tree removes it from both.
+    assert await run(git_rw, "restore -s HEAD~2 -SW b.txt") == (0, b"", b"")
+    assert not (repo_path / "b.txt").exists()
+    assert (await run(git_rw, "status --porcelain"))[1] == b"D  b.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_a_deleted_file_comes_back(git_rw, repo_path: Path):
+    (repo_path / "a.txt").unlink()
+    await git_rw.execute("ls /repo")
+    assert await run(git_rw, "restore a.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt").read_text() == "one changed\n"

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -15,10 +15,12 @@
 from pathlib import Path
 
 import pytest
-from dulwich.index import ConflictedIndexEntry, Index, IndexEntry
+from dulwich.index import Index, IndexEntry
+from dulwich.repo import Repo
 
 from mirage.commands.cli.builtin.git.restore import index_tree, parse_flags
 from mirage.commands.spec.types import FlagView
+from tests.commands.cli.builtin.git.conftest import conflict_index
 
 
 async def run(ws, line: str) -> tuple[int, bytes, bytes]:
@@ -142,31 +144,27 @@ async def test_a_deleted_file_comes_back(git_rw, repo_path: Path):
     assert (repo_path / "a.txt").read_text() == "one changed\n"
 
 
-def conflict_the_index(repo_path: Path, name: str) -> None:
-    """Turn one staged path into an unmerged one, stages 1 to 3.
-
-    Written straight into the index because reaching this state through
-    the CLI would need a merge, and what is under test is what
-    ``restore`` does to a path that is already conflicted.
-
-    Args:
-        repo_path (Path): the repository's working tree.
-        name (str): the path to conflict, repository-relative.
-    """
-    index = Index(str(repo_path / ".git" / "index"))
-    entry = index[name.encode()]
-    assert isinstance(entry, IndexEntry)
-    index[name.encode()] = ConflictedIndexEntry(ancestor=entry,
-                                                this=entry,
-                                                other=entry)
-    index.write()
-
-
 @pytest.mark.asyncio
 async def test_restoring_the_index_clears_the_conflict_stages(
         git_rw, repo_path: Path):
-    conflict_the_index(repo_path, "a.txt")
+    conflict_index(repo_path, "a.txt")
     assert await run(git_rw, "restore --staged a.txt") == (0, b"", b"")
     index = Index(str(repo_path / ".git" / "index"))
     assert not index.has_conflicts()
     assert isinstance(index[b"a.txt"], IndexEntry)
+
+
+@pytest.mark.asyncio
+async def test_a_raw_tree_is_a_source(git_rw, repo_path: Path):
+    with Repo(str(repo_path)) as repo:
+        tree = repo[b"HEAD"].tree.decode()
+    await git_rw.execute("echo edited > /repo/a.txt")
+    assert await run(git_rw, f"restore --source={tree} a.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt").read_text() == "one changed\n"
+
+
+@pytest.mark.asyncio
+async def test_a_source_that_is_no_tree_is_still_refused(git_rw):
+    code, _out, err = await run(git_rw, "restore --source=nosuch a.txt")
+    assert code == 128
+    assert err == b"fatal: could not resolve nosuch\n"

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -18,8 +18,12 @@ import pytest
 from dulwich.index import Index, IndexEntry
 from dulwich.repo import Repo
 
+from mirage.commands.cli.builtin.git import GIT
 from mirage.commands.cli.builtin.git.restore import index_tree, parse_flags
 from mirage.commands.spec.types import FlagView
+from mirage.resource.disk import DiskResource
+from mirage.types import MountMode
+from mirage.workspace import Workspace
 from tests.commands.cli.builtin.git.conftest import conflict_index
 
 
@@ -473,3 +477,55 @@ async def test_the_bit_is_cleared_the_other_way_too(git_rw):
     listed = await git_rw.execute("ls -l /repo/p.txt")
     assert (listed.stdout or b"").startswith(b"-rw-r--r--")
     assert (await run(git_rw, "status --short"))[1] == b""
+
+
+@pytest.mark.asyncio
+async def test_a_directory_holding_a_nested_mount_is_refused(
+        repo_path: Path, tmp_path: Path):
+    # The tree records a file where the working tree has a directory,
+    # so restoring it means removing the directory whole. A nested
+    # mount inside it is a different backend entirely: readdir merges
+    # it into the listing, so the walk would empty a store no branch
+    # ever recorded and then take its root with it.
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    (inner / "precious.txt").write_text("precious\n", encoding="utf-8")
+    with Workspace(
+        {
+            "/repo/": DiskResource(root=str(repo_path)),
+            "/repo/slot/data/": DiskResource(root=str(inner)),
+        },
+            mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        await ws.execute("printf 'i am a file\n' > /repo/slot")
+        assert (await run(ws, "add slot"))[0] == 0
+        assert (await run(ws, "commit -m slotted"))[0] == 0
+        await ws.execute("rm /repo/slot")
+        await ws.execute("mkdir /repo/slot")
+        code, _out, err = await run(ws, "restore slot")
+        assert code == 128
+        assert err == (b"fatal: cannot remove '/repo/slot': "
+                       b"'/repo/slot/data' is a mount root\n")
+    assert (inner / "precious.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_pruning_a_parent_leaves_a_mount_root_alone(
+        repo_path: Path, tmp_path: Path):
+    # The other removal path: git drops a directory the moment its last
+    # tracked file leaves it, and the mount root is the one directory
+    # that is not git's to drop.
+    inner = tmp_path / "held"
+    inner.mkdir()
+    with Workspace(
+        {
+            "/repo/": DiskResource(root=str(repo_path)),
+            "/repo/slot/data/": DiskResource(root=str(inner)),
+        },
+            mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        await ws.execute("printf 'x\n' > /repo/slot/data/x.txt")
+        assert (await run(ws, "add slot/data/x.txt"))[0] == 0
+        assert (await run(ws, "commit -m inside"))[0] == 0
+        assert (await run(ws, "rm slot/data/x.txt"))[0] == 0
+    assert inner.is_dir()

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -646,3 +646,33 @@ async def test_a_child_under_a_restored_gitlink_keeps_its_working_copy(
             "child.txt").read_text(encoding="utf-8") == "child\n"
     with Repo(str(repo_path)) as repo:
         assert b"sub/child.txt" not in repo.open_index()
+
+
+@pytest.mark.asyncio
+async def test_a_removed_gitlink_takes_an_empty_directory(
+        git_rw, repo_path: Path):
+    # What stands at a 160000 entry is a directory, so removing the
+    # entry is an rmdir: unlink died on it with the index already
+    # written.
+    await git_rw.execute("mkdir /repo/sub")
+    commit_gitlink(repo_path, "sub")
+    assert await run(
+        git_rw,
+        "restore --source=HEAD~1 --staged --worktree sub") == (0, b"", b"")
+    assert not (repo_path / "sub").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_removed_gitlink_keeps_a_directory_that_is_not_empty(
+        git_rw, repo_path: Path):
+    # git warns and goes on rather than failing: the checkout succeeded,
+    # and what is left is a directory it will not empty for anyone.
+    await git_rw.execute("mkdir /repo/sub && echo keep > /repo/sub/keep.txt")
+    commit_gitlink(repo_path, "sub")
+    code, out, err = await run(
+        git_rw, "restore --source=HEAD~1 --staged "
+        "--worktree sub")
+    assert (code, out) == (0, b"")
+    assert err == b"warning: unable to rmdir 'sub': Directory not empty\n"
+    assert (repo_path / "sub" /
+            "keep.txt").read_text(encoding="utf-8") == "keep\n"

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -18,9 +18,7 @@ import pytest
 from dulwich.index import Index, IndexEntry
 from dulwich.repo import Repo
 
-from mirage.commands.cli.builtin.git.restore import (index_tree,
-                                                     linked_ancestor,
-                                                     parse_flags)
+from mirage.commands.cli.builtin.git.restore import index_tree, parse_flags
 from mirage.commands.spec.types import FlagView
 from tests.commands.cli.builtin.git.conftest import conflict_index
 
@@ -363,27 +361,6 @@ async def test_a_worktree_restore_before_the_first_commit_still_goes(
     assert (await unborn_rw.execute("cat /repo/f.txt")).stdout == b"hi\n"
 
 
-def test_a_link_above_the_entry_is_found():
-
-    class Links:
-        """A link view holding one link, at ``/repo/slot``."""
-
-        def stat_at(self, path: str):
-            """What the namespace holds at a path, None when no link.
-
-            Args:
-                path (str): absolute virtual path.
-            """
-            return object() if path == "/repo/slot" else None
-
-    assert linked_ancestor("/repo", "slot/child", Links()) == "/repo/slot"
-    # The link itself is not an ancestor of itself, and a path with no
-    # link above it has none.
-    assert linked_ancestor("/repo", "slot", Links()) is None
-    assert linked_ancestor("/repo", "other/child", Links()) is None
-    assert linked_ancestor("/repo", "slot/child", None) is None
-
-
 @pytest.mark.asyncio
 async def test_a_link_standing_where_a_directory_belongs_is_replaced(
         git_rw, repo_path: Path):
@@ -436,3 +413,32 @@ async def test_a_bare_tag_id_still_names_a_source_tree(git_rw,
     # unwraps it, so `--source=<tag-id>` reads what `--source=v1` reads.
     assert await run(git_rw, f"restore --source={held} a.txt") == (0, b"", b"")
     assert (repo_path / "a.txt").read_text() == "one changed\n"
+
+
+@pytest.mark.asyncio
+async def test_a_file_standing_where_a_directory_belongs_is_replaced(git_rw):
+    # The symlink case's other half, and the commoner one: an untracked
+    # regular file on the way to the entry. git's create_directories
+    # unlinks any leading non-directory and makes the directory, so the
+    # restore succeeds and the file is gone. Left unhandled, the write
+    # failed with a raw ENOTDIR the caller could do nothing with.
+    await git_rw.execute("mkdir /repo/slot && echo c > /repo/slot/child")
+    assert (await run(git_rw, "add slot/child"))[0] == 0
+    assert (await run(git_rw, "commit -m child"))[0] == 0
+    await git_rw.execute("rm -rf /repo/slot && echo untracked > /repo/slot")
+    assert await run(git_rw, "restore slot/child") == (0, b"", b"")
+    assert (await git_rw.execute("cat /repo/slot/child")).stdout == b"c\n"
+
+
+@pytest.mark.asyncio
+async def test_a_removal_is_not_attempted_through_a_file_either(git_rw):
+    # The removal direction takes it the other way, exactly as it takes
+    # a link: git checks the leading path and removes nothing, so the
+    # untracked file standing there is left alone.
+    await git_rw.execute("mkdir /repo/slot && echo c > /repo/slot/child")
+    assert (await run(git_rw, "add slot/child"))[0] == 0
+    assert (await run(git_rw, "commit -m child"))[0] == 0
+    await git_rw.execute("rm -rf /repo/slot && echo untracked > /repo/slot")
+    assert await run(git_rw,
+                     "restore --source=HEAD~1 slot/child") == (0, b"", b"")
+    assert (await git_rw.execute("cat /repo/slot")).stdout == b"untracked\n"

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -18,7 +18,9 @@ import pytest
 from dulwich.index import Index, IndexEntry
 from dulwich.repo import Repo
 
-from mirage.commands.cli.builtin.git.restore import index_tree, parse_flags
+from mirage.commands.cli.builtin.git.restore import (index_tree,
+                                                     linked_ancestor,
+                                                     parse_flags)
 from mirage.commands.spec.types import FlagView
 from tests.commands.cli.builtin.git.conftest import conflict_index
 
@@ -359,3 +361,78 @@ async def test_a_worktree_restore_before_the_first_commit_still_goes(
     # first commit, so only the implicit HEAD source has nothing to read.
     assert await run(unborn_rw, "restore f.txt") == (0, b"", b"")
     assert (await unborn_rw.execute("cat /repo/f.txt")).stdout == b"hi\n"
+
+
+def test_a_link_above_the_entry_is_found():
+
+    class Links:
+        """A link view holding one link, at ``/repo/slot``."""
+
+        def stat_at(self, path: str):
+            """What the namespace holds at a path, None when no link.
+
+            Args:
+                path (str): absolute virtual path.
+            """
+            return object() if path == "/repo/slot" else None
+
+    assert linked_ancestor("/repo", "slot/child", Links()) == "/repo/slot"
+    # The link itself is not an ancestor of itself, and a path with no
+    # link above it has none.
+    assert linked_ancestor("/repo", "slot", Links()) is None
+    assert linked_ancestor("/repo", "other/child", Links()) is None
+    assert linked_ancestor("/repo", "slot/child", None) is None
+
+
+@pytest.mark.asyncio
+async def test_a_link_standing_where_a_directory_belongs_is_replaced(
+        git_rw, repo_path: Path):
+    await git_rw.execute("mkdir /repo/slot && echo c > /repo/slot/child")
+    await run(git_rw, "add -A")
+    await run(git_rw, "commit -m nested")
+    await git_rw.execute("rm -r /repo/slot && mkdir /repo/elsewhere")
+    await git_rw.execute("echo old > /repo/elsewhere/child")
+    await git_rw.execute("ln -s elsewhere /repo/slot")
+    assert await run(git_rw, "restore slot/child") == (0, b"", b"")
+    # git replaces the link with the directory the entry needs. Writing
+    # through it would have landed the content in elsewhere/child, a
+    # file no branch named, and left the link in place.
+    assert (repo_path / "slot" / "child").read_text() == "c\n"
+    assert (repo_path / "elsewhere" / "child").read_text() == "old\n"
+    # A link is namespace state, so the disk mount never held one:
+    # whether it is gone is a question for the namespace.
+    assert (await git_rw.execute("readlink /repo/slot")).exit_code != 0
+
+
+@pytest.mark.asyncio
+async def test_a_removal_is_not_attempted_through_a_link(
+        git_rw, repo_path: Path):
+    await git_rw.execute("mkdir /repo/slot && echo c > /repo/slot/child")
+    await run(git_rw, "add -A")
+    await run(git_rw, "commit -m nested")
+    await git_rw.execute("rm -r /repo/slot && mkdir /repo/elsewhere")
+    await git_rw.execute("echo old > /repo/elsewhere/child")
+    await git_rw.execute("ln -s elsewhere /repo/slot")
+    # HEAD~1 predates the entry, so restoring from it removes the path.
+    assert await run(git_rw,
+                     "restore --source=HEAD~1 slot/child") == (0, b"", b"")
+    # The source does not hold the path, so the entry would be removed;
+    # the unlink would resolve past the link and delete a file inside
+    # whatever it points at. git checks the leading path and removes
+    # nothing, link and target both left as they stand.
+    assert (repo_path / "elsewhere" / "child").read_text() == "old\n"
+    told = await git_rw.execute("readlink /repo/slot")
+    assert (told.exit_code, told.stdout) == (0, b"elsewhere\n")
+
+
+@pytest.mark.asyncio
+async def test_a_bare_tag_id_still_names_a_source_tree(git_rw,
+                                                       repo_path: Path):
+    await git_rw.execute("git -C /repo tag -a v1 -m annotated")
+    with Repo(str(repo_path)) as repo:
+        held = repo.refs[b"refs/tags/v1"].decode()
+    await git_rw.execute("echo edited > /repo/a.txt")
+    # The id names the tag object itself, which is no tree-ish; a source
+    # unwraps it, so `--source=<tag-id>` reads what `--source=v1` reads.
+    assert await run(git_rw, f"restore --source={held} a.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt").read_text() == "one changed\n"

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -529,3 +529,60 @@ async def test_pruning_a_parent_leaves_a_mount_root_alone(
         assert (await run(ws, "commit -m inside"))[0] == 0
         assert (await run(ws, "rm slot/data/x.txt"))[0] == 0
     assert inner.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_the_index_waits_for_the_worktree_pass_to_be_possible(
+        repo_path: Path, tmp_path: Path):
+    # -SW stages first and restores after, so a refusal in the second
+    # pass used to leave the index moved and the working tree exactly
+    # as it was: a fatal that changed something, which this verb has no
+    # wording for.
+    inner = tmp_path / "kept"
+    inner.mkdir()
+    (inner / "precious.txt").write_text("precious\n", encoding="utf-8")
+    with Workspace(
+        {
+            "/repo/": DiskResource(root=str(repo_path)),
+            "/repo/slot/data/": DiskResource(root=str(inner)),
+        },
+            mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        await ws.execute("printf 'i am a file\n' > /repo/slot")
+        assert (await run(ws, "add slot"))[0] == 0
+        assert (await run(ws, "commit -m slotted"))[0] == 0
+        await ws.execute("rm /repo/slot")
+        await ws.execute("mkdir /repo/slot")
+        assert (await run(ws, "rm --cached slot"))[0] == 0
+        before = (await run(ws, "status --short"))[1]
+        assert before.startswith(b"D  slot\n")
+        code, _out, err = await run(ws, "restore -SW slot")
+        assert code == 128
+        assert err == (b"fatal: cannot remove '/repo/slot': "
+                       b"'/repo/slot/data' is a mount root\n")
+        assert (await run(ws, "status --short"))[1] == before
+    assert (inner / "precious.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_the_staged_half_alone_is_untouched_by_the_preflight(
+        repo_path: Path, tmp_path: Path):
+    # --staged never touches the working tree, so the mount is not in
+    # its way and the line must still go through.
+    inner = tmp_path / "spare"
+    inner.mkdir()
+    with Workspace(
+        {
+            "/repo/": DiskResource(root=str(repo_path)),
+            "/repo/slot/data/": DiskResource(root=str(inner)),
+        },
+            mode=MountMode.WRITE) as ws:
+        ws.register_cli("git", GIT)
+        await ws.execute("printf 'i am a file\n' > /repo/slot")
+        assert (await run(ws, "add slot"))[0] == 0
+        assert (await run(ws, "commit -m slotted"))[0] == 0
+        await ws.execute("rm /repo/slot")
+        await ws.execute("mkdir /repo/slot")
+        assert (await run(ws, "rm --cached slot"))[0] == 0
+        assert await run(ws, "restore --staged slot") == (0, b"", b"")
+        assert (await run(ws, "status --short"))[1].startswith(b" D slot\n")

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -256,3 +256,72 @@ async def test_a_source_holding_the_conflict_restores_it(
     assert await run(git_rw, "restore --staged c.txt") == (0, b"", b"")
     index = Index(str(repo_path / ".git" / "index"))
     assert not index.has_conflicts()
+
+
+@pytest.mark.asyncio
+async def test_a_tree_peel_is_a_source(git_rw, repo_path: Path):
+    # git's own help says --source <tree-ish>, and a peel is the
+    # ordinary way to spell one. Probed on git 2.50.1: exit 0.
+    await git_rw.execute("echo edited > /repo/a.txt")
+    assert await run(git_rw,
+                     "restore --source=HEAD^{tree} a.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt").read_text() == "one changed\n"
+
+
+@pytest.mark.asyncio
+async def test_a_tag_peel_is_a_source(git_rw, repo_path: Path):
+    assert (await run(git_rw, "tag v1"))[0] == 0
+    await git_rw.execute("echo edited > /repo/a.txt")
+    assert await run(git_rw,
+                     "restore --source=v1^{tree} a.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt").read_text() == "one changed\n"
+
+
+@pytest.mark.asyncio
+async def test_a_subtree_at_a_path_is_a_source(git_rw, repo_path: Path):
+    (repo_path / "sub").mkdir()
+    (repo_path / "sub" / "a.txt").write_text("nested\n", encoding="utf-8")
+    assert (await run(git_rw, "add sub"))[0] == 0
+    assert (await run(git_rw, "commit -m nested"))[0] == 0
+    assert await run(git_rw,
+                     "restore --source=HEAD:sub a.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt").read_text() == "nested\n"
+
+
+@pytest.mark.asyncio
+async def test_a_source_that_is_no_tree_is_named_by_its_id(git_rw):
+    # git reports the object it reached, not the spelling: the name
+    # resolved fine and what it found was the problem.
+    code, _out, err = await run(git_rw, "restore --source=HEAD:a.txt a.txt")
+    assert code == 128
+    assert err.startswith(b"fatal: unable to read tree (")
+    assert err.endswith(b")\n")
+
+
+@pytest.mark.asyncio
+async def test_a_peel_that_resolves_to_nothing_is_named_as_typed(git_rw):
+    code, _out, err = await run(git_rw, "restore --source=nosuch^{tree} a.txt")
+    assert code == 128
+    assert err == b"fatal: could not resolve nosuch^{tree}\n"
+
+
+@pytest.mark.asyncio
+async def test_a_file_replaces_a_directory_an_untracked_file_holds(
+        git_rw, repo_path: Path):
+    # The source keeps a.txt as a file, the index keeps a.txt/child, and
+    # an untracked a.txt/keep holds the directory open. git replaces the
+    # whole directory here, untracked child and all, and exits 0
+    # (probed on git 2.50.1); the write would otherwise fail with the
+    # index already changed.
+    with Repo(str(repo_path)) as repo:
+        tree = repo[b"HEAD"].tree.decode()
+    await run(git_rw, "rm --cached a.txt")
+    (repo_path / "a.txt").unlink()
+    (repo_path / "a.txt").mkdir()
+    (repo_path / "a.txt" / "child").write_text("inner\n", encoding="utf-8")
+    await run(git_rw, "add a.txt/child")
+    (repo_path / "a.txt" / "keep").write_text("untracked\n", encoding="utf-8")
+    assert await run(git_rw,
+                     f"restore --source={tree} -SW a.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt").is_file()
+    assert (repo_path / "a.txt").read_text() == "one changed\n"

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -627,3 +627,22 @@ async def test_a_file_standing_where_a_gitlink_belongs_is_replaced(
     await git_rw.execute("printf 'i am a file\n' > /repo/sub")
     assert await run(git_rw, "restore sub") == (0, b"", b"")
     assert (repo_path / "sub").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_a_child_under_a_restored_gitlink_keeps_its_working_copy(
+        git_rw, repo_path: Path):
+    # Restoring the gitlink drops the child's index entry and leaves
+    # the file alone: git writes the directory and touches nothing
+    # under it. Removing it here loses content nothing has a copy of,
+    # since the source tree never held it.
+    await git_rw.execute("mkdir /repo/sub && echo keep > /repo/sub/keep.txt")
+    commit_gitlink(repo_path, "sub")
+    await git_rw.execute("echo child > /repo/sub/child.txt")
+    assert (await run(git_rw, "add sub/child.txt"))[0] == 0
+    assert await run(git_rw,
+                     "restore --staged --worktree sub") == (0, b"", b"")
+    assert (repo_path / "sub" /
+            "child.txt").read_text(encoding="utf-8") == "child\n"
+    with Repo(str(repo_path)) as repo:
+        assert b"sub/child.txt" not in repo.open_index()

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -24,7 +24,8 @@ from mirage.commands.spec.types import FlagView
 from mirage.resource.disk import DiskResource
 from mirage.types import MountMode
 from mirage.workspace import Workspace
-from tests.commands.cli.builtin.git.conftest import conflict_index
+from tests.commands.cli.builtin.git.conftest import (commit_gitlink,
+                                                     conflict_index)
 
 
 async def run(ws, line: str) -> tuple[int, bytes, bytes]:
@@ -586,3 +587,43 @@ async def test_the_staged_half_alone_is_untouched_by_the_preflight(
         assert (await run(ws, "rm --cached slot"))[0] == 0
         assert await run(ws, "restore --staged slot") == (0, b"", b"")
         assert (await run(ws, "status --short"))[1].startswith(b" D slot\n")
+
+
+@pytest.mark.asyncio
+async def test_a_gitlink_keeps_the_working_tree_it_already_has(
+        git_rw, repo_path: Path):
+    # A 160000 entry names a commit in another repository. git checks
+    # out no submodule content without --recurse-submodules, so all the
+    # entry asks of the working tree is that a directory stand at the
+    # name: reading it as a blob wrote an empty file over the whole
+    # directory, untracked work included.
+    await git_rw.execute("mkdir /repo/sub && echo keep > /repo/sub/keep.txt")
+    commit_gitlink(repo_path, "sub")
+    assert await run(git_rw, "restore sub") == (0, b"", b"")
+    assert (repo_path / "sub").is_dir()
+    assert (repo_path / "sub" /
+            "keep.txt").read_text(encoding="utf-8") == "keep\n"
+
+
+@pytest.mark.asyncio
+async def test_a_gitlink_with_nothing_there_gets_a_directory(
+        git_rw, repo_path: Path):
+    await git_rw.execute("mkdir /repo/sub && echo keep > /repo/sub/keep.txt")
+    commit_gitlink(repo_path, "sub")
+    await git_rw.execute("rm -rf /repo/sub")
+    assert await run(git_rw, "restore sub") == (0, b"", b"")
+    assert (repo_path / "sub").is_dir()
+    assert sorted(p.name for p in (repo_path / "sub").iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_a_file_standing_where_a_gitlink_belongs_is_replaced(
+        git_rw, repo_path: Path):
+    # git's own answer: the file goes and an empty directory takes its
+    # place, which is what it does to any non-directory at the name.
+    await git_rw.execute("mkdir /repo/sub && echo keep > /repo/sub/keep.txt")
+    commit_gitlink(repo_path, "sub")
+    await git_rw.execute("rm -rf /repo/sub")
+    await git_rw.execute("printf 'i am a file\n' > /repo/sub")
+    assert await run(git_rw, "restore sub") == (0, b"", b"")
+    assert (repo_path / "sub").is_dir()

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -206,3 +206,53 @@ async def test_a_file_source_replaces_a_directory(git_rw, repo_path: Path):
                      f"restore --source={tree} -SW a.txt") == (0, b"", b"")
     assert (repo_path / "a.txt").read_text() == "one changed\n"
     assert not (repo_path / "a.txt" / "child").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_conflict_the_source_cannot_put_back_is_refused(
+        git_rw, repo_path: Path):
+    # Added on this side only, so HEAD holds nothing to restore from
+    # and the index holds no stage 0 either. git names the path rather
+    # than reporting a pathspec it does not recognise.
+    (repo_path / "c.txt").write_text("mine\n", encoding="utf-8")
+    assert (await run(git_rw, "add c.txt"))[0] == 0
+    conflict_index(repo_path, "c.txt")
+    code, _out, err = await run(git_rw, "restore --staged c.txt")
+    assert code == 1
+    assert err == b"error: path 'c.txt' is unmerged\n"
+    assert Index(str(repo_path / ".git" / "index")).has_conflicts()
+
+
+@pytest.mark.asyncio
+async def test_restoring_a_conflict_from_the_index_is_refused(
+        git_rw, repo_path: Path):
+    # The working tree restores from the index, and an unmerged path
+    # has no stage 0 there whatever HEAD holds.
+    conflict_index(repo_path, "a.txt")
+    code, _out, err = await run(git_rw, "restore a.txt")
+    assert code == 1
+    assert err == b"error: path 'a.txt' is unmerged\n"
+
+
+@pytest.mark.asyncio
+async def test_every_unrestorable_conflict_is_named(git_rw, repo_path: Path):
+    conflict_index(repo_path, "a.txt")
+    conflict_index(repo_path, "b.txt")
+    code, _out, err = await run(git_rw, "restore a.txt b.txt")
+    assert code == 1
+    assert err == (b"error: path 'a.txt' is unmerged\n"
+                   b"error: path 'b.txt' is unmerged\n")
+
+
+@pytest.mark.asyncio
+async def test_a_source_holding_the_conflict_restores_it(
+        git_rw, repo_path: Path):
+    (repo_path / "c.txt").write_text("mine\n", encoding="utf-8")
+    assert (await run(git_rw, "add c.txt"))[0] == 0
+    assert (await run(git_rw, "commit -m added"))[0] == 0
+    (repo_path / "c.txt").write_text("theirs\n", encoding="utf-8")
+    assert (await run(git_rw, "add c.txt"))[0] == 0
+    conflict_index(repo_path, "c.txt")
+    assert await run(git_rw, "restore --staged c.txt") == (0, b"", b"")
+    index = Index(str(repo_path / ".git" / "index"))
+    assert not index.has_conflicts()

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -325,3 +325,37 @@ async def test_a_file_replaces_a_directory_an_untracked_file_holds(
                      f"restore --source={tree} -SW a.txt") == (0, b"", b"")
     assert (repo_path / "a.txt").is_file()
     assert (repo_path / "a.txt").read_text() == "one changed\n"
+
+
+@pytest.mark.asyncio
+async def test_a_staged_restore_before_the_first_commit_is_refused(unborn_rw):
+    await unborn_rw.execute("echo hi > /repo/f.txt")
+    await run(unborn_rw, "add f.txt")
+    assert await run(
+        unborn_rw,
+        "restore --staged f.txt") == (128, b"",
+                                      b"fatal: could not resolve HEAD\n")
+    # The refusal comes before the index is touched: reading the
+    # unborn HEAD as an empty tree unstaged the path and said nothing.
+    assert await run(unborn_rw, "status --short") == (0, b"A  f.txt\n", b"")
+
+
+@pytest.mark.asyncio
+async def test_staged_and_worktree_together_refuse_the_same_way(unborn_rw):
+    await unborn_rw.execute("echo hi > /repo/f.txt")
+    await run(unborn_rw, "add f.txt")
+    assert await run(
+        unborn_rw,
+        "restore -SW f.txt") == (128, b"", b"fatal: could not resolve HEAD\n")
+
+
+@pytest.mark.asyncio
+async def test_a_worktree_restore_before_the_first_commit_still_goes(
+        unborn_rw):
+    await unborn_rw.execute("echo hi > /repo/f.txt")
+    await run(unborn_rw, "add f.txt")
+    await unborn_rw.execute("echo edited > /repo/f.txt")
+    # The working tree restores from the index, which exists before the
+    # first commit, so only the implicit HEAD source has nothing to read.
+    assert await run(unborn_rw, "restore f.txt") == (0, b"", b"")
+    assert (await unborn_rw.execute("cat /repo/f.txt")).stdout == b"hi\n"

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -168,3 +168,41 @@ async def test_a_source_that_is_no_tree_is_still_refused(git_rw):
     code, _out, err = await run(git_rw, "restore --source=nosuch a.txt")
     assert code == 128
     assert err == b"fatal: could not resolve nosuch\n"
+
+
+@pytest.mark.asyncio
+async def test_a_directory_source_replaces_a_file(git_rw, repo_path: Path):
+    await run(git_rw, "rm --cached a.txt")
+    (repo_path / "a.txt").unlink()
+    (repo_path / "a.txt").mkdir()
+    (repo_path / "a.txt" / "child").write_text("inner\n", encoding="utf-8")
+    await run(git_rw, "add a.txt")
+    await run(git_rw, "commit -m dir")
+    with Repo(str(repo_path)) as repo:
+        tree = repo[b"HEAD"].tree.decode()
+    await run(git_rw, "rm -r --cached a.txt")
+    (repo_path / "a.txt" / "child").unlink()
+    (repo_path / "a.txt").rmdir()
+    (repo_path / "a.txt").write_text("flat\n", encoding="utf-8")
+    await run(git_rw, "add a.txt")
+    assert await run(git_rw,
+                     f"restore --source={tree} -SW a.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt" / "child").read_text() == "inner\n"
+    # The source is HEAD's tree, so a restore that reached both the index
+    # and the working tree leaves nothing for status to report.
+    assert (await run(git_rw, "status --porcelain"))[1] == b""
+
+
+@pytest.mark.asyncio
+async def test_a_file_source_replaces_a_directory(git_rw, repo_path: Path):
+    with Repo(str(repo_path)) as repo:
+        tree = repo[b"HEAD"].tree.decode()
+    await run(git_rw, "rm --cached a.txt")
+    (repo_path / "a.txt").unlink()
+    (repo_path / "a.txt").mkdir()
+    (repo_path / "a.txt" / "child").write_text("inner\n", encoding="utf-8")
+    await run(git_rw, "add a.txt")
+    assert await run(git_rw,
+                     f"restore --source={tree} -SW a.txt") == (0, b"", b"")
+    assert (repo_path / "a.txt").read_text() == "one changed\n"
+    assert not (repo_path / "a.txt" / "child").exists()

--- a/python/tests/commands/cli/builtin/git/test_restore.py
+++ b/python/tests/commands/cli/builtin/git/test_restore.py
@@ -442,3 +442,34 @@ async def test_a_removal_is_not_attempted_through_a_file_either(git_rw):
     assert await run(git_rw,
                      "restore --source=HEAD~1 slot/child") == (0, b"", b"")
     assert (await git_rw.execute("cat /repo/slot")).stdout == b"untracked\n"
+
+
+@pytest.mark.asyncio
+async def test_the_executable_bit_comes_back_with_the_content(git_rw):
+    # git records exactly one permission bit and restores it. Writing
+    # the bytes alone left the file unrunnable and left status calling
+    # it modified for ever, since the mode is half of what the index
+    # staged.
+    await git_rw.execute("printf '#!/bin/sh\n' > /repo/s.sh")
+    await git_rw.execute("chmod 755 /repo/s.sh")
+    assert (await run(git_rw, "add s.sh"))[0] == 0
+    assert (await run(git_rw, "commit -m script"))[0] == 0
+    await git_rw.execute("chmod 644 /repo/s.sh")
+    assert (await run(git_rw, "status --short"))[1] == b" M s.sh\n"
+    assert await run(git_rw, "restore s.sh") == (0, b"", b"")
+    listed = await git_rw.execute("ls -l /repo/s.sh")
+    assert (listed.stdout or b"").startswith(b"-rwxr-xr-x")
+    assert (await run(git_rw, "status --short"))[1] == b""
+
+
+@pytest.mark.asyncio
+async def test_the_bit_is_cleared_the_other_way_too(git_rw):
+    await git_rw.execute("printf 'plain\n' > /repo/p.txt")
+    assert (await run(git_rw, "add p.txt"))[0] == 0
+    assert (await run(git_rw, "commit -m plain"))[0] == 0
+    await git_rw.execute("chmod 755 /repo/p.txt")
+    assert (await run(git_rw, "status --short"))[1] == b" M p.txt\n"
+    assert await run(git_rw, "restore p.txt") == (0, b"", b"")
+    listed = await git_rw.execute("ls -l /repo/p.txt")
+    assert (listed.stdout or b"").startswith(b"-rw-r--r--")
+    assert (await run(git_rw, "status --short"))[1] == b""

--- a/python/tests/commands/cli/builtin/git/test_revparse.py
+++ b/python/tests/commands/cli/builtin/git/test_revparse.py
@@ -231,3 +231,50 @@ async def test_a_lightweight_tag_has_no_tag_to_peel_to(git_rw):
     repo = await open_repo(git_rw.dispatch, location)
     with pytest.raises(AmbiguousArgumentError):
         resolve_object(repo, "light^{tag}")
+
+
+@pytest.mark.asyncio
+async def test_a_bare_tag_id_is_the_tag_object(git_rw):
+    await git_rw.execute("git -C /repo tag -a v1 -m annotated")
+    location = await discover(*repo_facts(git_rw), "/repo")
+    repo = await open_repo(git_rw.dispatch, location)
+    held = repo.refs[b"refs/tags/v1"]
+    # git reads a bare id as that exact object, so the commit-ish
+    # reading must not peel it: ``git tag nested <tag-id>`` records the
+    # tag, which is the nested tag git warns about.
+    found = resolve_object(repo, held.decode())
+    assert found.type_name == b"tag"
+    assert found.id == held
+
+
+@pytest.mark.asyncio
+async def test_a_tag_name_still_peels_where_an_id_does_not(git_rw):
+    await git_rw.execute("git -C /repo tag -a v1 -m annotated")
+    location = await discover(*repo_facts(git_rw), "/repo")
+    repo = await open_repo(git_rw.dispatch, location)
+    # The split is git's own and is observable: a name resolves as a
+    # commit-ish, an id as itself.
+    assert resolve_object(repo, "v1").type_name == b"commit"
+
+
+@pytest.mark.asyncio
+async def test_a_path_reads_through_a_bare_tag_id(git_rw):
+    await git_rw.execute("git -C /repo tag -a v1 -m annotated")
+    location = await discover(*repo_facts(git_rw), "/repo")
+    repo = await open_repo(git_rw.dispatch, location)
+    held = repo.refs[b"refs/tags/v1"].decode()
+    # The rev half of a path expression is a tree-ish, so the tag comes
+    # off on the way exactly as it does for ``v1:a.txt``.
+    found = resolve_object(repo, f"{held}:a.txt")
+    assert found.type_name == b"blob"
+    assert found.id == resolve_object(repo, "v1:a.txt").id
+
+
+@pytest.mark.asyncio
+async def test_a_peel_through_a_bare_tag_id_still_reaches_the_tree(git_rw):
+    await git_rw.execute("git -C /repo tag -a v1 -m annotated")
+    location = await discover(*repo_facts(git_rw), "/repo")
+    repo = await open_repo(git_rw.dispatch, location)
+    held = repo.refs[b"refs/tags/v1"].decode()
+    assert resolve_object(repo, f"{held}^{{tree}}").type_name == b"tree"
+    assert resolve_object(repo, f"{held}^{{}}").type_name == b"commit"

--- a/python/tests/commands/cli/builtin/git/test_revparse.py
+++ b/python/tests/commands/cli/builtin/git/test_revparse.py
@@ -195,3 +195,39 @@ async def test_a_peel_naming_the_wrong_type_is_refused(workspace):
     repo = await open_repo(workspace.dispatch, location)
     with pytest.raises(AmbiguousArgumentError):
         resolve_object(repo, "HEAD^{blob}")
+
+
+@pytest.mark.asyncio
+async def test_a_typed_tag_peel_is_the_tag_itself(git_rw):
+    await git_rw.execute("git -C /repo tag -a v1 -m annotated")
+    location = await discover(*repo_facts(git_rw), "/repo")
+    repo = await open_repo(git_rw.dispatch, location)
+    found = resolve_object(repo, "v1^{tag}")
+    assert found.type_name == b"tag"
+    assert found.id == repo.refs[b"refs/tags/v1"]
+
+
+@pytest.mark.asyncio
+async def test_a_bare_peel_still_unwraps_the_tag(git_rw):
+    await git_rw.execute("git -C /repo tag -a v1 -m annotated")
+    location = await discover(*repo_facts(git_rw), "/repo")
+    repo = await open_repo(git_rw.dispatch, location)
+    assert resolve_object(repo, "v1^{}").id == resolve_commit(repo, "HEAD").id
+
+
+@pytest.mark.asyncio
+async def test_a_commit_peel_still_unwraps_the_tag(git_rw):
+    await git_rw.execute("git -C /repo tag -a v1 -m annotated")
+    location = await discover(*repo_facts(git_rw), "/repo")
+    repo = await open_repo(git_rw.dispatch, location)
+    found = resolve_object(repo, "v1^{commit}")
+    assert found.id == resolve_commit(repo, "HEAD").id
+
+
+@pytest.mark.asyncio
+async def test_a_lightweight_tag_has_no_tag_to_peel_to(git_rw):
+    await git_rw.execute("git -C /repo tag light")
+    location = await discover(*repo_facts(git_rw), "/repo")
+    repo = await open_repo(git_rw.dispatch, location)
+    with pytest.raises(AmbiguousArgumentError):
+        resolve_object(repo, "light^{tag}")

--- a/python/tests/commands/cli/builtin/git/test_revparse.py
+++ b/python/tests/commands/cli/builtin/git/test_revparse.py
@@ -20,26 +20,26 @@ from mirage.commands.cli.builtin.git.repo import open_repo
 from mirage.commands.cli.builtin.git.revparse import (object_at,
                                                       resolve_commit,
                                                       resolve_object,
-                                                      split_peel,
-                                                      split_revision)
+                                                      split_operators)
+from mirage.commands.cli.builtin.git.types import AncestryStep, PeelStep
 
 from .conftest import repo_facts
 
 
 def test_bare_revision_has_no_steps():
-    base, steps = split_revision("HEAD")
+    base, steps = split_operators("HEAD")
     assert base == "HEAD"
     assert steps == ()
 
 
 def test_bare_suffix_counts_as_one():
-    base, steps = split_revision("HEAD~")
+    base, steps = split_operators("HEAD~")
     assert base == "HEAD"
     assert [(s.first_parent, s.count) for s in steps] == [(True, 1)]
 
 
 def test_numeric_suffix_is_read():
-    _base, steps = split_revision("main~3")
+    _base, steps = split_operators("main~3")
     assert [(s.first_parent, s.count) for s in steps] == [(True, 3)]
 
 
@@ -49,7 +49,7 @@ def test_unicode_digit_suffix_is_not_a_count():
     # both languages. What is left over is not another step either, so
     # the whole expression is refused, which is git's own answer.
     with pytest.raises(AmbiguousArgumentError):
-        split_revision("main~٣")
+        split_operators("main~٣")
 
 
 @pytest.mark.parametrize("revision",
@@ -59,30 +59,30 @@ def test_a_suffix_that_is_not_a_step_is_refused(revision: str):
     # ``HEAD^x`` resolved to ``HEAD^^`` and a tag was written at a
     # commit nobody named.
     with pytest.raises(AmbiguousArgumentError):
-        split_revision(revision)
+        split_operators(revision)
 
 
 @pytest.mark.parametrize(
     "revision",
     ["HEAD^", "HEAD~", "HEAD^0", "HEAD^~", "HEAD~2^2~1", "HEAD^12"])
 def test_the_steps_git_does_take_still_parse(revision: str):
-    split_revision(revision)
+    split_operators(revision)
 
 
 def test_parent_suffix_is_distinguished_from_ancestor():
-    _base, steps = split_revision("HEAD^2")
+    _base, steps = split_operators("HEAD^2")
     assert [(s.first_parent, s.count) for s in steps] == [(False, 2)]
 
 
 def test_suffixes_chain():
-    base, steps = split_revision("HEAD~2^2~1")
+    base, steps = split_operators("HEAD~2^2~1")
     assert base == "HEAD"
     assert [(s.first_parent, s.count)
             for s in steps] == [(True, 2), (False, 2), (True, 1)]
 
 
 def test_a_bare_suffix_string_means_head():
-    base, _steps = split_revision("~1")
+    base, _steps = split_operators("~1")
     assert base == "HEAD"
 
 
@@ -129,23 +129,38 @@ async def test_second_parent_of_a_linear_commit_is_refused(workspace):
         resolve_commit(repo, "HEAD^2")
 
 
-def test_a_revision_with_no_peel_keeps_its_whole_spelling():
-    assert split_peel("HEAD~2") == ("HEAD~2", None)
+def test_a_revision_with_no_peel_carries_only_its_steps():
+    assert split_operators("HEAD~2") == ("HEAD", (AncestryStep(True, 2), ))
 
 
 def test_a_bare_peel_carries_an_empty_type():
-    assert split_peel("v1^{}") == ("v1", "")
+    assert split_operators("v1^{}") == ("v1", (PeelStep(""), ))
 
 
 def test_a_typed_peel_carries_its_word():
-    assert split_peel("HEAD^{tree}") == ("HEAD", "tree")
+    assert split_operators("HEAD^{tree}") == ("HEAD", (PeelStep("tree"), ))
 
 
 def test_a_peel_is_not_an_ancestry_step():
     # Read as one it is `^` with no digits, which means the first
     # parent: the caller was handed another commit without a word.
-    stem, _want = split_peel("HEAD^{tree}")
-    assert split_revision(stem) == ("HEAD", ())
+    _base, ops = split_operators("HEAD^{tree}")
+    assert ops == (PeelStep("tree"), )
+
+
+def test_a_peel_chains_with_the_steps_around_it():
+    # git reads a revision left to right, so a peel is an operator like
+    # any other rather than something that has to come last.
+    assert split_operators("HEAD^{commit}~1") == ("HEAD",
+                                                  (PeelStep("commit"),
+                                                   AncestryStep(True, 1)))
+    assert split_operators("v1~1^{tree}") == ("v1", (AncestryStep(True, 1),
+                                                     PeelStep("tree")))
+
+
+def test_a_peel_that_is_never_closed_is_refused():
+    with pytest.raises(AmbiguousArgumentError):
+        split_operators("HEAD^{commit")
 
 
 @pytest.mark.asyncio
@@ -332,3 +347,35 @@ async def test_a_commit_ish_still_reads_an_object_peel(git_rw):
     # lets ``git branch nb v1^{object}`` work.
     assert resolve_commit(repo, "HEAD^{object}").id == head.id
     assert resolve_commit(repo, "v1^{object}").id == head.id
+
+
+@pytest.mark.asyncio
+async def test_a_peel_followed_by_a_step_walks_from_the_peeled_commit(
+        workspace):
+    # A peel used to be read only at the end of a revision, so every
+    # chain that went on after one was refused although git takes it.
+    location = await discover(*repo_facts(workspace), "/repo")
+    repo = await open_repo(workspace.dispatch, location)
+    assert resolve_commit(repo, "HEAD^{commit}~1").message == b"second"
+    assert resolve_commit(repo, "HEAD^{}^").message == b"second"
+    assert resolve_object(repo, "HEAD^{commit}~1").id == resolve_commit(
+        repo, "HEAD~1").id
+
+
+@pytest.mark.asyncio
+async def test_a_step_followed_by_a_peel_reads_that_commit(workspace):
+    location = await discover(*repo_facts(workspace), "/repo")
+    repo = await open_repo(workspace.dispatch, location)
+    parent = resolve_commit(repo, "HEAD~1")
+    assert resolve_object(repo, "HEAD~1^{tree}").id == parent.tree
+    assert resolve_object(repo, "HEAD^{commit}~1^{tree}").id == parent.tree
+
+
+@pytest.mark.asyncio
+async def test_a_step_off_a_tree_is_refused(workspace):
+    # git dies here too: a tree has no parent, so the step has nothing
+    # to walk.
+    location = await discover(*repo_facts(workspace), "/repo")
+    repo = await open_repo(workspace.dispatch, location)
+    with pytest.raises(AmbiguousArgumentError):
+        resolve_object(repo, "HEAD^{tree}~1")

--- a/python/tests/commands/cli/builtin/git/test_revparse.py
+++ b/python/tests/commands/cli/builtin/git/test_revparse.py
@@ -278,3 +278,40 @@ async def test_a_peel_through_a_bare_tag_id_still_reaches_the_tree(git_rw):
     held = repo.refs[b"refs/tags/v1"].decode()
     assert resolve_object(repo, f"{held}^{{tree}}").type_name == b"tree"
     assert resolve_object(repo, f"{held}^{{}}").type_name == b"commit"
+
+
+@pytest.mark.asyncio
+async def test_an_object_peel_keeps_whatever_type_it_finds(git_rw):
+    await git_rw.execute("git -C /repo tag -a v1 -m annotated")
+    location = await discover(*repo_facts(git_rw), "/repo")
+    repo = await open_repo(git_rw.dispatch, location)
+    # ``^{object}`` is an existence check, not a type: every object
+    # reports a concrete type name, so comparing one against the word
+    # would refuse every expression that spells it.
+    assert resolve_object(repo, "HEAD^{object}").type_name == b"commit"
+    assert resolve_object(repo, "HEAD^{tree}^{object}").type_name == b"tree"
+
+
+@pytest.mark.asyncio
+async def test_an_object_peel_leaves_an_annotated_tag_wrapped(git_rw):
+    await git_rw.execute("git -C /repo tag -a v1 -m annotated")
+    location = await discover(*repo_facts(git_rw), "/repo")
+    repo = await open_repo(git_rw.dispatch, location)
+    # The one thing that separates it from ``^{}``: the named object is
+    # returned, so a tag stays a tag rather than being unwrapped.
+    found = resolve_object(repo, "v1^{object}")
+    assert found.type_name == b"tag"
+    assert found.id == repo.refs[b"refs/tags/v1"]
+    assert resolve_object(repo, "v1^{}").type_name == b"commit"
+
+
+@pytest.mark.asyncio
+async def test_a_commit_ish_still_reads_an_object_peel(git_rw):
+    await git_rw.execute("git -C /repo tag -a v1 -m annotated")
+    location = await discover(*repo_facts(git_rw), "/repo")
+    repo = await open_repo(git_rw.dispatch, location)
+    head = resolve_commit(repo, "HEAD")
+    # A caller that wants a commit takes the wrapper off, which is what
+    # lets ``git branch nb v1^{object}`` work.
+    assert resolve_commit(repo, "HEAD^{object}").id == head.id
+    assert resolve_commit(repo, "v1^{object}").id == head.id

--- a/python/tests/commands/cli/builtin/git/test_revparse.py
+++ b/python/tests/commands/cli/builtin/git/test_revparse.py
@@ -17,7 +17,10 @@ import pytest
 from mirage.commands.cli.builtin.git.discover import discover
 from mirage.commands.cli.builtin.git.errors import AmbiguousArgumentError
 from mirage.commands.cli.builtin.git.repo import open_repo
-from mirage.commands.cli.builtin.git.revparse import (resolve_commit,
+from mirage.commands.cli.builtin.git.revparse import (object_at,
+                                                      resolve_commit,
+                                                      resolve_object,
+                                                      split_peel,
                                                       split_revision)
 
 from .conftest import repo_facts
@@ -107,3 +110,88 @@ async def test_second_parent_of_a_linear_commit_is_refused(workspace):
     repo = await open_repo(workspace.dispatch, location)
     with pytest.raises(AmbiguousArgumentError):
         resolve_commit(repo, "HEAD^2")
+
+
+def test_a_revision_with_no_peel_keeps_its_whole_spelling():
+    assert split_peel("HEAD~2") == ("HEAD~2", None)
+
+
+def test_a_bare_peel_carries_an_empty_type():
+    assert split_peel("v1^{}") == ("v1", "")
+
+
+def test_a_typed_peel_carries_its_word():
+    assert split_peel("HEAD^{tree}") == ("HEAD", "tree")
+
+
+def test_a_peel_is_not_an_ancestry_step():
+    # Read as one it is `^` with no digits, which means the first
+    # parent: the caller was handed another commit without a word.
+    stem, _want = split_peel("HEAD^{tree}")
+    assert split_revision(stem) == ("HEAD", ())
+
+
+@pytest.mark.asyncio
+async def test_a_peel_to_a_commit_is_the_commit(workspace):
+    location = await discover(*repo_facts(workspace), "/repo")
+    repo = await open_repo(workspace.dispatch, location)
+    head = resolve_commit(repo, "HEAD")
+    assert resolve_commit(repo, "HEAD^{}").id == head.id
+    assert resolve_commit(repo, "HEAD^{commit}").id == head.id
+
+
+@pytest.mark.asyncio
+async def test_a_peel_to_another_type_is_no_commit(workspace):
+    location = await discover(*repo_facts(workspace), "/repo")
+    repo = await open_repo(workspace.dispatch, location)
+    with pytest.raises(AmbiguousArgumentError):
+        resolve_commit(repo, "HEAD^{tree}")
+
+
+@pytest.mark.asyncio
+async def test_an_object_expression_reaches_a_tree(workspace):
+    location = await discover(*repo_facts(workspace), "/repo")
+    repo = await open_repo(workspace.dispatch, location)
+    head = resolve_commit(repo, "HEAD")
+    assert resolve_object(repo, "HEAD^{tree}").id == head.tree
+
+
+@pytest.mark.asyncio
+async def test_an_object_expression_reaches_a_blob(workspace):
+    location = await discover(*repo_facts(workspace), "/repo")
+    repo = await open_repo(workspace.dispatch, location)
+    found = resolve_object(repo, "HEAD:a.txt")
+    assert found.type_name == b"blob"
+    assert found.data == b"one changed\n"
+
+
+@pytest.mark.asyncio
+async def test_an_ancestry_suffix_still_reads_inside_a_path(workspace):
+    location = await discover(*repo_facts(workspace), "/repo")
+    repo = await open_repo(workspace.dispatch, location)
+    assert resolve_object(repo, "HEAD~2:a.txt").data == b"one\n"
+
+
+@pytest.mark.asyncio
+async def test_a_bare_object_id_is_itself(workspace):
+    location = await discover(*repo_facts(workspace), "/repo")
+    repo = await open_repo(workspace.dispatch, location)
+    tree = resolve_commit(repo, "HEAD").tree.decode()
+    assert resolve_object(repo, tree).id.decode() == tree
+    assert object_at(repo, tree[:7]).id.decode() == tree
+
+
+@pytest.mark.asyncio
+async def test_a_path_the_tree_lacks_is_unresolvable(workspace):
+    location = await discover(*repo_facts(workspace), "/repo")
+    repo = await open_repo(workspace.dispatch, location)
+    with pytest.raises(AmbiguousArgumentError):
+        resolve_object(repo, "HEAD:nosuch")
+
+
+@pytest.mark.asyncio
+async def test_a_peel_naming_the_wrong_type_is_refused(workspace):
+    location = await discover(*repo_facts(workspace), "/repo")
+    repo = await open_repo(workspace.dispatch, location)
+    with pytest.raises(AmbiguousArgumentError):
+        resolve_object(repo, "HEAD^{blob}")

--- a/python/tests/commands/cli/builtin/git/test_revparse.py
+++ b/python/tests/commands/cli/builtin/git/test_revparse.py
@@ -45,11 +45,28 @@ def test_numeric_suffix_is_read():
 
 def test_unicode_digit_suffix_is_not_a_count():
     # python's \d and int() both read '٣' as 3, which TypeScript's [0-9]
-    # scan never consumes — the ancestry count stops at ASCII digits in
-    # both languages.
-    _base, steps = split_revision("main~٣")
-    assert [(s.first_parent, s.count) for s in steps] == [(True, 1),
-                                                          (False, 1)]
+    # scan never consumes: the ancestry count stops at ASCII digits in
+    # both languages. What is left over is not another step either, so
+    # the whole expression is refused, which is git's own answer.
+    with pytest.raises(AmbiguousArgumentError):
+        split_revision("main~٣")
+
+
+@pytest.mark.parametrize("revision",
+                         ["HEAD^x", "HEAD~x", "HEAD^-1", "HEAD~1z"])
+def test_a_suffix_that_is_not_a_step_is_refused(revision: str):
+    # Every character used to count as another first-parent hop, so
+    # ``HEAD^x`` resolved to ``HEAD^^`` and a tag was written at a
+    # commit nobody named.
+    with pytest.raises(AmbiguousArgumentError):
+        split_revision(revision)
+
+
+@pytest.mark.parametrize(
+    "revision",
+    ["HEAD^", "HEAD~", "HEAD^0", "HEAD^~", "HEAD~2^2~1", "HEAD^12"])
+def test_the_steps_git_does_take_still_parse(revision: str):
+    split_revision(revision)
 
 
 def test_parent_suffix_is_distinguished_from_ancestor():

--- a/python/tests/commands/cli/builtin/git/test_rm.py
+++ b/python/tests/commands/cli/builtin/git/test_rm.py
@@ -164,3 +164,13 @@ async def test_a_directory_is_refused_without_r_and_removed_with_it(
     assert await run(git_rw, "rm -r docs") == (0, b"rm 'docs/one.md'\n", b"")
     # git removes the directory its last tracked file left empty.
     assert not (repo_path / "docs").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_dashed_pathspec_is_removed_when_the_line_escapes_it(
+        git_rw, repo_path: Path):
+    (repo_path / "-draft").write_text("x\n", encoding="utf-8")
+    await run(git_rw, "add -- -draft")
+    await run(git_rw, "commit -m draft")
+    assert await run(git_rw, "rm -- -draft") == (0, b"rm '-draft'\n", b"")
+    assert not (repo_path / "-draft").exists()

--- a/python/tests/commands/cli/builtin/git/test_rm.py
+++ b/python/tests/commands/cli/builtin/git/test_rm.py
@@ -1,0 +1,166 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from pathlib import Path
+
+import pytest
+
+from mirage.commands.cli.builtin.git.errors import (NotRecursiveError,
+                                                    PathspecError)
+from mirage.commands.cli.builtin.git.rm import RmFlags, parse_flags, select
+from mirage.commands.cli.builtin.git.types import RepoLocation
+from mirage.commands.spec.types import FlagView
+
+LOCATION = RepoLocation(gitdir="/repo/.git",
+                        commondir="/repo/.git",
+                        worktree="/repo",
+                        mount_root="/repo")
+TRACKED = {"a.txt", "docs/one.md", "docs/two.md"}
+
+
+def flags(**given: bool) -> RmFlags:
+    """An RmFlags with every flag off except the ones named.
+
+    Args:
+        given (bool): flags to switch on, by field name.
+    """
+    return RmFlags(recursive=given.get("recursive", False),
+                   cached=given.get("cached", False),
+                   force=given.get("force", False),
+                   quiet=given.get("quiet", False),
+                   ignore_unmatch=given.get("ignore_unmatch", False))
+
+
+async def run(ws, line: str) -> tuple[int, bytes, bytes]:
+    """Run one git line against the mounted repository.
+
+    Args:
+        ws (Workspace): workspace with the repository and CLI.
+        line (str): the command line, without the leading directory.
+    """
+    result = await ws.execute(f"git -C /repo {line}")
+    return result.exit_code, result.stdout or b"", result.stderr or b""
+
+
+def test_flags_read_their_long_and_short_spellings():
+    parsed = parse_flags(
+        FlagView({
+            "r": True,
+            "cached": True,
+            "force": True,
+            "quiet": True,
+            "ignore_unmatch": True
+        }))
+    assert parsed == flags(recursive=True,
+                           cached=True,
+                           force=True,
+                           quiet=True,
+                           ignore_unmatch=True)
+
+
+def test_a_file_operand_selects_itself():
+    assert select(LOCATION, "/repo", ("a.txt", ), TRACKED,
+                  flags()) == ["a.txt"]
+
+
+def test_a_directory_needs_r():
+    with pytest.raises(NotRecursiveError):
+        select(LOCATION, "/repo", ("docs", ), TRACKED, flags())
+
+
+def test_r_expands_a_directory_in_index_order():
+    assert select(LOCATION, "/repo", ("docs", ), TRACKED,
+                  flags(recursive=True)) == ["docs/one.md", "docs/two.md"]
+
+
+def test_an_unknown_operand_is_fatal_before_anything_is_selected():
+    with pytest.raises(PathspecError):
+        select(LOCATION, "/repo", ("a.txt", "nosuch"), TRACKED, flags())
+
+
+def test_ignore_unmatch_skips_an_unknown_operand():
+    assert select(LOCATION, "/repo", ("nosuch", "a.txt"), TRACKED,
+                  flags(ignore_unmatch=True)) == ["a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_rm_stages_a_deletion_and_removes_the_file(
+        git_rw, repo_path: Path):
+    assert await run(git_rw, "rm a.txt") == (0, b"rm 'a.txt'\n", b"")
+    assert not (repo_path / "a.txt").exists()
+    assert (await run(git_rw, "status --porcelain"))[1] == b"D  a.txt\n"
+
+
+@pytest.mark.asyncio
+async def test_cached_keeps_the_file(git_rw, repo_path: Path):
+    code, out, _err = await run(git_rw, "rm --cached a.txt")
+    assert (code, out) == (0, b"rm 'a.txt'\n")
+    assert (repo_path / "a.txt").exists()
+    assert (await run(git_rw, "status --porcelain"))[1] == (b"D  a.txt\n"
+                                                            b"?? a.txt\n")
+
+
+@pytest.mark.asyncio
+async def test_a_local_modification_is_refused(git_rw, repo_path: Path):
+    await git_rw.execute("echo edited > /repo/a.txt")
+    code, out, err = await run(git_rw, "rm a.txt")
+    assert (code, out) == (1, b"")
+    assert err == (
+        b"error: the following file has local modifications:\n"
+        b"    a.txt\n"
+        b"(use --cached to keep the file, or -f to force removal)\n")
+    assert (repo_path / "a.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_staged_change_is_refused_with_its_own_wording(git_rw):
+    await git_rw.execute("echo edited > /repo/a.txt")
+    await run(git_rw, "add a.txt")
+    _code, _out, err = await run(git_rw, "rm a.txt")
+    assert err.startswith(b"error: the following file has changes staged "
+                          b"in the index:\n    a.txt\n")
+
+
+@pytest.mark.asyncio
+async def test_force_removes_over_an_edit(git_rw, repo_path: Path):
+    await git_rw.execute("echo edited > /repo/a.txt")
+    assert await run(git_rw, "rm -f a.txt") == (0, b"rm 'a.txt'\n", b"")
+    assert not (repo_path / "a.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_quiet_prints_nothing(git_rw):
+    assert await run(git_rw, "rm -q b.txt") == (0, b"", b"")
+
+
+@pytest.mark.asyncio
+async def test_no_pathspec_is_fatal(git_rw):
+    code, _out, err = await run(git_rw, "rm")
+    assert code == 128
+    assert err == (b"fatal: No pathspec was given. Which files should I "
+                   b"remove?\n")
+
+
+@pytest.mark.asyncio
+async def test_a_directory_is_refused_without_r_and_removed_with_it(
+        git_rw, repo_path: Path):
+    await git_rw.execute("mkdir /repo/docs && echo x > /repo/docs/one.md")
+    await run(git_rw, "add docs")
+    await run(git_rw, "commit -m docs")
+    code, _out, err = await run(git_rw, "rm docs")
+    assert code == 128
+    assert err == b"fatal: not removing 'docs' recursively without -r\n"
+    assert await run(git_rw, "rm -r docs") == (0, b"rm 'docs/one.md'\n", b"")
+    # git removes the directory its last tracked file left empty.
+    assert not (repo_path / "docs").exists()

--- a/python/tests/commands/cli/builtin/git/test_rm.py
+++ b/python/tests/commands/cli/builtin/git/test_rm.py
@@ -174,3 +174,76 @@ async def test_a_dashed_pathspec_is_removed_when_the_line_escapes_it(
     await run(git_rw, "commit -m draft")
     assert await run(git_rw, "rm -- -draft") == (0, b"rm '-draft'\n", b"")
     assert not (repo_path / "-draft").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_directory_where_a_tracked_file_was_is_refused(
+        git_rw, repo_path: Path):
+    # unlink cannot empty a tree, and git reports the strerror rather
+    # than removing what it never tracked. The index is written last, so
+    # the entry is left staged exactly as it stood.
+    await git_rw.execute("rm /repo/b.txt && mkdir /repo/b.txt")
+    await git_rw.execute("echo k > /repo/b.txt/keep")
+    code, out, err = await run(git_rw, "rm b.txt")
+    assert code == 128
+    assert err == b"fatal: git rm: 'b.txt': Is a directory\n"
+    # git prints the line for every selected path before it deletes
+    # anything, so it is printed whether the line goes through or not.
+    assert out == b"rm 'b.txt'\n"
+    assert (repo_path / "b.txt" / "keep").exists()
+    code, out, _err = await run(git_rw, "status --short")
+    assert b"D  b.txt" not in out
+
+
+@pytest.mark.asyncio
+async def test_a_deletion_already_made_tolerates_the_refusal(
+        git_rw, repo_path: Path):
+    # git's own rule: the failure is fatal only while nothing has been
+    # deleted yet. a.txt sorts first and goes, so b.txt's failure is
+    # swallowed and the whole line succeeds with both entries unstaged.
+    await git_rw.execute("rm /repo/b.txt && mkdir /repo/b.txt")
+    await git_rw.execute("echo k > /repo/b.txt/keep")
+    code, out, err = await run(git_rw, "rm -f a.txt b.txt")
+    assert (code, err) == (0, b"")
+    assert out == b"rm 'a.txt'\nrm 'b.txt'\n"
+    assert not (repo_path / "a.txt").exists()
+    assert (repo_path / "b.txt" / "keep").exists()
+
+
+@pytest.mark.asyncio
+async def test_the_refusal_stands_when_nothing_has_gone_yet(
+        git_rw, repo_path: Path):
+    # The mirror of the test above, with the directory on the path that
+    # sorts first: nothing has been deleted when a.txt fails, so the
+    # line is fatal and b.txt is never reached. An empty directory
+    # refuses the same way, since unlink is the call that cannot make
+    # it either.
+    await git_rw.execute("rm /repo/a.txt && mkdir /repo/a.txt")
+    code, _out, err = await run(git_rw, "rm -f a.txt b.txt")
+    assert code == 128
+    assert err == b"fatal: git rm: 'a.txt': Is a directory\n"
+    assert (repo_path / "b.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_cached_unstages_a_directory_without_touching_it(
+        git_rw, repo_path: Path):
+    # --cached deletes nothing, so the refusal never arises: the entry
+    # goes and the directory stays.
+    await git_rw.execute("rm /repo/b.txt && mkdir /repo/b.txt")
+    await git_rw.execute("echo k > /repo/b.txt/keep")
+    assert await run(git_rw, "rm --cached b.txt") == (0, b"rm 'b.txt'\n", b"")
+    assert (repo_path / "b.txt" / "keep").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_tracked_link_to_a_directory_is_removed_as_a_link(
+        git_rw, repo_path: Path):
+    # A link is not the directory it points at, and reading it as one
+    # would refuse a removal git makes: the namespace is asked first.
+    await git_rw.execute("mkdir /repo/real && echo r > /repo/real/child")
+    await git_rw.execute("ln -s real /repo/slot")
+    await run(git_rw, "add -A")
+    await run(git_rw, "commit -m linked")
+    assert await run(git_rw, "rm slot") == (0, b"rm 'slot'\n", b"")
+    assert (repo_path / "real" / "child").exists()

--- a/python/tests/commands/cli/builtin/git/test_rm.py
+++ b/python/tests/commands/cli/builtin/git/test_rm.py
@@ -16,9 +16,11 @@ from pathlib import Path
 
 import pytest
 
+from mirage.commands.cli.builtin.git.changes import DELETED, MODIFIED
 from mirage.commands.cli.builtin.git.errors import (NotRecursiveError,
                                                     PathspecError)
-from mirage.commands.cli.builtin.git.rm import RmFlags, parse_flags, select
+from mirage.commands.cli.builtin.git.rm import (RmFlags, parse_flags, select,
+                                                shadowed)
 from mirage.commands.cli.builtin.git.types import RepoLocation
 from mirage.commands.spec.types import FlagView
 
@@ -247,3 +249,116 @@ async def test_a_tracked_link_to_a_directory_is_removed_as_a_link(
     await run(git_rw, "commit -m linked")
     assert await run(git_rw, "rm slot") == (0, b"rm 'slot'\n", b"")
     assert (repo_path / "real" / "child").exists()
+
+
+class Hiding:
+    """A link view where ``slot`` is a link and ``slot/child`` is live.
+
+    ``resolve`` is the name plane's own walk, so a path under the link
+    comes back respelled; ``exists`` answers through the dispatcher, so
+    a target that is not there answers False.
+    """
+
+    def __init__(self, present: bool = True) -> None:
+        self.present = present
+
+    def resolve(self, path: str) -> str:
+        """Where a path really points.
+
+        Args:
+            path (str): absolute virtual path.
+        """
+        if path.startswith("/repo/slot"):
+            return path.replace("/repo/slot", "/away", 1)
+        return path
+
+    async def exists(self, path: str) -> bool:
+        """Whether anything is there once the links are resolved.
+
+        Asked with the path as typed, since the real view resolves for
+        itself: that is what lets a link across mounts answer at all.
+
+        Args:
+            path (str): absolute virtual path.
+        """
+        return self.present and self.resolve(path).startswith("/away")
+
+
+@pytest.mark.asyncio
+async def test_a_link_above_a_deleted_path_makes_it_a_local_change():
+    hidden = await shadowed(Hiding(), "/repo", ["slot/child"],
+                            {"slot/child": DELETED})
+    assert hidden == {"slot/child"}
+
+
+@pytest.mark.asyncio
+async def test_a_link_pointing_at_nothing_leaves_the_path_deleted():
+    # git lstats through the leading link and gets ENOENT, so there is
+    # no local change to lose and the removal goes through.
+    hidden = await shadowed(Hiding(present=False), "/repo", ["slot/child"],
+                            {"slot/child": DELETED})
+    assert hidden == set()
+
+
+@pytest.mark.asyncio
+async def test_a_path_the_walk_found_is_never_shadowed():
+    hidden = await shadowed(Hiding(), "/repo", ["slot/child"],
+                            {"slot/child": MODIFIED})
+    assert hidden == set()
+
+
+@pytest.mark.asyncio
+async def test_without_a_namespace_nothing_is_shadowed():
+    assert await shadowed(None, "/repo", ["slot/child"],
+                          {"slot/child": DELETED}) == set()
+
+
+@pytest.mark.asyncio
+async def test_a_tracked_path_behind_a_link_is_refused_as_a_local_change(
+        git_rw, repo_path: Path):
+    # The walk lstats, so the link hides the tracked file and the path
+    # reads as deleted, which is what git's own status says too. git
+    # rm does not read it that way: its lstat resolves the leading
+    # component and finds another file entirely.
+    await git_rw.execute("mkdir /repo/slot && echo t > /repo/slot/child")
+    await git_rw.execute("mkdir /repo/away && echo o > /repo/away/child")
+    await run(git_rw, "add slot/child")
+    await run(git_rw, "commit -m slotted")
+    await git_rw.execute("rm -rf /repo/slot")
+    await git_rw.execute("ln -s /repo/away /repo/slot")
+    assert await run(git_rw, "status --short") == (0, b" D slot/child\n"
+                                                   b"?? away/\n?? slot\n", b"")
+    code, _out, err = await run(git_rw, "rm slot/child")
+    assert code == 1
+    assert err == (b"error: the following file has local modifications:\n"
+                   b"    slot/child\n"
+                   b"(use --cached to keep the file, or -f to force "
+                   b"removal)\n")
+    assert (repo_path / "away" / "child").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_link_pointing_past_the_tracked_path_removes_it(
+        git_rw, repo_path: Path):
+    # Nothing at the other end, so git has nothing to lose and stages
+    # the deletion.
+    await git_rw.execute("mkdir /repo/slot && echo t > /repo/slot/child")
+    await git_rw.execute("mkdir /repo/away")
+    await run(git_rw, "add slot/child")
+    await run(git_rw, "commit -m slotted")
+    await git_rw.execute("rm -rf /repo/slot")
+    await git_rw.execute("ln -s /repo/away /repo/slot")
+    assert await run(git_rw, "rm slot/child") == (0, b"rm 'slot/child'\n", b"")
+
+
+@pytest.mark.asyncio
+async def test_cached_keeps_the_file_a_link_hides(git_rw):
+    await git_rw.execute("mkdir /repo/slot && echo t > /repo/slot/child")
+    await git_rw.execute("mkdir /repo/away && echo o > /repo/away/child")
+    await run(git_rw, "add slot/child")
+    await run(git_rw, "commit -m slotted")
+    await git_rw.execute("rm -rf /repo/slot")
+    await git_rw.execute("ln -s /repo/away /repo/slot")
+    assert await run(git_rw,
+                     "rm --cached slot/child") == (0, b"rm 'slot/child'\n",
+                                                   b"")

--- a/python/tests/commands/cli/builtin/git/test_switch.py
+++ b/python/tests/commands/cli/builtin/git/test_switch.py
@@ -19,6 +19,7 @@ from dulwich.refs import Ref
 from dulwich.repo import Repo
 
 from mirage.commands.cli.builtin.git.switch import expected_kind
+from tests.commands.cli.builtin.git.conftest import conflict_index
 
 
 async def run(ws, line: str) -> tuple[int, bytes, bytes]:
@@ -214,9 +215,6 @@ async def test_an_untracked_file_blocks_a_directory_the_target_holds(
     await run(git_rw, "add slot")
     await run(git_rw, "commit -m dir")
     await run(git_rw, "switch main")
-    # The switch removed the tracked file and left the directory that
-    # held it, so the untracked file has to take its place.
-    (repo_path / "slot").rmdir()
     (repo_path / "slot").write_text("mine\n", encoding="utf-8")
     code, _out, err = await run(git_rw, "switch other")
     assert code == 1
@@ -241,3 +239,90 @@ async def test_an_untracked_file_inside_a_directory_the_target_replaces(
     assert err == (b"error: Updating the following directories would lose "
                    b"untracked files in them:\n\tslot\n\nAborting\n")
     assert (repo_path / "slot" / "file").read_text() == "mine\n"
+
+
+@pytest.mark.asyncio
+async def test_an_unmerged_index_stops_a_switch(git_rw, repo_path: Path):
+    # Every collision check reads stage 0, so a path held only as
+    # stages 1 to 3 would be carried through them all and then cleared.
+    await run(git_rw, "branch topic")
+    conflict_index(repo_path, "a.txt")
+    code, out, err = await run(git_rw, "switch topic")
+    assert code == 1
+    assert out == b"a.txt: needs merge\n"
+    assert err == b"error: you need to resolve your current index first\n"
+    assert head_ref(repo_path) == b"ref: refs/heads/main"
+
+
+@pytest.mark.asyncio
+async def test_an_unmerged_index_stops_a_detach(git_rw, repo_path: Path):
+    conflict_index(repo_path, "a.txt")
+    code, out, _err = await run(git_rw, "switch --detach HEAD")
+    assert code == 1
+    assert out == b"a.txt: needs merge\n"
+    assert head_ref(repo_path) == b"ref: refs/heads/main"
+
+
+@pytest.mark.asyncio
+async def test_creating_a_branch_here_survives_an_unmerged_index(
+        git_rw, repo_path: Path):
+    # Nothing moves, so git writes the ref and leaves the index alone.
+    # Naming the same commit as a start point is refused a word later,
+    # which is the shape of the line deciding it rather than the trees.
+    conflict_index(repo_path, "a.txt")
+    assert await run(git_rw, "switch -c topic") == (0, b"", b"Switched to a "
+                                                    b"new branch 'topic'\n")
+    assert head_ref(repo_path) == b"ref: refs/heads/topic"
+    with Repo(str(repo_path)) as repo:
+        assert repo.open_index().has_conflicts()
+
+
+@pytest.mark.asyncio
+async def test_creating_a_branch_elsewhere_stops_at_an_unmerged_index(
+        git_rw, repo_path: Path):
+    conflict_index(repo_path, "a.txt")
+    code, out, _err = await run(git_rw, "switch -c topic HEAD")
+    assert code == 1
+    assert out == b"a.txt: needs merge\n"
+    assert head_ref(repo_path) == b"ref: refs/heads/main"
+
+
+@pytest.mark.asyncio
+async def test_a_file_becomes_a_directory_across_a_switch(
+        git_rw, repo_path: Path):
+    # The file has to go before the directory can be made, and the
+    # target tree names both places.
+    (repo_path / "slot").write_text("flat\n", encoding="utf-8")
+    await run(git_rw, "add slot")
+    await run(git_rw, "commit -m flat")
+    await run(git_rw, "switch -c other")
+    await run(git_rw, "rm slot")
+    (repo_path / "slot").mkdir()
+    (repo_path / "slot" / "child").write_text("deep\n", encoding="utf-8")
+    await run(git_rw, "add slot")
+    await run(git_rw, "commit -m deep")
+    await run(git_rw, "switch main")
+    assert (repo_path / "slot").read_text() == "flat\n"
+    assert await run(git_rw, "switch other") == (0, b"", b"Switched to branch "
+                                                 b"'other'\n")
+    assert (repo_path / "slot" / "child").read_text() == "deep\n"
+
+
+@pytest.mark.asyncio
+async def test_a_directory_becomes_a_file_across_a_switch(
+        git_rw, repo_path: Path):
+    (repo_path / "slot").mkdir()
+    (repo_path / "slot" / "child").write_text("deep\n", encoding="utf-8")
+    await run(git_rw, "add slot")
+    await run(git_rw, "commit -m deep")
+    await run(git_rw, "switch -c other")
+    await run(git_rw, "rm slot/child")
+    (repo_path / "slot").write_text("flat\n", encoding="utf-8")
+    await run(git_rw, "add slot")
+    await run(git_rw, "commit -m flat")
+    assert await run(git_rw, "switch main") == (0, b"", b"Switched to branch "
+                                                b"'main'\n")
+    assert (repo_path / "slot" / "child").read_text() == "deep\n"
+    assert await run(git_rw, "switch other") == (0, b"", b"Switched to branch "
+                                                 b"'other'\n")
+    assert (repo_path / "slot").read_text() == "flat\n"

--- a/python/tests/commands/cli/builtin/git/test_switch.py
+++ b/python/tests/commands/cli/builtin/git/test_switch.py
@@ -389,3 +389,23 @@ async def test_a_carried_edit_is_lettered_by_where_it_stands(git_rw):
     assert await run(git_rw,
                      "switch other") == (0, b"M\ta.txt\n",
                                          b"Switched to branch 'other'\n")
+
+
+@pytest.mark.asyncio
+async def test_the_unborn_branch_named_by_head_is_not_current(unborn_rw):
+    # HEAD names it, but the ref has never been written, so there is no
+    # commit to be on. Reading the name alone answered "Already on" at
+    # exit 0; git resolves it first and dies, which is what leaves
+    # ``switch -c`` as the only line an unborn HEAD accepts.
+    code, out, err = await run(unborn_rw, "switch main")
+    assert (code, out) == (128, b"")
+    assert err == b"fatal: invalid reference: main\n"
+
+
+@pytest.mark.asyncio
+async def test_creating_from_an_unborn_head_still_works(unborn_rw):
+    assert (await run(unborn_rw, "switch -c topic"))[0] == 0
+    # And the new branch is unborn in its turn, so naming it is the
+    # same refusal rather than a special case of the first one.
+    code, _out, err = await run(unborn_rw, "switch topic")
+    assert (code, err) == (128, b"fatal: invalid reference: topic\n")

--- a/python/tests/commands/cli/builtin/git/test_switch.py
+++ b/python/tests/commands/cli/builtin/git/test_switch.py
@@ -423,3 +423,20 @@ async def test_creating_a_branch_below_one_that_exists_is_refused(
     # Refused before the working tree moves, so HEAD is where it was.
     assert b"ref: refs/heads/main" in (repo_path / ".git" /
                                        "HEAD").read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_an_unmerged_index_stops_a_switch_to_the_current_branch(
+        git_rw, repo_path: Path):
+    # The shortcut moves nothing, which is not the same as having
+    # nothing to check: git reads the index before it answers, so
+    # "Already on" cannot be read as proof the repository is in a state
+    # anything can be built on.
+    code, out, err = await run(git_rw, "switch main")
+    assert (code, out, err) == (0, b"", b"Already on 'main'\n")
+    conflict_index(repo_path, "a.txt")
+    code, out, err = await run(git_rw, "switch main")
+    assert code == 1
+    assert out == b"a.txt: needs merge\n"
+    assert err == b"error: you need to resolve your current index first\n"
+    assert head_ref(repo_path) == b"ref: refs/heads/main"

--- a/python/tests/commands/cli/builtin/git/test_switch.py
+++ b/python/tests/commands/cli/builtin/git/test_switch.py
@@ -409,3 +409,17 @@ async def test_creating_from_an_unborn_head_still_works(unborn_rw):
     # same refusal rather than a special case of the first one.
     code, _out, err = await run(unborn_rw, "switch topic")
     assert (code, err) == (128, b"fatal: invalid reference: topic\n")
+
+
+@pytest.mark.asyncio
+async def test_creating_a_branch_below_one_that_exists_is_refused(
+        git_rw, repo_path: Path):
+    assert (await run(git_rw, "branch bb"))[0] == 0
+    code, _out, err = await run(git_rw, "switch -c bb/cc")
+    assert code == 128
+    assert err == (b"fatal: cannot lock ref 'refs/heads/bb/cc': "
+                   b"'refs/heads/bb' exists; cannot create "
+                   b"'refs/heads/bb/cc'\n")
+    # Refused before the working tree moves, so HEAD is where it was.
+    assert b"ref: refs/heads/main" in (repo_path / ".git" /
+                                       "HEAD").read_bytes()

--- a/python/tests/commands/cli/builtin/git/test_switch.py
+++ b/python/tests/commands/cli/builtin/git/test_switch.py
@@ -186,3 +186,20 @@ async def test_switch_c_refuses_a_name_holding_a_space(git_rw):
 async def test_an_unresolvable_start_point_is_named_first(git_rw):
     _code, _out, err = await run(git_rw, "switch -c ../../config nosuchstart")
     assert err == b"fatal: invalid reference: nosuchstart\n"
+
+
+@pytest.mark.asyncio
+async def test_detach_with_no_operand_takes_head(git_rw, repo_path: Path):
+    code, _out, err = await run(git_rw, "switch --detach")
+    assert code == 0
+    assert err.startswith(b"HEAD is now at ")
+    with Repo(str(repo_path)) as repo:
+        main = repo.refs[Ref(b"refs/heads/main")]
+        assert repo.refs.read_ref(b"HEAD") == main
+
+
+@pytest.mark.asyncio
+async def test_a_plain_switch_still_needs_a_branch(git_rw):
+    code, _out, err = await run(git_rw, "switch")
+    assert code == 128
+    assert err.startswith(b"fatal: ")

--- a/python/tests/commands/cli/builtin/git/test_switch.py
+++ b/python/tests/commands/cli/builtin/git/test_switch.py
@@ -326,3 +326,66 @@ async def test_a_directory_becomes_a_file_across_a_switch(
     assert await run(git_rw, "switch other") == (0, b"", b"Switched to branch "
                                                  b"'other'\n")
     assert (repo_path / "slot").read_text() == "flat\n"
+
+
+@pytest.mark.asyncio
+async def test_a_branch_is_created_on_an_unborn_head(unborn_rw,
+                                                     unborn_path: Path):
+    assert await run(
+        unborn_rw,
+        "switch -c topic") == (0, b"", b"Switched to a new branch 'topic'\n")
+    assert head_ref(unborn_path) == b"ref: refs/heads/topic"
+    # No ref and no reflog: a branch with no commit is a name and
+    # nothing else, which is why git can make one here at all.
+    assert not (unborn_path / ".git" / "refs" / "heads" / "topic").exists()
+    assert not (unborn_path / ".git" / "logs" / "HEAD").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_start_point_on_an_unborn_head_is_refused(
+        unborn_rw, unborn_path: Path):
+    assert await run(
+        unborn_rw,
+        "switch -c topic main") == (128, b"",
+                                    b"fatal: invalid reference: main\n")
+    assert head_ref(unborn_path) == b"ref: refs/heads/main"
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_name_on_an_unborn_head_is_refused(
+        unborn_rw, unborn_path: Path):
+    code, _out, err = await run(unborn_rw, "switch -c ../../evil")
+    assert code == 128
+    assert err.startswith(b"fatal: '../../evil' is not a valid branch name\n")
+    assert head_ref(unborn_path) == b"ref: refs/heads/main"
+
+
+@pytest.mark.asyncio
+async def test_a_staged_addition_survives_the_switch(git_rw):
+    await run(git_rw, "branch other")
+    await git_rw.execute("echo new > /repo/added.txt")
+    await run(git_rw, "add added.txt")
+    assert await run(git_rw,
+                     "switch other") == (0, b"A\tadded.txt\n",
+                                         b"Switched to branch 'other'\n")
+    assert await run(git_rw, "status --short") == (0, b"A  added.txt\n", b"")
+
+
+@pytest.mark.asyncio
+async def test_a_staged_deletion_survives_the_switch(git_rw):
+    await run(git_rw, "branch other")
+    await run(git_rw, "rm --cached b.txt")
+    assert await run(git_rw,
+                     "switch other") == (0, b"D\tb.txt\n",
+                                         b"Switched to branch 'other'\n")
+    assert await run(git_rw,
+                     "status --short") == (0, b"D  b.txt\n?? b.txt\n", b"")
+
+
+@pytest.mark.asyncio
+async def test_a_carried_edit_is_lettered_by_where_it_stands(git_rw):
+    await run(git_rw, "branch other")
+    await git_rw.execute("echo edited > /repo/a.txt")
+    assert await run(git_rw,
+                     "switch other") == (0, b"M\ta.txt\n",
+                                         b"Switched to branch 'other'\n")

--- a/python/tests/commands/cli/builtin/git/test_switch.py
+++ b/python/tests/commands/cli/builtin/git/test_switch.py
@@ -160,3 +160,29 @@ async def test_create_and_detach_do_not_mix(git_rw):
     code, _out, err = await run(git_rw, "switch -c x -d")
     assert code == 128
     assert err == b"fatal: '--detach' cannot be used with '-b/-B/--orphan'\n"
+
+
+@pytest.mark.asyncio
+async def test_switch_c_refuses_a_name_that_escapes_the_ref_tree(
+        git_rw, repo_path: Path):
+    before = (repo_path / ".git" / "config").read_bytes()
+    code, _out, err = await run(git_rw, "switch -c ../../config")
+    assert code == 128
+    assert err == (b"fatal: '../../config' is not a valid branch name\n"
+                   b"hint: See `man git check-ref-format`\n"
+                   b'hint: Disable this message with "git config set '
+                   b'advice.refSyntax false"\n')
+    assert (repo_path / ".git" / "config").read_bytes() == before
+
+
+@pytest.mark.asyncio
+async def test_switch_c_refuses_a_name_holding_a_space(git_rw):
+    code, _out, err = await run(git_rw, "switch -c 'bad name'")
+    assert code == 128
+    assert err.startswith(b"fatal: 'bad name' is not a valid branch name\n")
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_start_point_is_named_first(git_rw):
+    _code, _out, err = await run(git_rw, "switch -c ../../config nosuchstart")
+    assert err == b"fatal: invalid reference: nosuchstart\n"

--- a/python/tests/commands/cli/builtin/git/test_switch.py
+++ b/python/tests/commands/cli/builtin/git/test_switch.py
@@ -203,3 +203,41 @@ async def test_a_plain_switch_still_needs_a_branch(git_rw):
     code, _out, err = await run(git_rw, "switch")
     assert code == 128
     assert err.startswith(b"fatal: ")
+
+
+@pytest.mark.asyncio
+async def test_an_untracked_file_blocks_a_directory_the_target_holds(
+        git_rw, repo_path: Path):
+    await run(git_rw, "switch -c other")
+    (repo_path / "slot").mkdir()
+    (repo_path / "slot" / "file").write_text("x\n", encoding="utf-8")
+    await run(git_rw, "add slot")
+    await run(git_rw, "commit -m dir")
+    await run(git_rw, "switch main")
+    # The switch removed the tracked file and left the directory that
+    # held it, so the untracked file has to take its place.
+    (repo_path / "slot").rmdir()
+    (repo_path / "slot").write_text("mine\n", encoding="utf-8")
+    code, _out, err = await run(git_rw, "switch other")
+    assert code == 1
+    assert err == (b"error: The following untracked working tree files would "
+                   b"be overwritten by checkout:\n\tslot\nPlease move or "
+                   b"remove them before you switch branches.\nAborting\n")
+    assert (repo_path / "slot").read_text() == "mine\n"
+
+
+@pytest.mark.asyncio
+async def test_an_untracked_file_inside_a_directory_the_target_replaces(
+        git_rw, repo_path: Path):
+    await run(git_rw, "switch -c other")
+    (repo_path / "slot").write_text("theirs\n", encoding="utf-8")
+    await run(git_rw, "add slot")
+    await run(git_rw, "commit -m file")
+    await run(git_rw, "switch main")
+    (repo_path / "slot").mkdir()
+    (repo_path / "slot" / "file").write_text("mine\n", encoding="utf-8")
+    code, _out, err = await run(git_rw, "switch other")
+    assert code == 1
+    assert err == (b"error: Updating the following directories would lose "
+                   b"untracked files in them:\n\tslot\n\nAborting\n")
+    assert (repo_path / "slot" / "file").read_text() == "mine\n"

--- a/python/tests/commands/cli/builtin/git/test_switch.py
+++ b/python/tests/commands/cli/builtin/git/test_switch.py
@@ -1,0 +1,162 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from pathlib import Path
+
+import pytest
+from dulwich.refs import Ref
+from dulwich.repo import Repo
+
+from mirage.commands.cli.builtin.git.switch import expected_kind
+
+
+async def run(ws, line: str) -> tuple[int, bytes, bytes]:
+    """Run one git line against the mounted repository.
+
+    Args:
+        ws (Workspace): workspace with the repository and CLI.
+        line (str): the command line, without the leading directory.
+    """
+    result = await ws.execute(f"git -C /repo {line}")
+    return result.exit_code, result.stdout or b"", result.stderr or b""
+
+
+def head_ref(repo_path: Path) -> bytes:
+    """What ``.git/HEAD`` holds, read straight off disk.
+
+    Args:
+        repo_path (Path): the repository's working tree.
+    """
+    return (repo_path / ".git" / "HEAD").read_bytes().strip()
+
+
+def test_a_tag_is_named_as_one():
+    known = {Ref(b"refs/tags/v1"), Ref(b"refs/heads/main")}
+    assert expected_kind(known, "v1") == "tag"
+
+
+def test_a_remote_tracking_branch_is_named_as_one():
+    known = {Ref(b"refs/remotes/origin/main")}
+    assert expected_kind(known, "origin/main") == "remote branch"
+
+
+def test_anything_else_is_a_commit():
+    assert expected_kind(set(), "265ec3a") == "commit"
+
+
+@pytest.mark.asyncio
+async def test_switch_moves_to_a_branch(git_rw, repo_path: Path):
+    await run(git_rw, "branch topic")
+    assert await run(git_rw, "switch topic") == (0, b"", b"Switched to branch "
+                                                 b"'topic'\n")
+    assert head_ref(repo_path) == b"ref: refs/heads/topic"
+
+
+@pytest.mark.asyncio
+async def test_already_on_the_branch(git_rw):
+    assert await run(git_rw, "switch main") == (0, b"", b"Already on 'main'\n")
+
+
+@pytest.mark.asyncio
+async def test_c_creates_and_switches(git_rw, repo_path: Path):
+    assert await run(git_rw,
+                     "switch -c fresh") == (0, b"", b"Switched to a new "
+                                            b"branch 'fresh'\n")
+    assert head_ref(repo_path) == b"ref: refs/heads/fresh"
+
+
+@pytest.mark.asyncio
+async def test_c_starts_where_it_is_told(git_rw, repo_path: Path):
+    await run(git_rw, "switch -c older HEAD~1")
+    with Repo(str(repo_path)) as repo:
+        parent = repo[repo.refs[b"refs/heads/main"]].parents[0]
+        assert repo.refs[b"refs/heads/older"] == parent
+
+
+@pytest.mark.asyncio
+async def test_c_refuses_a_branch_that_exists(git_rw):
+    code, _out, err = await run(git_rw, "switch -c main")
+    assert code == 128
+    assert err == b"fatal: a branch named 'main' already exists\n"
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_name_is_an_invalid_reference(git_rw):
+    code, _out, err = await run(git_rw, "switch nosuch")
+    assert code == 128
+    assert err == b"fatal: invalid reference: nosuch\n"
+
+
+@pytest.mark.asyncio
+async def test_a_commit_needs_detach(git_rw, repo_path: Path):
+    with Repo(str(repo_path)) as repo:
+        sha = repo.refs[b"refs/heads/main"].decode()
+    code, _out, err = await run(git_rw, f"switch {sha[:7]}")
+    assert code == 128
+    assert err == (f"fatal: a branch is expected, got commit '{sha[:7]}'\n"
+                   f"hint: If you want to detach HEAD at the commit, try "
+                   f"again with the --detach option.\n").encode()
+    assert head_ref(repo_path) == b"ref: refs/heads/main"
+
+
+@pytest.mark.asyncio
+async def test_detach_lands_on_the_commit(git_rw, repo_path: Path):
+    code, out, err = await run(git_rw, "switch --detach HEAD~1")
+    assert (code, out) == (0, b"")
+    assert err.startswith(b"HEAD is now at ")
+    assert err.endswith(b" second\n")
+    assert not head_ref(repo_path).startswith(b"ref:")
+
+
+@pytest.mark.asyncio
+async def test_leaving_a_detached_head_names_where_it_was(git_rw):
+    await run(git_rw, "switch --detach HEAD~1")
+    _code, _out, err = await run(git_rw, "switch main")
+    lines = err.splitlines()
+    assert lines[0].startswith(b"Previous HEAD position was ")
+    assert lines[0].endswith(b" second")
+    assert lines[1] == b"Switched to branch 'main'"
+
+
+@pytest.mark.asyncio
+async def test_switch_refuses_to_lose_an_edit(git_rw, repo_path: Path):
+    await run(git_rw, "branch older HEAD~1")
+    await git_rw.execute("echo precious > /repo/a.txt")
+    code, _out, err = await run(git_rw, "switch older")
+    assert code == 1
+    assert err.startswith(
+        b"error: Your local changes to the following "
+        b"files would be overwritten by checkout:\n\ta.txt\n")
+    assert (repo_path / "a.txt").read_text() == "precious\n"
+
+
+@pytest.mark.asyncio
+async def test_no_operand_is_fatal(git_rw):
+    code, _out, err = await run(git_rw, "switch")
+    assert code == 128
+    assert err == b"fatal: missing branch or commit argument\n"
+
+
+@pytest.mark.asyncio
+async def test_two_operands_are_fatal(git_rw):
+    code, _out, err = await run(git_rw, "switch main main")
+    assert code == 128
+    assert err == b"fatal: only one reference expected\n"
+
+
+@pytest.mark.asyncio
+async def test_create_and_detach_do_not_mix(git_rw):
+    code, _out, err = await run(git_rw, "switch -c x -d")
+    assert code == 128
+    assert err == b"fatal: '--detach' cannot be used with '-b/-B/--orphan'\n"

--- a/python/tests/commands/cli/builtin/git/test_tag.py
+++ b/python/tests/commands/cli/builtin/git/test_tag.py
@@ -22,6 +22,7 @@ from dulwich.repo import Repo
 from mirage.commands.cli.builtin.git.tag import (parse_flags, render_listing,
                                                  selected_names, tag_names)
 from mirage.commands.spec.types import FlagView
+from tests.commands.cli.builtin.git.conftest import mounted_rw, pack_refs
 
 
 async def run(ws, line: str) -> tuple[int, bytes, bytes]:
@@ -197,3 +198,53 @@ async def test_a_tag_resolves_as_a_revision(git_rw):
     await run(git_rw, "tag old HEAD~1")
     assert (await run(git_rw,
                       "log --oneline -n 1 old"))[1].endswith(b" second\n")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("line", ["tag -a", "tag -m msg", "tag -f"])
+async def test_a_creation_option_needs_a_name(git_rw, line: str):
+    code, _out, err = await run(git_rw, line)
+    assert code == 129
+    assert err == (b"usage: git tag [-a] [-f] [-m <msg>] <tagname> "
+                   b"[<commit> | <object>]\n"
+                   b"   or: git tag -d <tagname>...\n"
+                   b"   or: git tag [-n[<num>]] -l [<pattern>...]\n")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("line", ["tag -l -a v1", "tag -d -a v1", "tag -n -f"])
+async def test_a_creation_option_cannot_list_or_delete(git_rw, line: str):
+    code, _out, err = await run(git_rw, line)
+    assert code == 129
+    assert err.startswith(b"usage: git tag [-a] [-f] [-m <msg>]")
+
+
+@pytest.mark.asyncio
+async def test_listing_and_deleting_still_take_no_name(git_rw):
+    assert await run(git_rw, "tag") == (0, b"", b"")
+    assert await run(git_rw, "tag -d") == (0, b"", b"")
+
+
+@pytest.mark.asyncio
+async def test_force_still_creates_when_a_name_is_given(git_rw):
+    assert await run(git_rw, "tag -f v1") == (0, b"", b"")
+    assert (await run(git_rw, "tag"))[1] == b"v1\n"
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_packed_tag_removes_it(repo_path: Path):
+    with mounted_rw(repo_path) as ws:
+        await run(ws, "tag lw")
+        await run(ws, "tag -a ann -m msg")
+    pack_refs(repo_path)
+    loose = repo_path / ".git" / "refs" / "tags"
+    assert not loose.exists() or not any(loose.iterdir())
+    with mounted_rw(repo_path) as ws:
+        code, out, _err = await run(ws, "tag -d lw")
+        assert (code, out.split(b" (was")[0]) == (0, b"Deleted tag 'lw'")
+        assert (await run(ws, "tag -d ann"))[0] == 0
+        assert (await run(ws, "tag"))[1] == b""
+    packed = (repo_path / ".git" / "packed-refs").read_text()
+    assert "refs/tags/" not in packed
+    assert "^" not in packed
+    assert "refs/heads/main" in packed

--- a/python/tests/commands/cli/builtin/git/test_tag.py
+++ b/python/tests/commands/cli/builtin/git/test_tag.py
@@ -286,3 +286,37 @@ async def test_a_target_that_is_no_object_is_still_refused(git_rw):
     code, _out, err = await run(git_rw, "tag v2 nosuchrev")
     assert code == 128
     assert err == b"fatal: Failed to resolve 'nosuchrev' as a valid ref.\n"
+
+
+@pytest.mark.asyncio
+async def test_a_tree_expression_is_a_tag_target(git_rw, repo_path: Path):
+    assert await run(git_rw, "tag treetag HEAD^{tree}") == (0, b"", b"")
+    with Repo(str(repo_path)) as repo:
+        head = repo[b"HEAD"]
+        assert repo.refs[b"refs/tags/treetag"] == head.tree
+
+
+@pytest.mark.asyncio
+async def test_a_path_expression_is_a_tag_target(git_rw, repo_path: Path):
+    assert await run(git_rw, "tag blobtag HEAD:a.txt") == (0, b"", b"")
+    with Repo(str(repo_path)) as repo:
+        held = repo[repo.refs[b"refs/tags/blobtag"]]
+        assert held.type_name == b"blob"
+        assert held.data == b"one changed\n"
+
+
+@pytest.mark.asyncio
+async def test_an_annotated_tag_records_the_expressions_type(
+        git_rw, repo_path: Path):
+    assert (await run(git_rw, "tag -a -m msg noted HEAD:a.txt"))[0] == 0
+    with Repo(str(repo_path)) as repo:
+        tag = repo[repo.refs[b"refs/tags/noted"]]
+        assert tag.object[0].type_name == b"blob"
+
+
+@pytest.mark.asyncio
+async def test_an_expression_that_resolves_to_nothing_is_refused(git_rw):
+    code, _out, err = await run(git_rw, "tag missed HEAD:nosuch")
+    assert code == 128
+    assert err == (b"fatal: Failed to resolve 'HEAD:nosuch' as a valid "
+                   b"ref.\n")

--- a/python/tests/commands/cli/builtin/git/test_tag.py
+++ b/python/tests/commands/cli/builtin/git/test_tag.py
@@ -358,3 +358,77 @@ async def test_a_bare_tag_id_makes_a_nested_tag(git_rw, repo_path: Path):
     # the tag rather than at the commit behind it.
     assert written.object[0].type_name == b"tag"
     assert written.object[1].decode() == held
+
+
+@pytest.mark.asyncio
+async def test_n_is_refused_on_a_line_that_deletes(git_rw):
+    assert await run(git_rw, "tag v") == (0, b"", b"")
+    code, out, err = await run(git_rw, "tag -d -n1 v")
+    assert (code, out) == (128, b"")
+    assert err == b"fatal: the '-n' option is only allowed in list mode\n"
+    assert (await run(git_rw, "tag -l"))[1] == b"v\n"
+
+
+@pytest.mark.asyncio
+async def test_n_still_implies_a_listing_on_its_own(git_rw):
+    # The refusal above is about -d having already chosen the mode: with
+    # nothing else on the line -n makes it a listing, so an operand is a
+    # pattern and one that matches nothing prints nothing at exit 0.
+    assert await run(git_rw, "tag v") == (0, b"", b"")
+    assert await run(git_rw, "tag -n1 nosuch") == (0, b"", b"")
+    assert (await run(git_rw, "tag -l"))[1] == b"v\n"
+
+
+@pytest.mark.asyncio
+async def test_the_incompatible_pair_outranks_the_n_refusal(git_rw):
+    # Ranking, not wording: git reaches the -d/-l pair first and exits
+    # 129 there rather than dying on -n. (It names the two options in
+    # the order they were typed, where this build has one fixed order.)
+    code, _out, err = await run(git_rw, "tag -l -d -n1 v")
+    assert code == 129
+    assert err == (b"error: options '-l' and '-d' cannot be used "
+                   b"together\n")
+
+
+@pytest.mark.asyncio
+async def test_a_tag_named_twice_deletes_nothing(git_rw):
+    assert await run(git_rw, "tag v") == (0, b"", b"")
+    assert await run(git_rw, "tag w") == (0, b"", b"")
+    code, out, err = await run(git_rw, "tag -d v w v")
+    assert (code, out) == (1, b"")
+    assert err == (b"error: could not delete references: multiple updates "
+                   b"for ref 'refs/tags/v' not allowed\n")
+    assert (await run(git_rw, "tag -l"))[1] == b"v\nw\n"
+
+
+@pytest.mark.asyncio
+async def test_a_name_that_is_not_there_is_reported_before_the_conflict(
+        git_rw):
+    # A name no ref answers never reaches the transaction, so it is an
+    # ordinary report and the conflict is found among what is left.
+    assert await run(git_rw, "tag v") == (0, b"", b"")
+    code, out, err = await run(git_rw, "tag -d v v nosuch")
+    assert (code, out) == (1, b"")
+    assert err == (b"error: tag 'nosuch' not found.\n"
+                   b"error: could not delete references: multiple updates "
+                   b"for ref 'refs/tags/v' not allowed\n")
+    assert (await run(git_rw, "tag -l"))[1] == b"v\n"
+
+
+@pytest.mark.asyncio
+async def test_a_missing_name_twice_is_two_reports(git_rw):
+    code, out, err = await run(git_rw, "tag -d nosuch nosuch")
+    assert (code, out) == (1, b"")
+    assert err == (b"error: tag 'nosuch' not found.\n"
+                   b"error: tag 'nosuch' not found.\n")
+
+
+@pytest.mark.asyncio
+async def test_the_blamed_ref_is_the_first_in_ref_order(git_rw):
+    # The transaction sorts its updates before it looks for the repeat,
+    # so `-d w w v v` blames v although w was typed first.
+    for name in ("v", "w"):
+        assert await run(git_rw, f"tag {name}") == (0, b"", b"")
+    _code, _out, err = await run(git_rw, "tag -d w w v v")
+    assert err == (b"error: could not delete references: multiple updates "
+                   b"for ref 'refs/tags/v' not allowed\n")

--- a/python/tests/commands/cli/builtin/git/test_tag.py
+++ b/python/tests/commands/cli/builtin/git/test_tag.py
@@ -518,3 +518,22 @@ async def test_minus_n_one_is_not_an_n_at_all(git_rw):
 async def test_minus_n_one_lists_names_alone(git_rw):
     assert await run(git_rw, "tag -a v -m body") == (0, b"", b"")
     assert (await run(git_rw, "tag -n-1"))[1] == b"v\n"
+
+
+@pytest.mark.asyncio
+async def test_a_suffix_that_is_not_a_step_writes_no_tag(git_rw):
+    # Every character used to count as another first-parent hop, so
+    # ``HEAD^x`` resolved to ``HEAD^^`` and the tag landed on a commit
+    # nobody named. git refuses the expression instead.
+    code, out, err = await run(git_rw, "tag release HEAD^x")
+    assert (code, out) == (128, b"")
+    assert err == b"fatal: Failed to resolve 'HEAD^x' as a valid ref.\n"
+    assert (await run(git_rw, "tag -l"))[1] == b""
+
+
+@pytest.mark.asyncio
+async def test_the_steps_git_does_take_still_tag(git_rw):
+    assert await run(git_rw, "tag first HEAD^") == (0, b"", b"")
+    assert await run(git_rw, "tag here HEAD^0") == (0, b"", b"")
+    assert await run(git_rw, "tag mixed HEAD^~") == (0, b"", b"")
+    assert (await run(git_rw, "tag -l"))[1] == b"first\nhere\nmixed\n"

--- a/python/tests/commands/cli/builtin/git/test_tag.py
+++ b/python/tests/commands/cli/builtin/git/test_tag.py
@@ -59,6 +59,16 @@ def test_no_n_means_no_message_lines():
     assert parse_flags(FlagView({})).lines is None
 
 
+def test_minus_one_is_where_gits_own_counter_starts():
+    # -1 is the sentinel git's parser initialises the count to, so
+    # ``-n-1`` says nothing at all rather than asking for -1 lines.
+    assert parse_flags(FlagView({"n": "-1"})).lines is None
+
+
+def test_a_count_below_the_sentinel_is_kept_for_the_refusal():
+    assert parse_flags(FlagView({"n": "-2"})).lines == -2
+
+
 def test_a_message_implies_an_annotated_tag():
     parsed = parse_flags(FlagView({"message": ["m"]}))
     assert parsed.annotate and parsed.message == "m"
@@ -463,3 +473,48 @@ async def test_force_does_not_open_a_colliding_path(git_rw):
     code, _out, err = await run(git_rw, "tag -f foo/bar")
     assert code == 128
     assert b"cannot lock ref 'refs/tags/foo/bar'" in err
+
+
+@pytest.mark.asyncio
+async def test_a_negative_count_is_fatal(git_rw):
+    # git parses the count while building the format it lists with, so
+    # the refusal names the format field rather than the option.
+    assert await run(git_rw, "tag v") == (0, b"", b"")
+    code, out, err = await run(git_rw, "tag -n-2")
+    assert (code, out) == (128, b"")
+    assert err == b"fatal: positive value expected contents:lines=-2\n"
+
+
+@pytest.mark.asyncio
+async def test_the_count_is_read_before_any_tag_is(git_rw):
+    # A pattern matching nothing would exit 0 on its own; the format is
+    # parsed first, so the refusal stands whatever the line selects.
+    code, _out, err = await run(git_rw, "tag -n-5 nosuch")
+    assert code == 128
+    assert err == b"fatal: positive value expected contents:lines=-5\n"
+
+
+@pytest.mark.asyncio
+async def test_the_list_mode_refusal_outranks_the_count(git_rw):
+    assert await run(git_rw, "tag v") == (0, b"", b"")
+    code, _out, err = await run(git_rw, "tag -d -n-2 v")
+    assert code == 128
+    assert err == b"fatal: the '-n' option is only allowed in list mode\n"
+    assert (await run(git_rw, "tag -l"))[1] == b"v\n"
+
+
+@pytest.mark.asyncio
+async def test_minus_n_one_is_not_an_n_at_all(git_rw):
+    # The sentinel reads as "-n was never given", so the two refusals a
+    # real -n earns here do not apply: the line deletes, and creates.
+    assert await run(git_rw, "tag v") == (0, b"", b"")
+    code, out, _err = await run(git_rw, "tag -d -n-1 v")
+    assert (code, out.startswith(b"Deleted tag 'v' (was ")) == (0, True)
+    assert await run(git_rw, "tag -n-1 -a later -m m") == (0, b"", b"")
+    assert (await run(git_rw, "tag -l"))[1] == b"later\n"
+
+
+@pytest.mark.asyncio
+async def test_minus_n_one_lists_names_alone(git_rw):
+    assert await run(git_rw, "tag -a v -m body") == (0, b"", b"")
+    assert (await run(git_rw, "tag -n-1"))[1] == b"v\n"

--- a/python/tests/commands/cli/builtin/git/test_tag.py
+++ b/python/tests/commands/cli/builtin/git/test_tag.py
@@ -1,0 +1,199 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from pathlib import Path
+
+import pytest
+from dulwich.objects import Commit, Tag
+from dulwich.refs import Ref
+from dulwich.repo import Repo
+
+from mirage.commands.cli.builtin.git.tag import (parse_flags, render_listing,
+                                                 selected_names, tag_names)
+from mirage.commands.spec.types import FlagView
+
+
+async def run(ws, line: str) -> tuple[int, bytes, bytes]:
+    """Run one git line against the mounted repository.
+
+    Args:
+        ws (Workspace): workspace with the repository and CLI.
+        line (str): the command line, without the leading directory.
+    """
+    result = await ws.execute(f"git -C /repo {line}")
+    return result.exit_code, result.stdout or b"", result.stderr or b""
+
+
+def tag_object(repo_path: Path, name: str):
+    """What a tag ref points at, read straight off disk.
+
+    Args:
+        repo_path (Path): the repository's working tree.
+        name (str): the tag name.
+    """
+    with Repo(str(repo_path)) as repo:
+        return repo[repo.refs[f"refs/tags/{name}".encode()]]
+
+
+def test_a_bare_n_means_one_line():
+    assert parse_flags(FlagView({"n": True})).lines == 1
+
+
+def test_an_attached_count_is_read():
+    assert parse_flags(FlagView({"n": "2"})).lines == 2
+
+
+def test_no_n_means_no_message_lines():
+    assert parse_flags(FlagView({})).lines is None
+
+
+def test_a_message_implies_an_annotated_tag():
+    parsed = parse_flags(FlagView({"message": ["m"]}))
+    assert parsed.annotate and parsed.message == "m"
+
+
+def test_several_messages_are_paragraphs():
+    assert parse_flags(FlagView({"message": ["one",
+                                             "two"]})).message == "one\n\ntwo"
+
+
+def test_tag_names_sort_in_byte_order():
+    known = {
+        Ref(b"refs/tags/a10"),
+        Ref(b"refs/tags/a9"),
+        Ref(b"refs/tags/B"),
+        Ref(b"refs/heads/main")
+    }
+    assert tag_names(known) == ["B", "a10", "a9"]
+
+
+def test_patterns_keep_any_match():
+    assert selected_names(["v0.9", "v1.0", "w"], ("v1*", "w")) == ["v1.0", "w"]
+
+
+def test_no_pattern_keeps_everything():
+    assert selected_names(["a", "b"], ()) == ["a", "b"]
+
+
+def test_listing_pads_the_name_and_indents_continuations():
+    rendered = render_listing(["v1", "v2"], {
+        "v1": ["first", "second"],
+        "v2": []
+    }, 2)
+    assert rendered == (b"v1              first\n"
+                        b"    second\n"
+                        b"v2              \n")
+
+
+@pytest.mark.asyncio
+async def test_a_bare_name_makes_a_lightweight_tag(git_rw, repo_path: Path):
+    assert await run(git_rw, "tag v1.0") == (0, b"", b"")
+    assert isinstance(tag_object(repo_path, "v1.0"), Commit)
+    assert (await run(git_rw, "tag"))[1] == b"v1.0\n"
+
+
+@pytest.mark.asyncio
+async def test_a_tag_points_where_it_is_told(git_rw, repo_path: Path):
+    await run(git_rw, "tag old HEAD~1")
+    with Repo(str(repo_path)) as repo:
+        parent = repo[repo.refs[b"refs/heads/main"]].parents[0]
+        assert repo.refs[b"refs/tags/old"] == parent
+
+
+@pytest.mark.asyncio
+async def test_a_message_writes_a_tag_object(git_rw, repo_path: Path):
+    assert await run(git_rw, "tag -a v1.1 -m 'first release'") == (0, b"", b"")
+    written = tag_object(repo_path, "v1.1")
+    assert isinstance(written, Tag)
+    assert written.message == b"first release\n"
+    assert written.tagger == b"mirage <mirage@localhost>"
+    assert (await run(git_rw,
+                      "tag -n"))[1] == b"v1.1            first release\n"
+
+
+@pytest.mark.asyncio
+async def test_annotated_needs_a_message(git_rw):
+    code, _out, err = await run(git_rw, "tag -a v1.2")
+    assert code == 128
+    assert err == (b"fatal: no tag message supplied (mirage has no editor "
+                   b"to open; pass -m)\n")
+
+
+@pytest.mark.asyncio
+async def test_a_name_that_exists_is_refused(git_rw):
+    await run(git_rw, "tag v1.0")
+    code, _out, err = await run(git_rw, "tag v1.0")
+    assert code == 128
+    assert err == b"fatal: tag 'v1.0' already exists\n"
+
+
+@pytest.mark.asyncio
+async def test_force_moves_the_tag(git_rw):
+    await run(git_rw, "tag v1.0 HEAD~1")
+    code, out, _err = await run(git_rw, "tag -f v1.0")
+    assert code == 0
+    assert out.startswith(b"Updated tag 'v1.0' (was ")
+
+
+@pytest.mark.asyncio
+async def test_an_object_it_cannot_resolve_is_fatal(git_rw):
+    code, _out, err = await run(git_rw, "tag v2 nosuchrev")
+    assert code == 128
+    assert err == b"fatal: Failed to resolve 'nosuchrev' as a valid ref.\n"
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_name_is_fatal(git_rw):
+    code, _out, err = await run(git_rw, "tag 'bad name'")
+    assert code == 128
+    assert err == b"fatal: 'bad name' is not a valid tag name.\n"
+
+
+@pytest.mark.asyncio
+async def test_l_filters_by_pattern(git_rw):
+    await run(git_rw, "tag v0.9")
+    await run(git_rw, "tag v1.0")
+    assert (await run(git_rw, "tag -l 'v1*'"))[1] == b"v1.0\n"
+
+
+@pytest.mark.asyncio
+async def test_d_deletes_and_reports_a_miss_without_stopping(git_rw):
+    await run(git_rw, "tag v1.0")
+    code, out, err = await run(git_rw, "tag -d nosuch v1.0")
+    assert code == 1
+    assert out.startswith(b"Deleted tag 'v1.0' (was ")
+    assert err == b"error: tag 'nosuch' not found.\n"
+    assert (await run(git_rw, "tag"))[1] == b""
+
+
+@pytest.mark.asyncio
+async def test_l_and_d_cannot_mix(git_rw):
+    code, _out, err = await run(git_rw, "tag -d -l")
+    assert code == 129
+    assert err == b"error: options '-l' and '-d' cannot be used together\n"
+
+
+@pytest.mark.asyncio
+async def test_a_tag_on_a_tag_points_at_the_tag_object(git_rw,
+                                                       repo_path: Path):
+    await run(git_rw, "tag -a v1 -m m")
+    await run(git_rw, "tag alias v1")
+    assert isinstance(tag_object(repo_path, "alias"), Tag)
+
+
+@pytest.mark.asyncio
+async def test_a_tag_resolves_as_a_revision(git_rw):
+    await run(git_rw, "tag old HEAD~1")
+    assert (await run(git_rw,
+                      "log --oneline -n 1 old"))[1].endswith(b" second\n")

--- a/python/tests/commands/cli/builtin/git/test_tag.py
+++ b/python/tests/commands/cli/builtin/git/test_tag.py
@@ -432,3 +432,34 @@ async def test_the_blamed_ref_is_the_first_in_ref_order(git_rw):
     _code, _out, err = await run(git_rw, "tag -d w w v v")
     assert err == (b"error: could not delete references: multiple updates "
                    b"for ref 'refs/tags/v' not allowed\n")
+
+
+@pytest.mark.asyncio
+async def test_a_tag_cannot_be_made_below_one_that_exists(git_rw):
+    assert (await run(git_rw, "tag foo"))[0] == 0
+    code, _out, err = await run(git_rw, "tag foo/bar")
+    assert code == 128
+    assert err == (b"fatal: cannot lock ref 'refs/tags/foo/bar': "
+                   b"'refs/tags/foo' exists; cannot create "
+                   b"'refs/tags/foo/bar'\n")
+    assert (await run(git_rw, "tag -l"))[1] == b"foo\n"
+
+
+@pytest.mark.asyncio
+async def test_a_tag_cannot_be_made_above_one_that_exists(git_rw):
+    assert (await run(git_rw, "tag baz/qux"))[0] == 0
+    code, _out, err = await run(git_rw, "tag baz")
+    assert code == 128
+    assert err == (b"fatal: cannot lock ref 'refs/tags/baz': "
+                   b"'refs/tags/baz/qux' exists; cannot create "
+                   b"'refs/tags/baz'\n")
+
+
+@pytest.mark.asyncio
+async def test_force_does_not_open_a_colliding_path(git_rw):
+    assert (await run(git_rw, "tag foo"))[0] == 0
+    # The obstacle is the path, not the value, so -f has nothing to
+    # overwrite.
+    code, _out, err = await run(git_rw, "tag -f foo/bar")
+    assert code == 128
+    assert b"cannot lock ref 'refs/tags/foo/bar'" in err

--- a/python/tests/commands/cli/builtin/git/test_tag.py
+++ b/python/tests/commands/cli/builtin/git/test_tag.py
@@ -248,3 +248,41 @@ async def test_deleting_a_packed_tag_removes_it(repo_path: Path):
     assert "refs/tags/" not in packed
     assert "^" not in packed
     assert "refs/heads/main" in packed
+
+
+@pytest.mark.asyncio
+async def test_n0_prints_bare_names(git_rw):
+    await run(git_rw, "tag -a v1 -m msg")
+    await run(git_rw, "tag lw")
+    assert (await run(git_rw, "tag -n0"))[1] == b"lw\nv1\n"
+    assert (await run(git_rw, "tag -n1"))[1] == (b"lw              third\n"
+                                                 b"v1              msg\n")
+
+
+@pytest.mark.asyncio
+async def test_a_tag_can_point_at_a_blob(git_rw, repo_path: Path):
+    with Repo(str(repo_path)) as repo:
+        blob = repo.get_object(repo[b"HEAD"].tree).lookup_path(
+            repo.get_object, b"a.txt")[1].decode()
+    assert await run(git_rw, f"tag blobtag {blob}") == (0, b"", b"")
+    assert tag_object(repo_path, "blobtag").id.decode() == blob
+    assert (await run(git_rw, "tag -n0"))[1] == b"blobtag\n"
+
+
+@pytest.mark.asyncio
+async def test_an_annotated_tag_records_the_blob_type(git_rw, repo_path: Path):
+    with Repo(str(repo_path)) as repo:
+        blob = repo.get_object(repo[b"HEAD"].tree).lookup_path(
+            repo.get_object, b"a.txt")[1].decode()
+    assert await run(git_rw, f"tag -a annblob -m m {blob}") == (0, b"", b"")
+    written = tag_object(repo_path, "annblob")
+    assert isinstance(written, Tag)
+    assert written.object[0].type_name == b"blob"
+    assert written.object[1].decode() == blob
+
+
+@pytest.mark.asyncio
+async def test_a_target_that_is_no_object_is_still_refused(git_rw):
+    code, _out, err = await run(git_rw, "tag v2 nosuchrev")
+    assert code == 128
+    assert err == b"fatal: Failed to resolve 'nosuchrev' as a valid ref.\n"

--- a/python/tests/commands/cli/builtin/git/test_tag.py
+++ b/python/tests/commands/cli/builtin/git/test_tag.py
@@ -320,3 +320,41 @@ async def test_an_expression_that_resolves_to_nothing_is_refused(git_rw):
     assert code == 128
     assert err == (b"fatal: Failed to resolve 'HEAD:nosuch' as a valid "
                    b"ref.\n")
+
+
+@pytest.mark.asyncio
+async def test_a_lightweight_tag_naming_a_blob_keeps_its_type(
+        git_rw, repo_path: Path):
+    # A lightweight tag is a ref like any other and points at whatever
+    # it was made from, so the annotated tag records the type read
+    # rather than assuming a commit: `type commit` beside a blob id is a
+    # tag object git show and git fsck reject.
+    assert (await run(git_rw, "tag blobtag HEAD:a.txt"))[0] == 0
+    assert await run(git_rw, "tag -a release -m x blobtag") == (0, b"", b"")
+    written = tag_object(repo_path, "release")
+    assert isinstance(written, Tag)
+    assert written.object[0].type_name == b"blob"
+
+
+@pytest.mark.asyncio
+async def test_a_lightweight_tag_naming_a_tree_keeps_its_type(
+        git_rw, repo_path: Path):
+    assert (await run(git_rw, "tag treetag HEAD^{tree}"))[0] == 0
+    assert await run(git_rw, "tag -a treerel -m x treetag") == (0, b"", b"")
+    written = tag_object(repo_path, "treerel")
+    assert isinstance(written, Tag)
+    assert written.object[0].type_name == b"tree"
+
+
+@pytest.mark.asyncio
+async def test_a_bare_tag_id_makes_a_nested_tag(git_rw, repo_path: Path):
+    assert (await run(git_rw, "tag -a v1 -m annotated"))[0] == 0
+    with Repo(str(repo_path)) as repo:
+        held = repo.refs[b"refs/tags/v1"].decode()
+    assert (await run(git_rw, f"tag -a nested -m x {held}"))[0] == 0
+    written = tag_object(repo_path, "nested")
+    assert isinstance(written, Tag)
+    # git reads a bare id as that exact object, so the new tag points at
+    # the tag rather than at the commit behind it.
+    assert written.object[0].type_name == b"tag"
+    assert written.object[1].decode() == held

--- a/python/tests/commands/cli/builtin/git/test_tree.py
+++ b/python/tests/commands/cli/builtin/git/test_tree.py
@@ -45,7 +45,7 @@ def test_tree_shape():
     assert GIT.name == "git"
     assert [v.name for v in GIT.subcommands] == [
         "status", "log", "show", "diff", "branch", "add", "reset", "commit",
-        "checkout"
+        "checkout", "switch", "restore", "rm", "mv", "tag"
     ]
 
 

--- a/python/tests/commands/cli/builtin/git/test_util.py
+++ b/python/tests/commands/cli/builtin/git/test_util.py
@@ -14,9 +14,10 @@
 
 import pytest
 
-from mirage.commands.cli.builtin.git.errors import (FATAL_EXIT,
-                                                    NotARepositoryError)
-from mirage.commands.cli.builtin.git.util import fatal, start_point
+from mirage.commands.cli.builtin.git.errors import (  # yapf: disable
+    FATAL_EXIT, NotARepositoryError, UnknownSwitchError)
+from mirage.commands.cli.builtin.git.util import (check_operands, escaped,
+                                                  fatal, start_point)
 from mirage.commands.spec.types import FlagView
 
 
@@ -120,3 +121,24 @@ async def test_branch_speaks_the_same_dialect(git_ws):
     result = await git_ws.execute("git -C /repo branch -Z")
     assert result.exit_code == 129
     assert result.stderr == b"error: unknown switch `Z'\n"
+
+
+def test_no_marker_escapes_nothing():
+    assert escaped(("rm", "-f", "a.txt")) == frozenset()
+
+
+def test_the_marker_escapes_every_word_after_it():
+    assert escaped(("rm", "--", "-draft", "b.txt")) == {"-draft", "b.txt"}
+
+
+def test_only_the_first_marker_counts():
+    assert escaped(("rm", "--", "-a", "--", "-b")) == {"-a", "--", "-b"}
+
+
+def test_an_escaped_operand_is_not_a_switch():
+    check_operands(("-draft", ), UnknownSwitchError, frozenset({"-draft"}))
+
+
+def test_an_unescaped_dashed_operand_is_still_refused():
+    with pytest.raises(UnknownSwitchError):
+        check_operands(("-draft", ), UnknownSwitchError, frozenset({"-other"}))

--- a/python/tests/workspace/dispatcher/test_dispatcher.py
+++ b/python/tests/workspace/dispatcher/test_dispatcher.py
@@ -302,18 +302,39 @@ async def test_rename_carries_the_nodes_below_a_directory():
 
 
 @pytest.mark.asyncio
-async def test_rename_replaces_the_nodes_below_the_destination():
-    # rename(2) replaces what it lands on, subtree included, so a link
-    # left below the destination would shadow the content that arrived.
+async def test_rename_refuses_a_destination_holding_a_link():
+    # A link is a directory entry no backend can see, so a destination
+    # the backend reads as empty is not: POSIX rename(2) answers
+    # ENOTEMPTY for it (probed on debian:stable-slim, where a directory
+    # holding one broken symlink refuses the rename). Letting the
+    # backend decide replaced the directory and deleted the link with
+    # it, which loses namespace state where the kernel refuses.
     with Workspace({"/ram/": RAMResource()}, mode=MountMode.WRITE) as ws:
         await ws.execute("mkdir -p /ram/d /ram/e && echo hi > /ram/d/a.txt")
         await ws.execute("ln -s a.txt /ram/d/link")
         await ws.execute("ln -s gone /ram/e/stale")
+        with pytest.raises(OSError) as caught:
+            await ws.dispatch("rename",
+                              PathSpec.from_str_path("/ram/d"),
+                              dst=PathSpec.from_str_path("/ram/e"))
+        assert caught.value.errno == errno.ENOTEMPTY
+        # Nothing moved: both ends are as they were.
+        assert ws._namespace.readlink("/ram/e/stale") == "gone"
+        assert ws._namespace.readlink("/ram/d/link") == "a.txt"
+
+
+@pytest.mark.asyncio
+async def test_rename_replaces_an_empty_destination():
+    # The other half of rename(2): a destination with nothing in it is
+    # replaced, and the subtree re-anchors onto the new name.
+    with Workspace({"/ram/": RAMResource()}, mode=MountMode.WRITE) as ws:
+        await ws.execute("mkdir -p /ram/d /ram/e && echo hi > /ram/d/a.txt")
+        await ws.execute("ln -s a.txt /ram/d/link")
         await ws.dispatch("rename",
                           PathSpec.from_str_path("/ram/d"),
                           dst=PathSpec.from_str_path("/ram/e"))
-        assert not ws._namespace.is_link("/ram/e/stale")
         assert ws._namespace.readlink("/ram/e/link") == "a.txt"
+        assert not ws._namespace.is_link("/ram/d/link")
 
 
 @pytest.mark.asyncio

--- a/python/tests/workspace/dispatcher/test_dispatcher.py
+++ b/python/tests/workspace/dispatcher/test_dispatcher.py
@@ -286,6 +286,37 @@ async def test_rename_moves_a_namespace_link():
 
 
 @pytest.mark.asyncio
+async def test_rename_carries_the_nodes_below_a_directory():
+    # A rename re-anchors a whole subtree, and the part of it no backend
+    # can see has to move with it: the link below the source used to
+    # stay at a name the rename had emptied, so the moved directory was
+    # missing it and the old name still answered readlink.
+    with Workspace({"/ram/": RAMResource()}, mode=MountMode.WRITE) as ws:
+        await ws.execute("mkdir -p /ram/d && echo hi > /ram/d/a.txt")
+        await ws.execute("ln -s a.txt /ram/d/link")
+        await ws.dispatch("rename",
+                          PathSpec.from_str_path("/ram/d"),
+                          dst=PathSpec.from_str_path("/ram/e"))
+        assert not ws._namespace.is_link("/ram/d/link")
+        assert ws._namespace.readlink("/ram/e/link") == "a.txt"
+
+
+@pytest.mark.asyncio
+async def test_rename_replaces_the_nodes_below_the_destination():
+    # rename(2) replaces what it lands on, subtree included, so a link
+    # left below the destination would shadow the content that arrived.
+    with Workspace({"/ram/": RAMResource()}, mode=MountMode.WRITE) as ws:
+        await ws.execute("mkdir -p /ram/d /ram/e && echo hi > /ram/d/a.txt")
+        await ws.execute("ln -s a.txt /ram/d/link")
+        await ws.execute("ln -s gone /ram/e/stale")
+        await ws.dispatch("rename",
+                          PathSpec.from_str_path("/ram/d"),
+                          dst=PathSpec.from_str_path("/ram/e"))
+        assert not ws._namespace.is_link("/ram/e/stale")
+        assert ws._namespace.readlink("/ram/e/link") == "a.txt"
+
+
+@pytest.mark.asyncio
 async def test_a_no_follow_stat_answers_a_links_own_row():
     # lstat asks for the row only the node table holds. Without it every
     # surface rebuilt the row from the target string and reported epoch

--- a/python/tests/workspace/dispatcher/test_dispatcher.py
+++ b/python/tests/workspace/dispatcher/test_dispatcher.py
@@ -21,6 +21,7 @@ from mirage.context import reset_current_session, set_current_session
 from mirage.policy import (Action, CommandRule, Deny, OpsContext, Policies,
                            Policy, PolicyDenied)
 from mirage.policy.rule import RulePolicy
+from mirage.resource.disk import DiskResource
 from mirage.resource.ram import RAMResource
 from mirage.types import (ConsistencyPolicy, FileType, HiddenPaths, MountMode,
                           PathSpec)
@@ -596,3 +597,24 @@ async def test_a_non_oserror_cascade_failure_keeps_the_refusal(monkeypatch):
     assert exc.value.errno in (errno.ENOTEMPTY, errno.EEXIST)
     kept = await ws.execute("cat /a/d/sec/k")
     assert (kept.stdout or b"") == b"k\n"
+
+
+@pytest.mark.asyncio
+async def test_a_directory_rename_drops_the_listing_cached_below_it(tmp_path):
+    # The old name kept answering from its cached children after the
+    # move, so a later rename onto that name saw a directory that was no
+    # longer there and landed the source inside it.
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "readme.md").write_text("notes\n", encoding="utf-8")
+    with Workspace({"/disk/": DiskResource(root=str(tmp_path))},
+                   mode=MountMode.WRITE) as ws:
+        listed = await ws.execute("ls /disk/docs")
+        assert listed.stdout == b"readme.md\n"
+        await ws.dispatch("rename",
+                          PathSpec.from_str_path("/disk/docs"),
+                          dst=PathSpec.from_str_path("/disk/moved"))
+        gone = await ws.execute("test -d /disk/docs && echo stale || echo gone"
+                                )
+        assert gone.stdout == b"gone\n"
+        assert (await ws.execute("ls /disk/docs")).exit_code != 0
+        assert (await ws.execute("ls /disk/moved")).stdout == b"readme.md\n"

--- a/python/tests/workspace/dispatcher/test_dispatcher.py
+++ b/python/tests/workspace/dispatcher/test_dispatcher.py
@@ -670,3 +670,36 @@ async def test_a_directory_rename_drops_the_listing_cached_below_it(tmp_path):
         assert gone.stdout == b"gone\n"
         assert (await ws.execute("ls /disk/docs")).exit_code != 0
         assert (await ws.execute("ls /disk/moved")).stdout == b"readme.md\n"
+
+
+@pytest.mark.asyncio
+async def test_a_rename_carries_the_node_at_the_source(tmp_path):
+    # The subtree below the source was re-anchored and the source's own
+    # node was not, so the mode a chmod recorded stayed at the emptied
+    # name: the landing read as the unclamped file and whatever was
+    # created at the old name next inherited the overlay.
+    (tmp_path / "a.txt").write_text("one\n", encoding="utf-8")
+    with Workspace({"/disk/": DiskResource(root=str(tmp_path))},
+                   mode=MountMode.WRITE) as ws:
+        assert (await ws.execute("chmod 400 /disk/a.txt")).exit_code == 0
+        assert ws.namespace.meta_for("/disk/a.txt").mode == 0o400
+        await ws.dispatch("rename",
+                          PathSpec.from_str_path("/disk/a.txt"),
+                          dst=PathSpec.from_str_path("/disk/b.txt"))
+        assert ws.namespace.meta_for("/disk/a.txt") is None
+        assert ws.namespace.meta_for("/disk/b.txt").mode == 0o400
+
+
+@pytest.mark.asyncio
+async def test_a_rename_replaces_the_node_at_the_landing(tmp_path):
+    # rename(2) replaces the destination, so the overlay it carried goes
+    # with it rather than staying to shadow what just landed.
+    (tmp_path / "a.txt").write_text("one\n", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("two\n", encoding="utf-8")
+    with Workspace({"/disk/": DiskResource(root=str(tmp_path))},
+                   mode=MountMode.WRITE) as ws:
+        assert (await ws.execute("chmod 400 /disk/b.txt")).exit_code == 0
+        await ws.dispatch("rename",
+                          PathSpec.from_str_path("/disk/a.txt"),
+                          dst=PathSpec.from_str_path("/disk/b.txt"))
+        assert ws.namespace.meta_for("/disk/b.txt") is None

--- a/python/tests/workspace/executor/builtins/links/test_links.py
+++ b/python/tests/workspace/executor/builtins/links/test_links.py
@@ -6,7 +6,8 @@ from mirage.types import MountMode, PathSpec
 from mirage.workspace import Workspace
 from mirage.workspace.executor.builtins.links import (accepts_line,
                                                       follow_parent,
-                                                      follow_paths, link_flags)
+                                                      follow_paths, link_flags,
+                                                      prepare_mv)
 
 
 def _ws() -> Workspace:
@@ -259,3 +260,57 @@ async def test_one_read_only_mount_speaks_once():
         assert r.stderr == b"rm: read-only mount at /data/\n", line
     assert ws.namespace.is_link("/data/l1")
     assert ws.namespace.is_link("/data/l2")
+
+
+@pytest.mark.asyncio
+async def test_prepare_mv_hands_back_the_pair_whatever_the_table_holds():
+    # Gated on the source carrying overlay attrs, the pair was withheld
+    # for a directory whose own node is empty, and every link below it
+    # stayed at the emptied name: readable nowhere, since the backend
+    # holds no entry for a link at all.
+    ws = _ws()
+    await ws.execute("mkdir -p /data/d; printf 't\\n' > /data/t")
+    await ws.execute("ln -s /data/t /data/d/link")
+    _items, unlinked, renamed, early = await prepare_mv(
+        ws.namespace, ws.dispatch, [
+            PathSpec.from_str_path("/data/d"),
+            PathSpec.from_str_path("/data/moved")
+        ], ("/data/d", "/data/moved"), "/")
+    assert early is None
+    assert unlinked == "/data/moved"
+    assert renamed == ("/data/d", "/data/moved")
+
+
+@pytest.mark.asyncio
+async def test_prepare_mv_reads_the_destination_off_the_parsed_line():
+    # -T names the destination outright, so the basename is not appended
+    # to it, and -t makes every positional a source, which is the shape
+    # a two-operand pair cannot describe at all.
+    ws = _ws()
+    await ws.execute("mkdir -p /data/dst; printf 'a\\n' > /data/a")
+    pair = [
+        PathSpec.from_str_path("/data/a"),
+        PathSpec.from_str_path("/data/dst")
+    ]
+    _items, _unlinked, renamed, _early = await prepare_mv(
+        ws.namespace, ws.dispatch, pair, ("/data/a", "/data/dst"), "/")
+    assert renamed == ("/data/a", "/data/dst/a")
+    _items, _unlinked, no_target, _early = await prepare_mv(
+        ws.namespace, ws.dispatch, pair, ("-T", "/data/a", "/data/dst"), "/")
+    assert no_target == ("/data/a", "/data/dst")
+    _items, _unlinked, target_dir, _early = await prepare_mv(
+        ws.namespace, ws.dispatch, pair, ("-t", "/data/dst", "/data/a"), "/")
+    assert target_dir is None
+
+
+@pytest.mark.asyncio
+async def test_a_link_below_a_renamed_directory_moves_with_it():
+    ws = _ws()
+    await ws.execute("mkdir -p /data/d; printf 't\\n' > /data/t")
+    await ws.execute("ln -s /data/t /data/d/link")
+    assert (await ws.execute("mv /data/d /data/moved")).exit_code == 0
+    read = await ws.execute("readlink /data/moved/link")
+    assert read.exit_code == 0
+    assert read.stdout == b"/data/t\n"
+    assert (await ws.execute("cat /data/moved/link")).stdout == b"t\n"
+    assert (await ws.execute("readlink /data/d/link")).exit_code != 0

--- a/typescript/packages/core/src/commands/cli/builtin/git/add.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/add.ts
@@ -37,7 +37,7 @@ import { matched, repoRelative } from './pathspec.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { EXECUTABLE, OWNER_EXECUTE, REGULAR, SYMLINK } from './constants.ts'
 import type { RepoLocation, WorkTree } from './types.ts'
-import { checkOperands, fatal, startPoint } from './util.ts'
+import { checkOperands, escaped, fatal, startPoint } from './util.ts'
 import { scan, UNTRACKED_ALL } from './worktree.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
@@ -187,7 +187,7 @@ export async function add(inv: CLIInvocation): Promise<CommandFnResult> {
     if (statPath === undefined || dispatch === undefined) {
       throw new NoWorkspaceError()
     }
-    checkOperands(texts, UnknownSwitchError)
+    checkOperands(texts, UnknownSwitchError, escaped(inv.argv))
     const parsed = parseFlags(fl)
     if (texts.length === 0 && !parsed.every && !parsed.update) throw new NothingSpecifiedError()
     const repo: Repo = await opened(fl, doors)

--- a/typescript/packages/core/src/commands/cli/builtin/git/branch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/branch.ts
@@ -27,11 +27,20 @@ import {
   InvalidBranchNameError,
   NoBranchError,
   NoWorkspaceError,
+  RefLockError,
   UnknownSwitchError,
   UnmergedBranchError,
 } from './errors.ts'
 import { short } from './format.ts'
-import { deleteRef, loadRefs, readHead, validRefName, writeRef, SYMREF_PREFIX } from './refs.ts'
+import {
+  blockingRef,
+  deleteRef,
+  loadRefs,
+  readHead,
+  validRefName,
+  writeRef,
+  SYMREF_PREFIX,
+} from './refs.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
 import type { Dispatch, HeadRef } from './types.ts'
@@ -74,6 +83,10 @@ async function create(
   const ref = `${HEADS_PREFIX}${name}`
   if (refs.has(ref)) throw new BranchExistsError(name)
   const oid = await resolveCommit(repo, start ?? HEAD)
+  // Last, as it is for git: a ref whose path another ref already holds fails
+  // when the lock is taken, so a bad start point is reported first.
+  const held = blockingRef(new Set(refs.keys()), ref)
+  if (held !== null) throw new RefLockError(ref, held)
   await writeRef(dispatch, repo.location.commondir, ref, oid)
 }
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/branch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/branch.ts
@@ -78,7 +78,7 @@ async function create(
  * HEAD carries an object id only when detached; attached it names a ref, which
  * is unset until the first commit.
  */
-function headCommit(refs: ReadonlyMap<string, string>, head: HeadRef): string | null {
+export function headCommit(refs: ReadonlyMap<string, string>, head: HeadRef): string | null {
   if (head.commit !== null) return head.commit
   if (head.ref === null) return null
   return refs.get(head.ref) ?? null

--- a/typescript/packages/core/src/commands/cli/builtin/git/branch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/branch.ts
@@ -24,13 +24,14 @@ import {
   BranchNameRequiredError,
   CheckedOutBranchError,
   GitError,
+  InvalidBranchNameError,
   NoBranchError,
   NoWorkspaceError,
   UnknownSwitchError,
   UnmergedBranchError,
 } from './errors.ts'
 import { short } from './format.ts'
-import { deleteRef, loadRefs, readHead, writeRef, SYMREF_PREFIX } from './refs.ts'
+import { deleteRef, loadRefs, readHead, validRefName, writeRef, SYMREF_PREFIX } from './refs.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
 import type { Dispatch, HeadRef } from './types.ts'
@@ -66,6 +67,10 @@ async function create(
   name: string,
   start: string | undefined,
 ): Promise<void> {
+  // Before the start point resolves, which is git's order here and the
+  // opposite of switch's. A ref is a path below .git, so an unchecked name
+  // reaches writeRef as one.
+  if (!validRefName(name)) throw new InvalidBranchNameError(name)
   const ref = `${HEADS_PREFIX}${name}`
   if (refs.has(ref)) throw new BranchExistsError(name)
   const oid = await resolveCommit(repo, start ?? HEAD)

--- a/typescript/packages/core/src/commands/cli/builtin/git/branch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/branch.ts
@@ -35,7 +35,7 @@ import { deleteRef, loadRefs, readHead, validRefName, writeRef, SYMREF_PREFIX } 
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
 import type { Dispatch, HeadRef } from './types.ts'
-import { checkOperands, fatal } from './util.ts'
+import { checkOperands, escaped, fatal } from './util.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
 const ENC = new TextEncoder()
@@ -147,7 +147,7 @@ export async function branch(inv: CLIInvocation): Promise<CommandFnResult> {
   try {
     const dispatch = doors.dispatch
     if (dispatch === undefined) throw new NoWorkspaceError()
-    checkOperands(texts, UnknownSwitchError)
+    checkOperands(texts, UnknownSwitchError, escaped(inv.argv))
     const repo = await opened(fl, doors)
     refs = await loadRefs(dispatch, repo.location.gitdir, repo.location.commondir)
     head = await readHead(dispatch, repo.location.gitdir)

--- a/typescript/packages/core/src/commands/cli/builtin/git/changes.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/changes.ts
@@ -35,7 +35,7 @@ import { scan } from './worktree.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
 const UNCHANGED = ' '
-const MODIFIED = 'M'
+export const MODIFIED = 'M'
 const ADDED = 'A'
 const DELETED = 'D'
 const RENAMED = 'R'

--- a/typescript/packages/core/src/commands/cli/builtin/git/changes.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/changes.ts
@@ -36,8 +36,8 @@ import { compareCodePoints } from '../../../../utils/sort.ts'
 
 const UNCHANGED = ' '
 export const MODIFIED = 'M'
-const ADDED = 'A'
-const DELETED = 'D'
+export const ADDED = 'A'
+export const DELETED = 'D'
 const RENAMED = 'R'
 const UNTRACKED = '?'
 // git's own two rename knobs: a pair counts as a rename at 60% shared content,

--- a/typescript/packages/core/src/commands/cli/builtin/git/changes.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/changes.ts
@@ -46,11 +46,16 @@ const UNTRACKED = '?'
 // git gives up rather than answer differently.
 const RENAME_THRESHOLD = 60
 const MAX_RENAME_FILES = 200
-// A regular file, as the mode's type bits spell it. Only these are rename
-// candidates: a symlink and a file that happen to share bytes are not a rename
-// of each other.
+// A regular file, as the mode's type bits spell it. Only these are scored for
+// similarity: a symlink is paired only with another symlink holding the same
+// bytes, since scoring one against a file would pair two unrelated things by
+// the bytes of a path.
 const REGULAR_MODE = '100644'
 const REGULAR_EXEC_MODE = '100755'
+// What a mode says a path is, for pairing within one kind. Only the executable
+// bit separates the two regular modes, and git renames across it.
+const SYMLINK_KIND = 'symlink'
+const REGULAR_KIND = 'regular'
 
 // git spells an unmerged path by which of the three index stages it kept, keyed
 // here as (ancestor, ours, theirs). The pair is the porcelain XY, and the long
@@ -70,6 +75,12 @@ type StagedRow = readonly [string, string | null]
 
 function isRegular(mode: string): boolean {
   return mode === REGULAR_MODE || mode === REGULAR_EXEC_MODE
+}
+
+/** What a mode makes a path, for a rename pair that must not cross kinds. */
+function kindOf(mode: string): string {
+  if (isRegular(mode)) return REGULAR_KIND
+  return mode === '120000' ? SYMLINK_KIND : mode
 }
 
 /**
@@ -94,23 +105,30 @@ export async function headEntries(repo: Repo): Promise<Map<string, TreeEntry> | 
  * Pair an add with a delete holding byte-identical content.
  *
  * Costs a map rather than a read, so it runs first and takes every pair it can
- * before anything is fetched.
+ * before anything is fetched. Keyed by kind as well as content, because a
+ * symlink and a regular file that happen to share bytes are not a rename of
+ * each other, while a moved symlink is exactly one.
  */
 function exactRenames(
   adds: readonly string[],
   deletes: readonly string[],
   oids: ReadonlyMap<string, string>,
+  kinds: ReadonlyMap<string, string>,
 ): [string, string][] {
+  const key = (path: string): string | undefined => {
+    const oid = oids.get(path)
+    return oid === undefined ? undefined : `${kinds.get(path) ?? ''}:${oid}`
+  }
   const sources = new Map<string, string>()
   for (const path of deletes) {
-    const oid = oids.get(path)
-    if (oid !== undefined && !sources.has(oid)) sources.set(oid, path)
+    const held = key(path)
+    if (held !== undefined && !sources.has(held)) sources.set(held, path)
   }
   const taken = new Set<string>()
   const pairs: [string, string][] = []
   for (const path of adds) {
-    const oid = oids.get(path)
-    const origin = oid === undefined ? undefined : sources.get(oid)
+    const held = key(path)
+    const origin = held === undefined ? undefined : sources.get(held)
     if (origin !== undefined && !taken.has(origin)) {
       taken.add(origin)
       pairs.push([path, origin])
@@ -187,29 +205,31 @@ async function contentRenames(
  * Fold an add and a delete of the same file into one rename.
  *
  * Two passes, git's own order: identical content first, then what is merely
- * similar enough.
+ * similar enough. Both pair within one kind, and only the second is limited to
+ * regular files: a moved symlink is a rename git reports as one.
  */
 async function pairRenames(
   repo: Repo,
   staged: ReadonlyMap<string, string>,
   oids: ReadonlyMap<string, string>,
-  regular: ReadonlySet<string>,
+  kinds: ReadonlyMap<string, string>,
 ): Promise<Map<string, StagedRow>> {
   const pick = (letter: string): string[] =>
     [...staged.entries()]
-      .filter(([path, held]) => held === letter && regular.has(path))
+      .filter(([path, held]) => held === letter && kinds.has(path))
       .map(([path]) => path)
       .sort(compareCodePoints)
   const adds = pick(ADDED)
   const deletes = pick(DELETED)
-  const pairs = exactRenames(adds, deletes, oids)
+  const pairs = exactRenames(adds, deletes, oids, kinds)
   const matchedNew = new Set(pairs.map(([fresh]) => fresh))
   const matchedOld = new Set(pairs.map(([, old]) => old))
+  const scored = (side: string[]): string[] => side.filter((p) => kinds.get(p) === REGULAR_KIND)
   pairs.push(
     ...(await contentRenames(
       repo,
-      adds.filter((p) => !matchedNew.has(p)),
-      deletes.filter((p) => !matchedOld.has(p)),
+      scored(adds.filter((p) => !matchedNew.has(p))),
+      scored(deletes.filter((p) => !matchedOld.has(p))),
       oids,
     )),
   )
@@ -240,13 +260,13 @@ async function stageChanges(
   const tree = head ?? new Map<string, TreeEntry>()
   const staged = new Map<string, string>()
   const oids = new Map<string, string>()
-  const regular = new Set<string>()
+  const kinds = new Map<string, string>()
   for (const [path, entry] of entries) {
     const recorded = tree.get(path)
     if (recorded === undefined) {
       staged.set(path, ADDED)
       oids.set(path, entry.oid)
-      if (isRegular(entry.mode.toString(8))) regular.add(path)
+      kinds.set(path, kindOf(entry.mode.toString(8)))
     } else if (recorded.oid !== entry.oid || Number.parseInt(recorded.mode, 8) !== entry.mode) {
       staged.set(path, MODIFIED)
     }
@@ -255,9 +275,9 @@ async function stageChanges(
     if (entries.has(path) || conflicts.has(path)) continue
     staged.set(path, DELETED)
     oids.set(path, recorded.oid)
-    if (isRegular(recorded.mode)) regular.add(path)
+    kinds.set(path, kindOf(recorded.mode))
   }
-  return pairRenames(repo, staged, oids, regular)
+  return pairRenames(repo, staged, oids, kinds)
 }
 
 /** The two-letter code for each unmerged path. */

--- a/typescript/packages/core/src/commands/cli/builtin/git/changes.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/changes.ts
@@ -17,6 +17,7 @@ import git from 'isomorphic-git'
 import type { LinkView, StatPath } from '../../../../ops/types.ts'
 import type { FileStat } from '../../../../types.ts'
 import { isMissingPath } from '../../../../utils/errors.ts'
+import { GITLINK_MODE } from './constants.ts'
 import { readIndex } from './index_file.ts'
 import { entryBytes, under } from './io.ts'
 import { repoArgs, type Repo } from './repo.ts'
@@ -352,6 +353,14 @@ export async function workChanges(
 ): Promise<Map<string, string>> {
   const changes = new Map<string, string>()
   for (const [path, entry] of entries) {
+    // A 160000 entry records another repository's HEAD, and what stands at the
+    // name is a directory, so the walk never finds a file there and every
+    // submodule read as deleted. git compares the submodule's own HEAD, which
+    // is unreadable from here, and says nothing at all when there is none;
+    // saying nothing is both the closest this can get and what keeps a branch
+    // switch away from a submodule from being refused over a file that was
+    // never missing.
+    if (entry.mode === Number.parseInt(GITLINK_MODE, 8)) continue
     const info = found.files.get(path)
     if (info === undefined) changes.set(path, DELETED)
     else if (await differs(repo, dispatch, worktree, path, entry, info)) {

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -32,7 +32,7 @@ import {
 } from './errors.ts'
 import { short } from './format.ts'
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
-import { removeEmptyParents, removeFile, restoreEntry, under } from './io.ts'
+import { blockingAncestor, removeEmptyParents, removeFile, restoreEntry, under } from './io.ts'
 import { record } from './reflog.ts'
 import { BRANCH_PREFIX, detachHead, loadRefs, readHead, setHead, writeRef } from './refs.ts'
 import { under as inside } from './pathspec.ts'
@@ -149,6 +149,34 @@ function overwritten(
 }
 
 /**
+ * Which uncommitted paths stand where a written entry needs a directory.
+ *
+ * The same shape as the untracked check above, over the other set: an index
+ * entry at `slot` is in the way of a target recording `slot/child`, because the
+ * directory cannot be created without removing the file. The exact-key
+ * comparison cannot see it, since `slot` is in neither tree.
+ *
+ * Deliberate divergence, and the same trade the staged case above makes. git
+ * allows this and discards the staged addition in silence: `git switch` onto a
+ * branch recording `slot/child` with `slot` staged succeeds, replaces the file
+ * with the directory and leaves a clean status, with the staged blob reachable
+ * from nothing. Where the working tree *also* differs from the index git
+ * refuses instead, filed oddly under its untracked wording. mirage refuses both
+ * and names the path: there is no reflog here to recover a staged blob from,
+ * and a refusal the caller can act on beats a silent discard. Pinned against
+ * git 2.50.1.
+ */
+function blockedAncestors(
+  writing: ReadonlyMap<string, TreeEntry>,
+  dirty: ReadonlySet<string>,
+): string[] {
+  const names = [...writing.keys()]
+  return [...dirty]
+    .filter((path) => names.some((name) => inside(name, path)))
+    .sort(compareCodePoints)
+}
+
+/**
  * Which directories the switch would empty of untracked files.
  *
  * The mirror of the case above: the target records a *file* where the working
@@ -179,6 +207,7 @@ function lostDirectories(
 async function switchTo(
   repo: Repo,
   dispatch: Dispatch,
+  statPath: StatPath,
   before: ReadonlyMap<string, TreeEntry>,
   after: ReadonlyMap<string, TreeEntry>,
   links: LinkView | null,
@@ -200,6 +229,13 @@ async function switchTo(
     const entry = changed.get(path)
     if (entry === undefined) continue
     const { blob } = await git.readBlob({ ...repoArgs(repo), oid: entry.oid })
+    // Whatever the removals above did not take, a component above the entry
+    // may still not be a directory: an ignored file or link is in neither tree
+    // and in no collision list, so it reaches here. git replaces it with the
+    // directory the entry needs rather than writing through it, which is what
+    // keeps a link's target tree, a path no branch named, out of the way.
+    const above = await blockingAncestor(statPath, repo.location.worktree, path, links)
+    if (above !== null) await removeFile(dispatch, above)
     await restoreEntry(dispatch, under(repo.location.worktree, path), entry.mode, blob, links)
   }
   // The index is git's two-way merge, not a copy of the target tree: only a
@@ -365,13 +401,15 @@ export async function moveHead(
   const carried = new Map([...unstaged, ...stageLetters(before, state.entries)])
   const dirty = new Set(carried.keys())
   const writing = written(before, after)
-  const blocked = conflicts(before, after, dirty)
+  const blocked = [
+    ...new Set([...conflicts(before, after, dirty), ...blockedAncestors(writing, dirty)]),
+  ].sort(compareCodePoints)
   const clobbered = overwritten(writing, found.untracked)
   const lost = lostDirectories(writing, found.untracked)
   if (blocked.length > 0 || clobbered.length > 0 || lost.length > 0) {
     throw new CheckoutConflictError(blocked, clobbered, lost)
   }
-  await switchTo(repo, dispatch, before, after, links)
+  await switchTo(repo, dispatch, statPath, before, after, links)
   await attach(dispatch, repo, known, head, oid, target, ref, creating)
   return carried
 }

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -56,7 +56,7 @@ import { opened, repoArgs, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
 import { restored } from './reset.ts'
 import { commitEntries, type TreeEntry } from './tree.ts'
-import type { LinkView, StatPath } from '../../../../ops/types.ts'
+import type { LinkView, MountView, StatPath } from '../../../../ops/types.ts'
 import { FileType } from '../../../../types.ts'
 import type { Dispatch, HeadRef, IndexEntry } from './types.ts'
 import { checkOperands, escaped, fatal } from './util.ts'
@@ -254,6 +254,7 @@ async function switchTo(
   before: ReadonlyMap<string, TreeEntry>,
   after: ReadonlyMap<string, TreeEntry>,
   links: LinkView | null,
+  mounts: MountView | null,
 ): Promise<void> {
   // Removals first, and the emptied directories with them, because the two
   // sets name the same place whenever a branch records a file where the other
@@ -265,7 +266,7 @@ async function switchTo(
     if (after.has(path)) continue
     const where = under(repo.location.worktree, path)
     await removeFile(dispatch, where)
-    await removeEmptyParents(dispatch, where, repo.location.worktree)
+    await removeEmptyParents(dispatch, where, repo.location.worktree, mounts)
   }
   const changed = written(before, after)
   for (const path of [...changed.keys()].sort(compareCodePoints)) {
@@ -289,7 +290,7 @@ async function switchTo(
     if ((links?.statAt(where) ?? null) === null) {
       const info = await statPath(where)
       if (info !== null && info.type === FileType.DIRECTORY) {
-        await removeTree(dispatch, where, links)
+        await removeTree(dispatch, where, links, mounts)
       }
     }
     await restoreEntry(dispatch, where, entry.mode, blob, links)
@@ -399,6 +400,7 @@ function stageLetters(
  * @param dispatch workspace op dispatcher
  * @param statPath dispatcher-backed stat, both channels
  * @param links the name plane's link facts, null outside a workspace
+ * @param mounts the name plane's mount boundaries, null outside a workspace
  * @param repo the opened repository
  * @param known every ref the repository publishes
  * @param head what HEAD pointed at before the move
@@ -415,6 +417,7 @@ export async function moveHead(
   dispatch: Dispatch,
   statPath: StatPath,
   links: LinkView | null,
+  mounts: MountView | null,
   repo: Repo,
   known: ReadonlyMap<string, string>,
   head: HeadRef,
@@ -469,7 +472,7 @@ export async function moveHead(
   if (blocked.length > 0 || clobbered.length > 0 || lost.length > 0) {
     throw new CheckoutConflictError(blocked, clobbered, lost)
   }
-  await switchTo(repo, dispatch, statPath, before, after, links)
+  await switchTo(repo, dispatch, statPath, before, after, links, mounts)
   await attach(dispatch, repo, known, head, oid, target, ref, creating)
   return carried
 }
@@ -536,6 +539,7 @@ export async function checkout(inv: CLIInvocation): Promise<CommandFnResult> {
       dispatch,
       statPath,
       doors.ns?.links ?? null,
+      doors.ns?.mounts ?? null,
       repo,
       known,
       head,

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -26,12 +26,13 @@ import {
   CheckoutConflictError,
   GitError,
   NoWorkspaceError,
+  ResolveIndexError,
   UnknownPathspecError,
   UnknownSwitchError,
 } from './errors.ts'
 import { short } from './format.ts'
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
-import { removeFile, restoreEntry, under } from './io.ts'
+import { removeEmptyParents, removeFile, restoreEntry, under } from './io.ts'
 import { record } from './reflog.ts'
 import { BRANCH_PREFIX, detachHead, loadRefs, readHead, setHead, writeRef } from './refs.ts'
 import { under as inside } from './pathspec.ts'
@@ -158,16 +159,26 @@ async function switchTo(
   held: ReadonlyMap<string, IndexEntry>,
   links: LinkView | null,
 ): Promise<void> {
-  for (const [path, entry] of after) {
+  // Removals first, and the emptied directories with them, because the two
+  // sets name the same place whenever a branch records a file where the other
+  // records a directory: writing `slot/child` while the file `slot` is still
+  // there fails, and so does writing the file while the directory is. Nothing
+  // is read back from the working tree, so emptying it first is free.
+  // `restore` orders its own pass the same way, for the same reason.
+  for (const path of [...before.keys()].sort(compareCodePoints)) {
+    if (after.has(path)) continue
+    const where = under(repo.location.worktree, path)
+    await removeFile(dispatch, where)
+    await removeEmptyParents(dispatch, where, repo.location.worktree)
+  }
+  for (const path of [...after.keys()].sort(compareCodePoints)) {
+    const entry = after.get(path)
+    if (entry === undefined) continue
     const old = before.get(path)
     if (old?.oid === entry.oid && old.mode === entry.mode) continue
     if (keep.has(path)) continue
     const { blob } = await git.readBlob({ ...repoArgs(repo), oid: entry.oid })
     await restoreEntry(dispatch, under(repo.location.worktree, path), entry.mode, blob, links)
-  }
-  for (const path of before.keys()) {
-    if (after.has(path)) continue
-    await removeFile(dispatch, under(repo.location.worktree, path))
   }
   const state = await readIndex(repo, dispatch)
   const staged = new Map<string, StagedEntry>()
@@ -200,15 +211,47 @@ export async function previousPosition(repo: Repo, head: HeadRef): Promise<strin
 }
 
 /**
+ * Point HEAD at a commit and write the reflog line for the move.
+ *
+ * The half of a checkout that happens whatever the working tree holds: a branch
+ * created where HEAD already is does only this.
+ */
+async function attach(
+  dispatch: Dispatch,
+  repo: Repo,
+  known: ReadonlyMap<string, string>,
+  head: HeadRef,
+  oid: string,
+  target: string,
+  ref: string | null,
+  creating: boolean,
+): Promise<void> {
+  if (creating && ref !== null) await writeRef(dispatch, repo.location.commondir, ref, oid)
+  if (ref !== null) await setHead(dispatch, repo.location.gitdir, ref)
+  else await detachHead(dispatch, repo.location.gitdir, oid)
+  const where = head.branch ?? short(head.commit ?? '', repo.abbrev)
+  await record(
+    dispatch,
+    repo.location.gitdir,
+    ref,
+    headCommit(known, head),
+    oid,
+    IDENTITY,
+    Math.floor(Date.now() / 1000),
+    `checkout: moving from ${where} to ${target}`,
+  )
+}
+
+/**
  * Move HEAD, the index and the working tree to a commit.
  *
  * The one procedure `checkout` and `switch` share, since the two differ only in
  * what they accept and how they word a miss. Refuses rather than overwriting
  * when the move would destroy work that is not committed, whether that is an
- * edit to a tracked file or an untracked file the target holds. That check is
- * the whole reason either verb is safe to offer: without it a branch switch
- * silently throws away whatever was changed and not staged, and there is no
- * reflog here to get it back from.
+ * edit to a tracked file, an untracked file the target holds, or a conflict
+ * still being resolved. Those checks are the whole reason either verb is safe to
+ * offer: without them a branch switch silently throws away whatever was changed
+ * and not staged, and there is no reflog here to get it back from.
  *
  * @param dispatch workspace op dispatcher
  * @param statPath dispatcher-backed stat, both channels
@@ -220,6 +263,8 @@ export async function previousPosition(repo: Repo, head: HeadRef): Promise<strin
  * @param target the operand as the user spelled it, for the reflog
  * @param ref the branch to attach HEAD to, null to detach it at the commit
  * @param creating whether `ref` is a new branch to write first
+ * @param inPlace whether the line named no start point, so the new branch is
+ *   being created where HEAD already is
  * @returns the paths whose uncommitted changes were carried across
  */
 export async function moveHead(
@@ -233,10 +278,27 @@ export async function moveHead(
   target: string,
   ref: string | null,
   creating: boolean,
+  inPlace: boolean,
 ): Promise<Set<string>> {
+  // A branch created where HEAD already is moves nothing: git writes the ref,
+  // points HEAD at it, and never touches the working tree or the index, so an
+  // unmerged index survives `git switch -c topic` and is refused by
+  // `git switch -c topic HEAD` a word later. The shape of the line is what
+  // decides it, which is git's own reading rather than a comparison of the two
+  // trees. Pinned against git 2.50.1.
+  if (inPlace) {
+    await attach(dispatch, repo, known, head, oid, target, ref, creating)
+    return new Set()
+  }
   const before = (await headEntries(repo)) ?? new Map<string, TreeEntry>()
   const after = await commitEntries(repo, oid)
   const state = await readIndex(repo, dispatch)
+  // First, before either tree is compared and before the working tree is
+  // walked, which is where git refuses it too. Every check below reads stage 0,
+  // so a path held only as conflict stages is invisible to all of them and the
+  // move would clear the stages and delete the file, throwing away a resolution
+  // in progress.
+  if (state.conflicts.size > 0) throw new ResolveIndexError([...state.conflicts.keys()])
   const tracked = new Set(state.entries.keys())
   // UNTRACKED_ALL, not the mode status uses: "normal" collapses a wholly
   // untracked directory to one `dir/` entry, and a collision has to be
@@ -261,20 +323,7 @@ export async function moveHead(
     throw new CheckoutConflictError(blocked, clobbered, lost)
   }
   await switchTo(repo, dispatch, before, after, dirty, state.entries, links)
-  if (creating && ref !== null) await writeRef(dispatch, repo.location.commondir, ref, oid)
-  if (ref !== null) await setHead(dispatch, repo.location.gitdir, ref)
-  else await detachHead(dispatch, repo.location.gitdir, oid)
-  const where = head.branch ?? short(head.commit ?? '', repo.abbrev)
-  await record(
-    dispatch,
-    repo.location.gitdir,
-    ref,
-    headCommit(known, head),
-    oid,
-    IDENTITY,
-    Math.floor(Date.now() / 1000),
-    `checkout: moving from ${where} to ${target}`,
-  )
+  await attach(dispatch, repo, known, head, oid, target, ref, creating)
   return dirty
 }
 
@@ -342,6 +391,7 @@ export async function checkout(inv: CLIInvocation): Promise<CommandFnResult> {
       target,
       attached ? ref : null,
       creating,
+      creating && startPoint === undefined,
     )
     carried = [...dirty]
       .sort(compareCodePoints)

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -27,13 +27,12 @@ import {
   GitError,
   NoWorkspaceError,
   RefLockError,
-  ResolveIndexError,
   UnknownPathspecError,
   UnknownSwitchError,
 } from './errors.ts'
 import { GITLINK_MODE } from './constants.ts'
 import { short } from './format.ts'
-import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
+import { readIndex, refuseUnresolved, updateIndex, type StagedEntry } from './index_file.ts'
 import {
   blockingAncestor,
   keepGitlink,
@@ -230,12 +229,20 @@ function blockedDescendants(
  * anything untracked inside it is gone. git words this one differently and
  * names the directory rather than the files, since the directory is what the
  * caller has to move. Pinned against git 2.50.1.
+ *
+ * A gitlink is not one of those entries. It asks for a directory, not for a
+ * file, so an existing one is left standing with everything in it, and git
+ * takes this switch rather than refusing it. An untracked *file* at the same
+ * name is still refused, by the check above, because the directory cannot be
+ * made without deleting it.
  */
 function lostDirectories(
   writing: ReadonlyMap<string, TreeEntry>,
   untracked: readonly string[],
 ): string[] {
-  return [...writing.keys()]
+  return [...writing]
+    .filter(([, entry]) => entry.mode !== GITLINK_MODE)
+    .map(([name]) => name)
     .filter((name) => untracked.some((path) => inside(path, name)))
     .sort(compareCodePoints)
 }
@@ -461,7 +468,7 @@ export async function moveHead(
   // so a path held only as conflict stages is invisible to all of them and the
   // move would clear the stages and delete the file, throwing away a resolution
   // in progress.
-  if (state.conflicts.size > 0) throw new ResolveIndexError([...state.conflicts.keys()])
+  refuseUnresolved(state)
   const tracked = new Set(state.entries.keys())
   // UNTRACKED_ALL, not the mode status uses: "normal" collapses a wholly
   // untracked directory to one `dir/` entry, and a collision has to be
@@ -528,6 +535,11 @@ export async function checkout(inv: CLIInvocation): Promise<CommandFnResult> {
       }
     }
     if (!creating && target === head.branch) {
+      // The shortcut moves nothing, and that is exactly why it has to read the
+      // index: git refuses the line over an unresolved index rather than
+      // answering that there is nothing to do, so a caller cannot read
+      // "Already on" as proof the repository is in a state it can build on.
+      refuseUnresolved(await readIndex(repo, dispatch))
       return [null, new IOResult({ stderr: ENC.encode(`Already on '${target}'\n`) })]
     }
     // `checkout -b <new> [<start>]` branches from the start point when one is

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -31,10 +31,12 @@ import {
   UnknownPathspecError,
   UnknownSwitchError,
 } from './errors.ts'
+import { GITLINK_MODE } from './constants.ts'
 import { short } from './format.ts'
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
 import {
   blockingAncestor,
+  keepGitlink,
   refuseReplacedMounts,
   removeEmptyParents,
   removeFile,
@@ -258,11 +260,15 @@ async function switchTo(
   mounts: MountView | null,
 ): Promise<void> {
   const changed = written(before, after)
+  // A gitlink is not written into the working tree at all, so it is neither
+  // read as a blob nor allowed to clear what stands at the name; keepGitlink is
+  // the whole of what the entry asks for.
+  const replacing = [...changed.keys()].filter((path) => changed.get(path)?.mode !== GITLINK_MODE)
   // Before the first removal, not at the entry that meets it: a refusal
   // halfway through leaves the entries already written holding the target's
   // content while HEAD and the index still name the branch being left, which
   // is the half-switch every other check above exists to prevent.
-  await refuseReplacedMounts(statPath, repo.location.worktree, [...changed.keys()], links, mounts)
+  await refuseReplacedMounts(statPath, repo.location.worktree, replacing, links, mounts)
   // Removals first, and the emptied directories with them, because the two
   // sets name the same place whenever a branch records a file where the other
   // records a directory: writing `slot/child` while the file `slot` is still
@@ -278,6 +284,10 @@ async function switchTo(
   for (const path of [...changed.keys()].sort(compareCodePoints)) {
     const entry = changed.get(path)
     if (entry === undefined) continue
+    if (entry.mode === GITLINK_MODE) {
+      await keepGitlink(dispatch, statPath, under(repo.location.worktree, path), links)
+      continue
+    }
     const { blob } = await git.readBlob({ ...repoArgs(repo), oid: entry.oid })
     // Whatever the removals above did not take, a component above the entry
     // may still not be a directory: an ignored file or link is in neither tree

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -35,6 +35,7 @@ import { short } from './format.ts'
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
 import {
   blockingAncestor,
+  refuseReplacedMounts,
   removeEmptyParents,
   removeFile,
   removeTree,
@@ -256,6 +257,12 @@ async function switchTo(
   links: LinkView | null,
   mounts: MountView | null,
 ): Promise<void> {
+  const changed = written(before, after)
+  // Before the first removal, not at the entry that meets it: a refusal
+  // halfway through leaves the entries already written holding the target's
+  // content while HEAD and the index still name the branch being left, which
+  // is the half-switch every other check above exists to prevent.
+  await refuseReplacedMounts(statPath, repo.location.worktree, [...changed.keys()], links, mounts)
   // Removals first, and the emptied directories with them, because the two
   // sets name the same place whenever a branch records a file where the other
   // records a directory: writing `slot/child` while the file `slot` is still
@@ -268,7 +275,6 @@ async function switchTo(
     await removeFile(dispatch, where)
     await removeEmptyParents(dispatch, where, repo.location.worktree, mounts)
   }
-  const changed = written(before, after)
   for (const path of [...changed.keys()].sort(compareCodePoints)) {
     const entry = changed.get(path)
     if (entry === undefined) continue

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -32,7 +32,14 @@ import {
 } from './errors.ts'
 import { short } from './format.ts'
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
-import { blockingAncestor, removeEmptyParents, removeFile, restoreEntry, under } from './io.ts'
+import {
+  blockingAncestor,
+  removeEmptyParents,
+  removeFile,
+  removeTree,
+  restoreEntry,
+  under,
+} from './io.ts'
 import { record } from './reflog.ts'
 import { BRANCH_PREFIX, detachHead, loadRefs, readHead, setHead, writeRef } from './refs.ts'
 import { under as inside } from './pathspec.ts'
@@ -41,6 +48,7 @@ import { resolveCommit } from './revparse.ts'
 import { restored } from './reset.ts'
 import { commitEntries, type TreeEntry } from './tree.ts'
 import type { LinkView, StatPath } from '../../../../ops/types.ts'
+import { FileType } from '../../../../types.ts'
 import type { Dispatch, HeadRef, IndexEntry } from './types.ts'
 import { checkOperands, escaped, fatal } from './util.ts'
 import { scan, UNTRACKED_ALL } from './worktree.ts'
@@ -236,7 +244,20 @@ async function switchTo(
     // keeps a link's target tree, a path no branch named, out of the way.
     const above = await blockingAncestor(statPath, repo.location.worktree, path, links)
     if (above !== null) await removeFile(dispatch, above)
-    await restoreEntry(dispatch, under(repo.location.worktree, path), entry.mode, blob, links)
+    const where = under(repo.location.worktree, path)
+    // And the same thing standing on the name itself rather than above it: a
+    // directory holding only ignored files is in no collision list either,
+    // since the check that refuses one is about the untracked files it would
+    // lose. git updates ignored files by default and takes the whole directory
+    // with it. A link is left to restoreEntry, which retargets it; following
+    // one to a directory here would delete a tree no branch named.
+    if ((links?.statAt(where) ?? null) === null) {
+      const info = await statPath(where)
+      if (info !== null && info.type === FileType.DIRECTORY) {
+        await removeTree(dispatch, where)
+      }
+    }
+    await restoreEntry(dispatch, where, entry.mode, blob, links)
   }
   // The index is git's two-way merge, not a copy of the target tree: only a
   // path the two trees disagree about is decided by the target, and where they

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -35,6 +35,7 @@ import { short } from './format.ts'
 import { readIndex, refuseUnresolved, updateIndex, type StagedEntry } from './index_file.ts'
 import {
   blockingAncestor,
+  dropGitlink,
   keepGitlink,
   refuseReplacedMounts,
   removeEmptyParents,
@@ -60,7 +61,7 @@ import { restored } from './reset.ts'
 import { commitEntries, type TreeEntry } from './tree.ts'
 import type { LinkView, MountView, StatPath } from '../../../../ops/types.ts'
 import { FileType } from '../../../../types.ts'
-import type { Dispatch, HeadRef, IndexEntry } from './types.ts'
+import type { Dispatch, HeadMove, HeadRef, IndexEntry } from './types.ts'
 import { checkOperands, escaped, fatal } from './util.ts'
 import { scan, UNTRACKED_ALL } from './worktree.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
@@ -265,7 +266,7 @@ async function switchTo(
   after: ReadonlyMap<string, TreeEntry>,
   links: LinkView | null,
   mounts: MountView | null,
-): Promise<void> {
+): Promise<string[]> {
   const changed = written(before, after)
   // A gitlink is not written into the working tree at all, so it is neither
   // read as a blob nor allowed to clear what stands at the name; keepGitlink is
@@ -282,10 +283,20 @@ async function switchTo(
   // there fails, and so does writing the file while the directory is. Nothing
   // is read back from the working tree, so emptying it first is free.
   // `restore` orders its own pass the same way, for the same reason.
+  const notes: string[] = []
   for (const path of [...before.keys()].sort(compareCodePoints)) {
     if (after.has(path)) continue
     const where = under(repo.location.worktree, path)
-    await removeFile(dispatch, where)
+    // A gitlink the target tree drops is a directory, not a file: git rmdirs
+    // it and warns rather than failing when something is still in it, where
+    // the unlink here died on it with the removals ahead of it already
+    // applied.
+    if (before.get(path)?.mode === GITLINK_MODE) {
+      const warned = await dropGitlink(dispatch, statPath, where, path, links)
+      if (warned !== null) notes.push(warned)
+    } else {
+      await removeFile(dispatch, where)
+    }
     await removeEmptyParents(dispatch, where, repo.location.worktree, mounts)
   }
   for (const path of [...changed.keys()].sort(compareCodePoints)) {
@@ -331,6 +342,7 @@ async function switchTo(
   }
   const removed = [...before.keys()].filter((path) => !after.has(path))
   await updateIndex(repo, staged, removed)
+  return notes
 }
 
 /**
@@ -449,7 +461,7 @@ export async function moveHead(
   ref: string | null,
   creating: boolean,
   inPlace: boolean,
-): Promise<Map<string, string>> {
+): Promise<HeadMove> {
   // A branch created where HEAD already is moves nothing: git writes the ref,
   // points HEAD at it, and never touches the working tree or the index, so an
   // unmerged index survives `git switch -c topic` and is refused by
@@ -458,7 +470,7 @@ export async function moveHead(
   // trees. Pinned against git 2.50.1.
   if (inPlace) {
     await attach(dispatch, repo, known, head, oid, target, ref, creating)
-    return new Map()
+    return { carried: new Map(), warnings: '' }
   }
   const before = (await headEntries(repo)) ?? new Map<string, TreeEntry>()
   const after = await commitEntries(repo, oid)
@@ -495,9 +507,9 @@ export async function moveHead(
   if (blocked.length > 0 || clobbered.length > 0 || lost.length > 0) {
     throw new CheckoutConflictError(blocked, clobbered, lost)
   }
-  await switchTo(repo, dispatch, statPath, before, after, links, mounts)
+  const notes = await switchTo(repo, dispatch, statPath, before, after, links, mounts)
   await attach(dispatch, repo, known, head, oid, target, ref, creating)
-  return carried
+  return { carried, warnings: notes.join('') }
 }
 
 /**
@@ -577,11 +589,14 @@ export async function checkout(inv: CLIInvocation): Promise<CommandFnResult> {
       creating,
       creating && startPoint === undefined,
     )
-    carried = [...moved]
+    carried = [...moved.carried]
       .sort(([a], [b]) => compareCodePoints(a, b))
       .map(([path, letter]) => `${letter}\t${path}\n`)
       .join('')
-    note = await previousPosition(repo, head)
+    // git writes the warning above everything it says about the move, because
+    // the directory it could not remove is a fact about the working tree
+    // rather than about where HEAD went.
+    note = moved.warnings + (await previousPosition(repo, head))
     if (attached) {
       const verb = creating ? 'Switched to a new branch' : 'Switched to branch'
       note += `${verb} '${target}'\n`

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -18,6 +18,7 @@ import { IOResult } from '../../../../io/types.ts'
 import type { CommandFnResult } from '../../../config.ts'
 import { FlagView } from '../../../spec/types.ts'
 import type { CLIInvocation } from '../../types.ts'
+import { headCommit } from './branch.ts'
 import { headEntries, workChanges } from './changes.ts'
 import {
   BadStartPointError,
@@ -37,8 +38,8 @@ import { opened, repoArgs, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
 import { restored } from './reset.ts'
 import { commitEntries, type TreeEntry } from './tree.ts'
-import type { LinkView } from '../../../../ops/types.ts'
-import type { Dispatch, IndexEntry } from './types.ts'
+import type { LinkView, StatPath } from '../../../../ops/types.ts'
+import type { Dispatch, HeadRef, IndexEntry } from './types.ts'
 import { checkOperands, fatal } from './util.ts'
 import { scan, UNTRACKED_ALL } from './worktree.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
@@ -158,13 +159,102 @@ async function switchTo(
 }
 
 /**
+ * git's line for leaving a detached HEAD, empty when it was on a branch.
+ *
+ * Printed before the line saying where HEAD went, because a commit made while
+ * detached is reachable from nothing once HEAD moves, and this is the one place
+ * its id is still written down for the caller.
+ */
+export async function previousPosition(repo: Repo, head: HeadRef): Promise<string> {
+  if (head.commit === null) return ''
+  const { commit } = await git.readCommit({ ...repoArgs(repo), oid: head.commit })
+  const subject = commit.message.split('\n')[0] ?? ''
+  return `Previous HEAD position was ${short(head.commit, repo.abbrev)} ${subject}\n`
+}
+
+/**
+ * Move HEAD, the index and the working tree to a commit.
+ *
+ * The one procedure `checkout` and `switch` share, since the two differ only in
+ * what they accept and how they word a miss. Refuses rather than overwriting
+ * when the move would destroy work that is not committed, whether that is an
+ * edit to a tracked file or an untracked file the target holds. That check is
+ * the whole reason either verb is safe to offer: without it a branch switch
+ * silently throws away whatever was changed and not staged, and there is no
+ * reflog here to get it back from.
+ *
+ * @param dispatch workspace op dispatcher
+ * @param statPath dispatcher-backed stat, both channels
+ * @param links the name plane's link facts, null outside a workspace
+ * @param repo the opened repository
+ * @param known every ref the repository publishes
+ * @param head what HEAD pointed at before the move
+ * @param oid the commit to move to
+ * @param target the operand as the user spelled it, for the reflog
+ * @param ref the branch to attach HEAD to, null to detach it at the commit
+ * @param creating whether `ref` is a new branch to write first
+ * @returns the paths whose uncommitted changes were carried across
+ */
+export async function moveHead(
+  dispatch: Dispatch,
+  statPath: StatPath,
+  links: LinkView | null,
+  repo: Repo,
+  known: ReadonlyMap<string, string>,
+  head: HeadRef,
+  oid: string,
+  target: string,
+  ref: string | null,
+  creating: boolean,
+): Promise<Set<string>> {
+  const before = (await headEntries(repo)) ?? new Map<string, TreeEntry>()
+  const after = await commitEntries(repo, oid)
+  const state = await readIndex(repo, dispatch)
+  const tracked = new Set(state.entries.keys())
+  // UNTRACKED_ALL, not the mode status uses: "normal" collapses a wholly
+  // untracked directory to one `dir/` entry, and a collision has to be
+  // decided per file. git names the file inside such a directory, so the
+  // list has to hold it.
+  const found = await scan(dispatch, statPath, repo.location, tracked, UNTRACKED_ALL, links)
+  const unstaged = await workChanges(repo, dispatch, repo.location.worktree, state.entries, found)
+  // Both kinds of uncommitted change count: an edit in the working tree, and
+  // one already staged. Leaving the staged ones out is what silently threw
+  // them away.
+  const stagedPaths = [...state.entries.entries()]
+    .filter(([path, entry]) => {
+      const recorded = before.get(path)
+      return recorded?.oid !== entry.oid || Number.parseInt(recorded.mode, 8) !== entry.mode
+    })
+    .map(([path]) => path)
+  const dirty = new Set([...unstaged.keys(), ...stagedPaths])
+  const blocked = conflicts(before, after, dirty)
+  const clobbered = overwritten(after, found.untracked)
+  if (blocked.length > 0 || clobbered.length > 0) {
+    throw new CheckoutConflictError(blocked, clobbered)
+  }
+  await switchTo(repo, dispatch, before, after, dirty, state.entries, links)
+  if (creating && ref !== null) await writeRef(dispatch, repo.location.commondir, ref, oid)
+  if (ref !== null) await setHead(dispatch, repo.location.gitdir, ref)
+  else await detachHead(dispatch, repo.location.gitdir, oid)
+  const where = head.branch ?? short(head.commit ?? '', repo.abbrev)
+  await record(
+    dispatch,
+    repo.location.gitdir,
+    ref,
+    headCommit(known, head),
+    oid,
+    IDENTITY,
+    Math.floor(Date.now() / 1000),
+    `checkout: moving from ${where} to ${target}`,
+  )
+  return dirty
+}
+
+/**
  * Switch the working tree to another branch or commit.
  *
  * Refuses rather than overwriting when the switch would destroy work that is not
- * committed, whether that is an edit to a tracked file or an untracked file the
- * target branch happens to hold. That check is the whole reason this verb is
- * safe to offer: without it a branch switch silently throws away whatever was
- * changed and not staged, and there is no reflog here to get it back from.
+ * committed; see `moveHead`, which does the moving for `switch` as well.
  */
 export async function checkout(inv: CLIInvocation): Promise<CommandFnResult> {
   const doors = inv.doors ?? {}
@@ -212,65 +302,31 @@ export async function checkout(inv: CLIInvocation): Promise<CommandFnResult> {
     } else {
       oid = await resolveCommit(repo, creating ? 'HEAD' : target)
     }
-    const before = (await headEntries(repo)) ?? new Map<string, TreeEntry>()
-    const after = await commitEntries(repo, oid)
-    const state = await readIndex(repo, dispatch)
-    const tracked = new Set(state.entries.keys())
-    // UNTRACKED_ALL, not the mode status uses: "normal" collapses a wholly
-    // untracked directory to one `dir/` entry, and a collision has to be
-    // decided per file. git names the file inside such a directory, so the
-    // list has to hold it.
-    const found = await scan(
+    const attached = creating || known.has(ref)
+    const dirty = await moveHead(
       dispatch,
       statPath,
-      repo.location,
-      tracked,
-      UNTRACKED_ALL,
       doors.ns?.links ?? null,
-    )
-    const unstaged = await workChanges(repo, dispatch, repo.location.worktree, state.entries, found)
-    // Both kinds of uncommitted change count: an edit in the working tree, and
-    // one already staged. Leaving the staged ones out is what silently threw
-    // them away.
-    const stagedPaths = [...state.entries.entries()]
-      .filter(([path, entry]) => {
-        const recorded = before.get(path)
-        return recorded?.oid !== entry.oid || Number.parseInt(recorded.mode, 8) !== entry.mode
-      })
-      .map(([path]) => path)
-    const dirty = new Set([...unstaged.keys(), ...stagedPaths])
-    const blocked = conflicts(before, after, dirty)
-    const clobbered = overwritten(after, found.untracked)
-    if (blocked.length > 0 || clobbered.length > 0) {
-      throw new CheckoutConflictError(blocked, clobbered)
-    }
-    await switchTo(repo, dispatch, before, after, dirty, state.entries, doors.ns?.links ?? null)
-    const attached = creating || known.has(ref)
-    if (creating) await writeRef(dispatch, repo.location.commondir, ref, oid)
-    if (attached) await setHead(dispatch, repo.location.gitdir, ref)
-    else await detachHead(dispatch, repo.location.gitdir, oid)
-    const where = head.branch ?? short(head.commit ?? '', repo.abbrev)
-    await record(
-      dispatch,
-      repo.location.gitdir,
-      attached ? ref : null,
-      head.commit ?? (head.ref !== null ? (known.get(head.ref) ?? null) : null),
+      repo,
+      known,
+      head,
       oid,
-      IDENTITY,
-      Math.floor(Date.now() / 1000),
-      `checkout: moving from ${where} to ${target}`,
+      target,
+      attached ? ref : null,
+      creating,
     )
     carried = [...dirty]
       .sort(compareCodePoints)
       .map((path) => `M\t${path}\n`)
       .join('')
+    note = await previousPosition(repo, head)
     if (attached) {
       const verb = creating ? 'Switched to a new branch' : 'Switched to branch'
-      note = `${verb} '${target}'\n`
+      note += `${verb} '${target}'\n`
     } else {
       const { commit } = await git.readCommit({ ...repoArgs(repo), oid })
       const subject = commit.message.split('\n')[0] ?? ''
-      note =
+      note +=
         `Note: switching to '${target}'.\n\n${DETACHED_ADVICE}\n` +
         `HEAD is now at ${short(oid, repo.abbrev)} ${subject}\n`
     }

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -26,6 +26,7 @@ import {
   CheckoutConflictError,
   GitError,
   NoWorkspaceError,
+  RefLockError,
   ResolveIndexError,
   UnknownPathspecError,
   UnknownSwitchError,
@@ -41,7 +42,15 @@ import {
   under,
 } from './io.ts'
 import { record } from './reflog.ts'
-import { BRANCH_PREFIX, detachHead, loadRefs, readHead, setHead, writeRef } from './refs.ts'
+import {
+  BRANCH_PREFIX,
+  blockingRef,
+  detachHead,
+  loadRefs,
+  readHead,
+  setHead,
+  writeRef,
+} from './refs.ts'
 import { under as inside } from './pathspec.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
@@ -185,6 +194,32 @@ function blockedAncestors(
 }
 
 /**
+ * Which uncommitted paths stand inside a directory a written file replaces.
+ *
+ * The other half of the check above, over the same set. A staged `slot/child`
+ * is in the way of a target recording the *file* `slot`, because the file
+ * cannot be written without removing the directory, and the index entry for the
+ * child would survive the switch as one half of a shape git's index has no room
+ * for. The exact-key comparison misses it for the same reason as the ancestor
+ * case: `slot/child` is in neither tree.
+ *
+ * The same deliberate divergence, and named the same way. git allows it:
+ * switching onto a branch recording the file `slot` with `slot/child` staged
+ * succeeds, removes the directory, and drops the staged entry with nothing left
+ * pointing at its blob. mirage refuses and names the path instead. Pinned
+ * against git 2.50.1.
+ */
+function blockedDescendants(
+  writing: ReadonlyMap<string, TreeEntry>,
+  dirty: ReadonlySet<string>,
+): string[] {
+  const names = [...writing.keys()]
+  return [...dirty]
+    .filter((path) => names.some((name) => inside(path, name)))
+    .sort(compareCodePoints)
+}
+
+/**
  * Which directories the switch would empty of untracked files.
  *
  * The mirror of the case above: the target records a *file* where the working
@@ -254,7 +289,7 @@ async function switchTo(
     if ((links?.statAt(where) ?? null) === null) {
       const info = await statPath(where)
       if (info !== null && info.type === FileType.DIRECTORY) {
-        await removeTree(dispatch, where)
+        await removeTree(dispatch, where, links)
       }
     }
     await restoreEntry(dispatch, where, entry.mode, blob, links)
@@ -423,7 +458,11 @@ export async function moveHead(
   const dirty = new Set(carried.keys())
   const writing = written(before, after)
   const blocked = [
-    ...new Set([...conflicts(before, after, dirty), ...blockedAncestors(writing, dirty)]),
+    ...new Set([
+      ...conflicts(before, after, dirty),
+      ...blockedAncestors(writing, dirty),
+      ...blockedDescendants(writing, dirty),
+    ]),
   ].sort(compareCodePoints)
   const clobbered = overwritten(writing, found.untracked)
   const lost = lostDirectories(writing, found.untracked)
@@ -487,6 +526,11 @@ export async function checkout(inv: CLIInvocation): Promise<CommandFnResult> {
     } else {
       oid = await resolveCommit(repo, creating ? 'HEAD' : target)
     }
+    // Before the working tree moves, which is where git refuses it too: the
+    // ref is locked first and nothing is checked out when the lock cannot be
+    // taken.
+    const held = creating ? blockingRef(new Set(known.keys()), ref) : null
+    if (held !== null) throw new RefLockError(ref, held)
     const attached = creating || known.has(ref)
     const moved = await moveHead(
       dispatch,

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -19,7 +19,7 @@ import type { CommandFnResult } from '../../../config.ts'
 import { FlagView } from '../../../spec/types.ts'
 import type { CLIInvocation } from '../../types.ts'
 import { headCommit } from './branch.ts'
-import { headEntries, workChanges } from './changes.ts'
+import { ADDED, DELETED, headEntries, MODIFIED, workChanges } from './changes.ts'
 import {
   BadStartPointError,
   BranchExistsError,
@@ -101,7 +101,31 @@ function conflicts(
 }
 
 /**
- * Which untracked files the tree being switched to would write over.
+ * The entries a switch actually writes into the working tree.
+ *
+ * Every check that asks what is standing in the way has to ask about these
+ * rather than about the whole target tree. A path both trees record identically
+ * is never written, so an untracked file sitting on it is left exactly where it
+ * is; that file is one the index staged a deletion for, and git carries the
+ * staged deletion rather than refusing the switch over the copy left on disk.
+ * Content does not enter into it from the other side either: a path only the
+ * target records is refused even when the untracked copy already matches it byte
+ * for byte. Pinned against git 2.50.1.
+ */
+function written(
+  before: ReadonlyMap<string, TreeEntry>,
+  after: ReadonlyMap<string, TreeEntry>,
+): Map<string, TreeEntry> {
+  const out = new Map<string, TreeEntry>()
+  for (const [path, entry] of after) {
+    const old = before.get(path)
+    if (old?.oid !== entry.oid || old.mode !== entry.mode) out.set(path, entry)
+  }
+  return out
+}
+
+/**
+ * Which untracked files the entries being written would write over.
  *
  * An untracked file is in neither tree and neither index, so the comparison
  * above cannot see it, and writing the target branch's blob over it destroys
@@ -115,12 +139,12 @@ function conflicts(
  * the entry that needs the room.
  */
 function overwritten(
-  after: ReadonlyMap<string, TreeEntry>,
+  writing: ReadonlyMap<string, TreeEntry>,
   untracked: readonly string[],
 ): string[] {
-  const names = [...after.keys()]
+  const names = [...writing.keys()]
   return untracked
-    .filter((path) => after.has(path) || names.some((name) => inside(name, path)))
+    .filter((path) => writing.has(path) || names.some((name) => inside(name, path)))
     .sort(compareCodePoints)
 }
 
@@ -134,10 +158,10 @@ function overwritten(
  * caller has to move. Pinned against git 2.50.1.
  */
 function lostDirectories(
-  after: ReadonlyMap<string, TreeEntry>,
+  writing: ReadonlyMap<string, TreeEntry>,
   untracked: readonly string[],
 ): string[] {
-  return [...after.keys()]
+  return [...writing.keys()]
     .filter((name) => untracked.some((path) => inside(path, name)))
     .sort(compareCodePoints)
 }
@@ -145,18 +169,18 @@ function lostDirectories(
 /**
  * Make the working tree and index match the tree being switched to.
  *
- * Only paths whose recorded content differs are touched, so a file that is the
+ * Only paths the two trees disagree about are touched, so a file that is the
  * same on both branches keeps whatever the working tree has, including an
- * uncommitted edit. A path carried across keeps its index entry too, which is
- * what preserves a staged change that both branches happen to agree about.
+ * uncommitted edit, and keeps its index entry, which is what preserves a staged
+ * change both branches happen to agree about. Every path the trees do disagree
+ * about has already been refused by the caller if anything uncommitted stands on
+ * it, so the tree diff is the whole decision here.
  */
 async function switchTo(
   repo: Repo,
   dispatch: Dispatch,
   before: ReadonlyMap<string, TreeEntry>,
   after: ReadonlyMap<string, TreeEntry>,
-  keep: ReadonlySet<string>,
-  held: ReadonlyMap<string, IndexEntry>,
   links: LinkView | null,
 ): Promise<void> {
   // Removals first, and the emptied directories with them, because the two
@@ -171,28 +195,25 @@ async function switchTo(
     await removeFile(dispatch, where)
     await removeEmptyParents(dispatch, where, repo.location.worktree)
   }
-  for (const path of [...after.keys()].sort(compareCodePoints)) {
-    const entry = after.get(path)
+  const changed = written(before, after)
+  for (const path of [...changed.keys()].sort(compareCodePoints)) {
+    const entry = changed.get(path)
     if (entry === undefined) continue
-    const old = before.get(path)
-    if (old?.oid === entry.oid && old.mode === entry.mode) continue
-    if (keep.has(path)) continue
     const { blob } = await git.readBlob({ ...repoArgs(repo), oid: entry.oid })
     await restoreEntry(dispatch, under(repo.location.worktree, path), entry.mode, blob, links)
   }
-  const state = await readIndex(repo, dispatch)
+  // The index is git's two-way merge, not a copy of the target tree: only a
+  // path the two trees disagree about is decided by the target, and where they
+  // agree the entry is left exactly as it stands. That is what carries all three
+  // kinds of staged work across. Rebuilding the index from the target alone
+  // dropped a staged addition, which is in neither tree, and resurrected a
+  // staged deletion, which is in both and in no entry, turning both into
+  // unstaged changes a later commit would silently omit.
   const staged = new Map<string, StagedEntry>()
-  for (const [path, entry] of after) {
-    const carried = held.get(path)
-    if (keep.has(path) && carried !== undefined) {
-      staged.set(path, { oid: carried.oid, mode: carried.mode, size: carried.size })
-    } else {
-      staged.set(path, restored(entry.oid, Number.parseInt(entry.mode, 8)))
-    }
+  for (const [path, entry] of changed) {
+    staged.set(path, restored(entry.oid, Number.parseInt(entry.mode, 8)))
   }
-  const removed = [...state.entries.keys(), ...state.conflicts.keys()].filter(
-    (path) => !after.has(path),
-  )
+  const removed = [...before.keys()].filter((path) => !after.has(path))
   await updateIndex(repo, staged, removed)
 }
 
@@ -243,6 +264,36 @@ async function attach(
 }
 
 /**
+ * How the index differs from HEAD, one status letter per path.
+ *
+ * The same three comparisons `status` makes against HEAD, kept here rather than
+ * borrowed from `stageChanges` because that one pairs renames and this list does
+ * not: git letters a carried change by what it is on its own, and an unmerged
+ * path cannot reach this (the caller refuses one before any tree is read).
+ *
+ * A path the index has no entry for is the one git's own reading gets right and
+ * a walk of the entries cannot see at all: a staged deletion is an absence, so
+ * it has to be read off HEAD's tree.
+ */
+function stageLetters(
+  before: ReadonlyMap<string, TreeEntry>,
+  entries: ReadonlyMap<string, IndexEntry>,
+): Map<string, string> {
+  const letters = new Map<string, string>()
+  for (const [path, entry] of entries) {
+    const recorded = before.get(path)
+    if (recorded === undefined) letters.set(path, ADDED)
+    else if (recorded.oid !== entry.oid || Number.parseInt(recorded.mode, 8) !== entry.mode) {
+      letters.set(path, MODIFIED)
+    }
+  }
+  for (const path of before.keys()) {
+    if (!entries.has(path)) letters.set(path, DELETED)
+  }
+  return letters
+}
+
+/**
  * Move HEAD, the index and the working tree to a commit.
  *
  * The one procedure `checkout` and `switch` share, since the two differ only in
@@ -265,7 +316,8 @@ async function attach(
  * @param creating whether `ref` is a new branch to write first
  * @param inPlace whether the line named no start point, so the new branch is
  *   being created where HEAD already is
- * @returns the paths whose uncommitted changes were carried across
+ * @returns each path whose uncommitted change was carried across, against the
+ *   status letter git prints for it
  */
 export async function moveHead(
   dispatch: Dispatch,
@@ -279,7 +331,7 @@ export async function moveHead(
   ref: string | null,
   creating: boolean,
   inPlace: boolean,
-): Promise<Set<string>> {
+): Promise<Map<string, string>> {
   // A branch created where HEAD already is moves nothing: git writes the ref,
   // points HEAD at it, and never touches the working tree or the index, so an
   // unmerged index survives `git switch -c topic` and is refused by
@@ -288,7 +340,7 @@ export async function moveHead(
   // trees. Pinned against git 2.50.1.
   if (inPlace) {
     await attach(dispatch, repo, known, head, oid, target, ref, creating)
-    return new Set()
+    return new Map()
   }
   const before = (await headEntries(repo)) ?? new Map<string, TreeEntry>()
   const after = await commitEntries(repo, oid)
@@ -308,23 +360,20 @@ export async function moveHead(
   const unstaged = await workChanges(repo, dispatch, repo.location.worktree, state.entries, found)
   // Both kinds of uncommitted change count: an edit in the working tree, and
   // one already staged. Leaving the staged ones out is what silently threw
-  // them away.
-  const stagedPaths = [...state.entries.entries()]
-    .filter(([path, entry]) => {
-      const recorded = before.get(path)
-      return recorded?.oid !== entry.oid || Number.parseInt(recorded.mode, 8) !== entry.mode
-    })
-    .map(([path]) => path)
-  const dirty = new Set([...unstaged.keys(), ...stagedPaths])
+  // them away. The index column wins where a path has both, which is how git's
+  // own short status reads a row and how it letters this list.
+  const carried = new Map([...unstaged, ...stageLetters(before, state.entries)])
+  const dirty = new Set(carried.keys())
+  const writing = written(before, after)
   const blocked = conflicts(before, after, dirty)
-  const clobbered = overwritten(after, found.untracked)
-  const lost = lostDirectories(after, found.untracked)
+  const clobbered = overwritten(writing, found.untracked)
+  const lost = lostDirectories(writing, found.untracked)
   if (blocked.length > 0 || clobbered.length > 0 || lost.length > 0) {
     throw new CheckoutConflictError(blocked, clobbered, lost)
   }
-  await switchTo(repo, dispatch, before, after, dirty, state.entries, links)
+  await switchTo(repo, dispatch, before, after, links)
   await attach(dispatch, repo, known, head, oid, target, ref, creating)
-  return dirty
+  return carried
 }
 
 /**
@@ -380,7 +429,7 @@ export async function checkout(inv: CLIInvocation): Promise<CommandFnResult> {
       oid = await resolveCommit(repo, creating ? 'HEAD' : target)
     }
     const attached = creating || known.has(ref)
-    const dirty = await moveHead(
+    const moved = await moveHead(
       dispatch,
       statPath,
       doors.ns?.links ?? null,
@@ -393,9 +442,9 @@ export async function checkout(inv: CLIInvocation): Promise<CommandFnResult> {
       creating,
       creating && startPoint === undefined,
     )
-    carried = [...dirty]
-      .sort(compareCodePoints)
-      .map((path) => `M\t${path}\n`)
+    carried = [...moved]
+      .sort(([a], [b]) => compareCodePoints(a, b))
+      .map(([path, letter]) => `${letter}\t${path}\n`)
       .join('')
     note = await previousPosition(repo, head)
     if (attached) {

--- a/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/checkout.ts
@@ -34,13 +34,14 @@ import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
 import { removeFile, restoreEntry, under } from './io.ts'
 import { record } from './reflog.ts'
 import { BRANCH_PREFIX, detachHead, loadRefs, readHead, setHead, writeRef } from './refs.ts'
+import { under as inside } from './pathspec.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
 import { restored } from './reset.ts'
 import { commitEntries, type TreeEntry } from './tree.ts'
 import type { LinkView, StatPath } from '../../../../ops/types.ts'
 import type { Dispatch, HeadRef, IndexEntry } from './types.ts'
-import { checkOperands, fatal } from './util.ts'
+import { checkOperands, escaped, fatal } from './util.ts'
 import { scan, UNTRACKED_ALL } from './worktree.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
@@ -106,12 +107,38 @@ function conflicts(
  * the only copy there is. git refuses and names each one. An ignored file is
  * not in this list and git overwrites it silently, which is the same split.
  * Pinned against git 2.50.
+ *
+ * Equality is not the whole test. An untracked file `slot` is also in the way
+ * of a target that records `slot/child`, because the directory cannot be
+ * created without deleting it; git names the untracked file itself there, not
+ * the entry that needs the room.
  */
 function overwritten(
   after: ReadonlyMap<string, TreeEntry>,
   untracked: readonly string[],
 ): string[] {
-  return untracked.filter((path) => after.has(path)).sort(compareCodePoints)
+  const names = [...after.keys()]
+  return untracked
+    .filter((path) => after.has(path) || names.some((name) => inside(name, path)))
+    .sort(compareCodePoints)
+}
+
+/**
+ * Which directories the switch would empty of untracked files.
+ *
+ * The mirror of the case above: the target records a *file* where the working
+ * tree has a directory, so writing it means removing the directory, and
+ * anything untracked inside it is gone. git words this one differently and
+ * names the directory rather than the files, since the directory is what the
+ * caller has to move. Pinned against git 2.50.1.
+ */
+function lostDirectories(
+  after: ReadonlyMap<string, TreeEntry>,
+  untracked: readonly string[],
+): string[] {
+  return [...after.keys()]
+    .filter((name) => untracked.some((path) => inside(path, name)))
+    .sort(compareCodePoints)
 }
 
 /**
@@ -229,8 +256,9 @@ export async function moveHead(
   const dirty = new Set([...unstaged.keys(), ...stagedPaths])
   const blocked = conflicts(before, after, dirty)
   const clobbered = overwritten(after, found.untracked)
-  if (blocked.length > 0 || clobbered.length > 0) {
-    throw new CheckoutConflictError(blocked, clobbered)
+  const lost = lostDirectories(after, found.untracked)
+  if (blocked.length > 0 || clobbered.length > 0 || lost.length > 0) {
+    throw new CheckoutConflictError(blocked, clobbered, lost)
   }
   await switchTo(repo, dispatch, before, after, dirty, state.entries, links)
   if (creating && ref !== null) await writeRef(dispatch, repo.location.commondir, ref, oid)
@@ -268,7 +296,7 @@ export async function checkout(inv: CLIInvocation): Promise<CommandFnResult> {
     if (statPath === undefined || dispatch === undefined) {
       throw new NoWorkspaceError()
     }
-    checkOperands(texts, UnknownSwitchError)
+    checkOperands(texts, UnknownSwitchError, escaped(inv.argv))
     const target = texts[0]
     if (target === undefined) throw new UnknownPathspecError('')
     const repo = await opened(fl, doors)

--- a/typescript/packages/core/src/commands/cli/builtin/git/commit.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/commit.ts
@@ -52,7 +52,7 @@ const AUTHOR_EMAIL = 'GIT_AUTHOR_EMAIL'
 const FALLBACK_EMAIL = 'EMAIL'
 
 /** An author string split into the two halves git records separately. */
-interface Identity {
+export interface Identity {
   readonly name: string
   readonly email: string
   /** The `Name <email>` spelling, which is what a reflog line carries. */
@@ -77,7 +77,7 @@ interface Identity {
  * Read through the session plane's door rather than the frozen `inv.env`
  * snapshot, so a hidden name reads as unset exactly as it does in the shell.
  */
-function identity(fl: FlagView, session: SessionView | undefined): Identity {
+export function identity(fl: FlagView, session: SessionView | undefined): Identity {
   const author = fl.asStr('author')
   if (author === undefined || author === '') {
     const name = session?.get(AUTHOR_NAME) ?? null

--- a/typescript/packages/core/src/commands/cli/builtin/git/constants.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/constants.ts
@@ -30,6 +30,12 @@ export const PERMISSION_BITS = 0o777
 // records a number and a tree records git's octal string, so both spellings
 // are real here and neither is a stand-in for the other.
 export const SYMLINK_MODE = '120000'
+/**
+ * A gitlink: the commit another repository is checked out at. It is not an
+ * object this repository holds, so nothing about it is written into the working
+ * tree; git only makes sure a directory stands at the name.
+ */
+export const GITLINK_MODE = '160000'
 
 // The symbolic ref every verb resolves first.
 export const HEAD = 'HEAD'

--- a/typescript/packages/core/src/commands/cli/builtin/git/constants.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/constants.ts
@@ -22,6 +22,10 @@ export const REGULAR = 0o100644
 export const EXECUTABLE = 0o100755
 export const SYMLINK = 0o120000
 export const OWNER_EXECUTE = 0o100
+// The part of a tree entry's mode that is a permission: what a restored
+// entry's own bits are set from, the object type above it being the mount's
+// business rather than the tree's.
+export const PERMISSION_BITS = 0o777
 // The same mode as `SYMLINK`, in the spelling a tree entry carries. The index
 // records a number and a tree records git's octal string, so both spellings
 // are real here and neither is a stand-in for the other.

--- a/typescript/packages/core/src/commands/cli/builtin/git/diff.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/diff.ts
@@ -23,7 +23,7 @@ import { GitError, InvalidOptionError } from './errors.ts'
 import { treeDiff } from './patch.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
-import { checkOperands, fatal } from './util.ts'
+import { checkOperands, escaped, fatal } from './util.ts'
 
 const ENC = new TextEncoder()
 
@@ -47,7 +47,7 @@ export async function diff(inv: CLIInvocation): Promise<CommandFnResult> {
   const first = texts[0]
   if (first === undefined) return [null, new IOResult()]
   try {
-    checkOperands(texts, InvalidOptionError)
+    checkOperands(texts, InvalidOptionError, escaped(inv.argv))
     const repo = await opened(fl, doors)
     const body = await treeDiff(
       repo,

--- a/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
@@ -780,6 +780,44 @@ export class TagNotFoundError extends GitError {
   }
 }
 
+/**
+ * `-n` on a `tag` line that deletes rather than lists.
+ *
+ * `-n` asks for message lines beside each name, which only a listing prints,
+ * and git makes it *imply* a listing rather than refuse it: `git tag -n1
+ * nosuch` is a listing whose pattern matches nothing and exits 0. The
+ * implication is what cannot happen once `-d` has already said what mode the
+ * line is in, so git dies there instead, with the tags untouched. Refusing it
+ * matters more here than the wording does: read as a listing flag and dropped,
+ * the line went on to delete the refs its operands named. Pinned against git
+ * 2.50.1.
+ */
+export class ListModeOnlyError extends GitError {
+  constructor() {
+    super("the '-n' option is only allowed in list mode")
+  }
+}
+
+/**
+ * `tag -d` naming one tag twice.
+ *
+ * git stages every deletion on the line as one ref transaction, and a
+ * transaction holding two updates for the same ref is refused before any of
+ * them applies, so the whole line is a no-op: the repeated tag survives, and so
+ * does every other tag the line named. The ref it blames is the first in ref
+ * order rather than the first typed, since the transaction sorts before it
+ * looks for the repeat. Reported the way git reports it, as an `error` exiting
+ * 1 rather than a fatal.
+ */
+export class RefUpdateConflictError extends GitError {
+  override readonly prefix = 'error'
+  override readonly code = 1
+
+  constructor(ref: string) {
+    super(`could not delete references: multiple updates for ref '${ref}' not allowed`)
+  }
+}
+
 /** A tag name git's ref rules refuse. */
 export class InvalidTagNameError extends GitError {
   constructor(name: string) {

--- a/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
@@ -31,6 +31,8 @@ const ADVICE_IGNORED =
   'hint: Disable this message with "git config set advice.addIgnoredFile false"'
 const ADVICE_EMPTY_PATHSPEC =
   'hint: Disable this message with "git config set advice.addEmptyPathspec false"'
+const ADVICE_REF_FORMAT = 'hint: See `man git check-ref-format`'
+const ADVICE_REF_SYNTAX = 'hint: Disable this message with "git config set advice.refSyntax false"'
 
 /**
  * Base for a git fatal: rendered as `fatal: <message>`, exit 128.
@@ -291,6 +293,21 @@ export class UnmergedIndexError extends GitError {
 export class BranchExistsError extends GitError {
   constructor(name: string) {
     super(`a branch named '${name}' already exists`)
+  }
+}
+
+/**
+ * A branch name git's ref rules refuse.
+ *
+ * Refused before the name reaches a ref file, because a ref is written as a path
+ * below `.git`: `../../config` would land on the repository's own configuration
+ * rather than on a branch. git closes the refusal with the two hint lines kept
+ * here, and words it without the full stop its tag twin carries. Pinned against
+ * git 2.50.1.
+ */
+export class InvalidBranchNameError extends GitError {
+  constructor(name: string) {
+    super(`'${name}' is not a valid branch name\n${ADVICE_REF_FORMAT}\n${ADVICE_REF_SYNTAX}`)
   }
 }
 
@@ -662,6 +679,30 @@ export class InvalidTagNameError extends GitError {
 export class UnresolvedRefError extends GitError {
   constructor(revision: string) {
     super(`Failed to resolve '${revision}' as a valid ref.`)
+  }
+}
+
+/**
+ * `tag` given a creation option with no tag name to create.
+ *
+ * `-a`, `-m` and `-f` are creation options, so git refuses them on a line that
+ * lists or deletes instead: no operand at all lists, and `-l` or `-d` says so
+ * outright. It prints its usage and exits 129, where an operand-free `git tag`
+ * or `git tag -d` lists and exits 0. The synopsis is trimmed to the options this
+ * build has, the way `mv`'s is: git's own lines advertise `-s`, `-u`, `-F`, `-e`
+ * and `-v`, which would be a promise nothing here keeps. Pinned against git
+ * 2.50.1.
+ */
+export class TagUsageError extends GitError {
+  override readonly prefix = null
+  override readonly code = OPTION_EXIT
+
+  constructor() {
+    super(
+      'usage: git tag [-a] [-f] [-m <msg>] <tagname> [<commit> | <object>]\n' +
+        '   or: git tag -d <tagname>...\n' +
+        '   or: git tag [-n[<num>]] -l [<pattern>...]',
+    )
   }
 }
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
@@ -43,11 +43,17 @@ const ADVICE_REF_SYNTAX = 'hint: Disable this message with "git config set advic
  * what git does when the refusal is a report rather than an error ("nothing to
  * commit"), and such a report goes to stdout because that is where the report it
  * replaces would have gone.
+ *
+ * `report` is the other half of a refusal git splits across both streams: the
+ * sentence saying it refused goes to stderr, and the per-path diagnosis naming
+ * what is in the way goes to stdout, which is where the same lines would have
+ * gone had the command run.
  */
 export class GitError extends Error {
   readonly prefix: string | null = 'fatal'
   readonly code: number = FATAL_EXIT
   readonly stream: 'stdout' | 'stderr' = 'stderr'
+  readonly report: string = ''
 }
 
 /**
@@ -450,6 +456,62 @@ export class CheckoutConflictError extends GitError {
     // git emits each paragraph as its own error, so the second one carries the
     // prefix inline: the renderer only writes the first.
     super(`${blocks.map((block) => `${block}\n`).join('error: ')}Aborting`)
+  }
+}
+
+/**
+ * A branch move while the index still records conflict stages.
+ *
+ * Every collision check a checkout makes reads stage 0, so a path held only as
+ * stages 1-3 is invisible to all of them: the move would clear the stages and
+ * delete the working-tree copy, throwing away a conflict resolution in progress
+ * with no reflog to recover it from. git refuses first, before it reads either
+ * tree.
+ *
+ * Both streams carry part of it, pinned against git 2.50.1: the per-path
+ * diagnosis is stdout's, written by the index refresh that found the stages, and
+ * the sentence saying the command stopped is stderr's. Exit 1, not the 128 a
+ * fatal takes.
+ */
+export class ResolveIndexError extends GitError {
+  override readonly prefix = 'error'
+  override readonly code = 1
+  override readonly report: string
+
+  constructor(paths: readonly string[]) {
+    super('you need to resolve your current index first')
+    this.report = [...paths]
+      .sort(compareCodePoints)
+      .map((path) => `${path}: needs merge\n`)
+      .join('')
+  }
+}
+
+/**
+ * `restore` naming a path the source cannot put back.
+ *
+ * A path with conflict stages has no stage-0 content, so restoring the working
+ * tree from the index has nothing to write and restoring the index from a tree
+ * that does not hold the path has nothing to stage. git names each such path and
+ * does none of the work; a path the source *does* hold restores normally and the
+ * stages go with it.
+ *
+ * One line per path, so several are refused in one answer rather than one per
+ * run. Pinned against git 2.50.1.
+ */
+export class UnmergedPathError extends GitError {
+  override readonly prefix = 'error'
+  override readonly code = 1
+
+  constructor(paths: readonly string[]) {
+    // git emits each path as its own error, so every line after the first
+    // carries the prefix inline: the renderer writes one.
+    super(
+      [...paths]
+        .sort(compareCodePoints)
+        .map((path) => `path '${path}' is unmerged`)
+        .join('\nerror: '),
+    )
   }
 }
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
@@ -637,6 +637,33 @@ export class RemovePathError extends GitError {
 }
 
 /**
+ * A working-tree removal that would take a nested mount with it.
+ *
+ * A mount nested inside the repository is served by another resource entirely,
+ * so removing the directory it stands in empties that backend rather than the
+ * repository: the store behind it is gone, and no branch ever recorded a line
+ * of it. mirage refuses instead, which is the rule `MountRootPolicy` already
+ * enforces for `rm` and `mv` at the command tier; a git verb reaches the
+ * dispatcher directly, so it has to ask for itself.
+ *
+ * The mount is named only when the session may be told about it. A hidden one
+ * blocks the removal just the same, because avoiding a boundary and naming it
+ * are two different questions, and naming a hidden mount is the one thing the
+ * hide exists to prevent.
+ */
+export class MountInWayError extends GitError {
+  constructor(path: string, mount: string | null = null) {
+    const held =
+      mount === null
+        ? 'it holds a mount root'
+        : mount === path
+          ? 'it is a mount root'
+          : `'${mount}' is a mount root`
+    super(`cannot remove '${path}': ${held}`)
+  }
+}
+
+/**
  * `mv` with fewer than two operands.
  *
  * git prints its usage and exits 129. Only the two synopsis lines are kept: the
@@ -810,6 +837,23 @@ export class TagNotFoundError extends GitError {
 export class ListModeOnlyError extends GitError {
   constructor() {
     super("the '-n' option is only allowed in list mode")
+  }
+}
+
+/**
+ * `tag -n<num>` with a count below the one git reserves.
+ *
+ * `-n` carries an optional count, and git's parser starts that count at -1 to
+ * mean "not given at all". `-n-1` is therefore not a listing flag at all:
+ * `git tag -d -n-1 v` deletes and `git tag -n-1 -a v -m m` creates, where a
+ * real `-n` refuses both. Anything below -1 is a count, and a count has to be
+ * positive, which git discovers while parsing the format it lists with rather
+ * than while parsing the option: the list-mode refusal outranks this one, and
+ * it fires in a repository holding no tags at all. Pinned against git 2.50.1.
+ */
+export class TagLinesError extends GitError {
+  constructor(lines: number) {
+    super(`positive value expected contents:lines=${String(lines)}`)
   }
 }
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
@@ -617,6 +617,26 @@ export class RemovalRefusedError extends GitError {
 }
 
 /**
+ * `rm` whose working-tree deletion the mount refused.
+ *
+ * git names the path and the strerror. The one reason a mount gives is a
+ * directory standing where a tracked file was: `unlink` refuses that, and git
+ * reports it rather than removing the tree.
+ *
+ * The `rm` lines ride along on stdout because git prints them for every
+ * selected path before it deletes anything, so the ones printed before the
+ * failure are printed whether the line goes through or not.
+ */
+export class RemovePathError extends GitError {
+  override readonly report: string
+
+  constructor(path: string, report = '', reason = 'Is a directory') {
+    super(`git rm: '${path}': ${reason}`)
+    this.report = report
+  }
+}
+
+/**
  * `mv` with fewer than two operands.
  *
  * git prints its usage and exits 129. Only the two synopsis lines are kept: the

--- a/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
@@ -453,3 +453,244 @@ export class InvalidOptionError extends GitError {
     super(`invalid option: ${argument}`)
   }
 }
+
+/** `rm` with no pathspec at all. */
+export class NoPathspecRemoveError extends GitError {
+  constructor() {
+    super('No pathspec was given. Which files should I remove?')
+  }
+}
+
+/** `rm` naming a directory without `-r`. */
+export class NotRecursiveError extends GitError {
+  constructor(operand: string) {
+    super(`not removing '${operand}' recursively without -r`)
+  }
+}
+
+// The three refusals `rm` groups its paths under, in the order git prints
+// them: a path whose staged content matches neither the file nor HEAD, a path
+// with a staged change, a path with an unstaged edit. Each header comes in a
+// singular and a plural form.
+const STAGED_BOTH: [string, string, string] = [
+  'the following file has staged content different from both the\nfile and the HEAD:',
+  'the following files have staged content different from both the\nfile and the HEAD:',
+  '(use -f to force removal)',
+]
+const STAGED_INDEX: [string, string, string] = [
+  'the following file has changes staged in the index:',
+  'the following files have changes staged in the index:',
+  '(use --cached to keep the file, or -f to force removal)',
+]
+const LOCAL_CHANGES: [string, string, string] = [
+  'the following file has local modifications:',
+  'the following files have local modifications:',
+  '(use --cached to keep the file, or -f to force removal)',
+]
+
+/** One paragraph of an `rm` refusal. */
+function removalBlock(wording: [string, string, string], paths: readonly string[]): string {
+  const header = paths.length === 1 ? wording[0] : wording[1]
+  const listed = [...paths]
+    .sort(compareCodePoints)
+    .map((path) => `    ${path}`)
+    .join('\n')
+  return `${header}\n${listed}\n${wording[2]}`
+}
+
+/**
+ * `rm` naming a path whose removal would lose uncommitted work.
+ *
+ * git refuses rather than deleting, and names every path under the reason it
+ * refused it. Three reasons, printed as three paragraphs in a fixed order when
+ * more than one applies, pinned against git 2.50.1.
+ */
+export class RemovalRefusedError extends GitError {
+  override readonly prefix = 'error'
+  override readonly code = 1
+
+  constructor(both: readonly string[], staged: readonly string[], local: readonly string[]) {
+    const blocks: string[] = []
+    if (both.length > 0) blocks.push(removalBlock(STAGED_BOTH, both))
+    if (staged.length > 0) blocks.push(removalBlock(STAGED_INDEX, staged))
+    if (local.length > 0) blocks.push(removalBlock(LOCAL_CHANGES, local))
+    // git emits each paragraph as its own error, so the second one carries the
+    // prefix inline: the renderer only writes the first.
+    super(blocks.join('\nerror: '))
+  }
+}
+
+/**
+ * `mv` with fewer than two operands.
+ *
+ * git prints its usage and exits 129. Only the two synopsis lines are kept: the
+ * option list below them describes flags this build does not all have.
+ */
+export class MoveUsageError extends GitError {
+  override readonly prefix = null
+  override readonly code = OPTION_EXIT
+
+  constructor() {
+    super(
+      'usage: git mv [-v] [-f] [-n] [-k] <source> <destination>\n' +
+        '   or: git mv [-v] [-f] [-n] [-k] <source>... <destination-directory>',
+    )
+  }
+}
+
+/** `mv` refusing one source, in git's `reason, source, destination` shape. */
+export class MoveRefusedError extends GitError {
+  constructor(reason: string, source: string, destination: string) {
+    super(`${reason}, source=${source}, destination=${destination}`)
+  }
+}
+
+/** `mv` with several sources and a destination that is not a directory. */
+export class NotADirectoryDestinationError extends GitError {
+  constructor(destination: string) {
+    super(`destination '${destination}' is not a directory`)
+  }
+}
+
+/**
+ * `mv` whose rename the mount refused.
+ *
+ * git names the source and the strerror. The one reason a mount gives is a
+ * destination whose directory does not exist: git does not create it, and
+ * neither does this.
+ */
+export class RenameFailedError extends GitError {
+  constructor(source: string, reason = 'No such file or directory') {
+    super(`renaming '${source}' failed: ${reason}`)
+  }
+}
+
+/** `restore` with no pathspec at all. */
+export class NoRestorePathsError extends GitError {
+  constructor() {
+    super('you must specify path(s) to restore')
+  }
+}
+
+/** `restore --source` naming a tree this repository cannot resolve. */
+export class UnresolvableSourceError extends GitError {
+  constructor(source: string) {
+    super(`could not resolve ${source}`)
+  }
+}
+
+/**
+ * `switch` naming something that is neither a branch nor a commit.
+ *
+ * `switch` words the miss differently from `checkout`, which calls the same
+ * operand a pathspec: switch never takes a path, so nothing it was given could
+ * have been one.
+ */
+export class InvalidReferenceError extends GitError {
+  constructor(name: string) {
+    super(`invalid reference: ${name}`)
+  }
+}
+
+/**
+ * `switch` given a commit, tag or remote branch without `--detach`.
+ *
+ * git refuses rather than detaching, because a detached HEAD is the state an
+ * agent loses commits in, and `switch` exists to be the verb that never gets
+ * there by accident.
+ */
+export class BranchExpectedError extends GitError {
+  constructor(kind: string, name: string) {
+    super(
+      `a branch is expected, got ${kind} '${name}'\n` +
+        `hint: If you want to detach HEAD at the commit, try again with the --detach option.`,
+    )
+  }
+}
+
+/** `switch` with nothing to switch to. */
+export class MissingBranchArgumentError extends GitError {
+  constructor() {
+    super('missing branch or commit argument')
+  }
+}
+
+/** `switch` given more than one operand. */
+export class OneReferenceError extends GitError {
+  constructor() {
+    super('only one reference expected')
+  }
+}
+
+/** `switch -c` together with `--detach`. */
+export class DetachWithCreateError extends GitError {
+  constructor() {
+    super(`'--detach' cannot be used with '-b/-B/--orphan'`)
+  }
+}
+
+/** `tag <name>` naming a tag that is already there. */
+export class TagExistsError extends GitError {
+  constructor(name: string) {
+    super(`tag '${name}' already exists`)
+  }
+}
+
+/**
+ * `tag -d` naming a tag that is not there.
+ *
+ * Reported and moved past: git deletes the other names on the line and exits 1
+ * at the end, so this is rendered per name rather than thrown.
+ */
+export class TagNotFoundError extends GitError {
+  override readonly prefix = 'error'
+  override readonly code = 1
+
+  constructor(name: string) {
+    super(`tag '${name}' not found.`)
+  }
+}
+
+/** A tag name git's ref rules refuse. */
+export class InvalidTagNameError extends GitError {
+  constructor(name: string) {
+    super(`'${name}' is not a valid tag name.`)
+  }
+}
+
+/** `tag` given an object it cannot resolve. */
+export class UnresolvedRefError extends GitError {
+  constructor(revision: string) {
+    super(`Failed to resolve '${revision}' as a valid ref.`)
+  }
+}
+
+/** `tag` given more operands than a name and an object. */
+export class TooManyArgumentsError extends GitError {
+  constructor() {
+    super('too many arguments')
+  }
+}
+
+/**
+ * `tag -a` with no `-m`.
+ *
+ * git would open an editor here, exactly as `commit` would, and the same answer
+ * applies: a mount has no editor, and inventing a message would put an
+ * unreviewed one into the repository.
+ */
+export class MissingTagMessageError extends GitError {
+  constructor() {
+    super('no tag message supplied (mirage has no editor to open; pass -m)')
+  }
+}
+
+/** Two options git refuses to take together. */
+export class IncompatibleOptionsError extends GitError {
+  override readonly prefix = 'error'
+  override readonly code = OPTION_EXIT
+
+  constructor(first: string, second: string) {
+    super(`options '${first}' and '${second}' cannot be used together`)
+  }
+}

--- a/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
@@ -661,6 +661,21 @@ export class MoveRefusedError extends GitError {
   }
 }
 
+/**
+ * `mv` given both a directory and something inside it.
+ *
+ * git refuses the whole line rather than one source, and `-k` does not skip it:
+ * the two moves would race for the same bytes, and the one that lost would be
+ * reported as a rename that failed after the other had already changed the
+ * working tree. The child is named first however the operands were ordered.
+ * Pinned against git 2.50.1.
+ */
+export class MoveOverlapError extends GitError {
+  constructor(child: string, parent: string) {
+    super(`cannot move both '${child}' and its parent directory '${parent}'`)
+  }
+}
+
 /** `mv` with several sources and a destination that is not a directory. */
 export class NotADirectoryDestinationError extends GitError {
   constructor(destination: string) {
@@ -815,6 +830,19 @@ export class RefUpdateConflictError extends GitError {
 
   constructor(ref: string) {
     super(`could not delete references: multiple updates for ref '${ref}' not allowed`)
+  }
+}
+
+/**
+ * A ref that cannot be written because another one holds its path.
+ *
+ * git reports this as a failure to take the lock rather than as a name that is
+ * already taken, and names the ref standing in the way. `-f` does not help: the
+ * obstacle is the path, not the value. Pinned against git 2.50.1.
+ */
+export class RefLockError extends GitError {
+  constructor(ref: string, held: string) {
+    super(`cannot lock ref '${ref}': '${held}' exists; cannot create '${ref}'`)
   }
 }
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
@@ -384,8 +384,12 @@ export class UnknownPathspecError extends GitError {
 
 /**
  * One named-files paragraph of a checkout refusal.
+ *
+ * The advice line is optional because one of git's three paragraphs has none:
+ * the directory one ends at its list, which renders as the blank line before
+ * the next paragraph.
  */
-function conflictBlock(header: string, paths: readonly string[], advice: string): string {
+function conflictBlock(header: string, paths: readonly string[], advice = ''): string {
   const listed = [...paths]
     .sort(compareCodePoints)
     .map((path) => `\t${path}`)
@@ -401,16 +405,21 @@ function conflictBlock(header: string, paths: readonly string[], advice: string)
  * silently destroys whatever was edited and not staged.
  *
  * Two kinds of work are at risk and git words them differently: a tracked file
- * carrying uncommitted changes, and an untracked file the target branch would
- * write over. Both are carried here rather than thrown separately because when
- * both apply git prints both paragraphs and aborts once, pinned against git
- * 2.50.
+ * carrying uncommitted changes, an untracked *directory* the target replaces
+ * with a file of the same name, and an untracked file the target branch would
+ * write over. All three are carried here rather than thrown separately because
+ * when several apply git prints every paragraph and aborts once, in this
+ * order, pinned against git 2.50.1.
  */
 export class CheckoutConflictError extends GitError {
   override readonly prefix = 'error'
   override readonly code = 1
 
-  constructor(local: readonly string[], untracked: readonly string[]) {
+  constructor(
+    local: readonly string[],
+    untracked: readonly string[],
+    directories: readonly string[] = [],
+  ) {
     const blocks: string[] = []
     if (local.length > 0) {
       blocks.push(
@@ -418,6 +427,14 @@ export class CheckoutConflictError extends GitError {
           'Your local changes to the following files would be overwritten by checkout:',
           local,
           'Please commit your changes or stash them before you switch branches.',
+        ),
+      )
+    }
+    if (directories.length > 0) {
+      blocks.push(
+        conflictBlock(
+          'Updating the following directories would lose untracked files in them:',
+          directories,
         ),
       )
     }

--- a/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/errors.ts
@@ -668,6 +668,19 @@ export class NoRestorePathsError extends GitError {
   }
 }
 
+/**
+ * `restore --source` naming an object that is no tree.
+ *
+ * A revision that resolves is reported by the id it resolved to rather than by
+ * the spelling, which is git's own wording: the complaint is about the object
+ * found, not about the name.
+ */
+export class UnreadableTreeError extends GitError {
+  constructor(oid: string) {
+    super(`unable to read tree (${oid})`)
+  }
+}
+
 /** `restore --source` naming a tree this repository cannot resolve. */
 export class UnresolvableSourceError extends GitError {
   constructor(source: string) {

--- a/typescript/packages/core/src/commands/cli/builtin/git/index.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/index.ts
@@ -21,9 +21,14 @@ import { checkout } from './checkout.ts'
 import { commit } from './commit.ts'
 import { diff } from './diff.ts'
 import { log } from './log.ts'
+import { mv } from './mv.ts'
 import { reset } from './reset.ts'
+import { restore } from './restore.ts'
+import { rm } from './rm.ts'
 import { show } from './show.ts'
 import { status } from './status.ts'
+import { switchBranch } from './switch.ts'
+import { tag } from './tag.ts'
 
 // `-C` is git's own before-anything-else option, so it sits on the root and
 // every verb inherits it. The "." default is load-bearing: a PATH default lands
@@ -148,6 +153,76 @@ const CHECKOUT_OPTIONS = [
   new Option({ short: '-b', description: 'Create the branch and switch to it' }),
 ]
 
+const SWITCH_OPTIONS = [
+  new Option({
+    short: '-c',
+    long: '--create',
+    type: 'str',
+    description: 'Create the branch and switch to it',
+  }),
+  new Option({ short: '-d', long: '--detach', description: 'Detach HEAD at the named commit' }),
+]
+
+const RESTORE_OPTIONS = [
+  new Option({ short: '-S', long: '--staged', description: 'Restore the index' }),
+  new Option({
+    short: '-W',
+    long: '--worktree',
+    description: 'Restore the working tree (default)',
+  }),
+  new Option({
+    short: '-s',
+    long: '--source',
+    type: 'str',
+    description: 'Which tree-ish to restore from',
+  }),
+]
+
+const RM_OPTIONS = [
+  new Option({ short: '-r', description: 'Allow recursive removal' }),
+  new Option({ long: '--cached', description: 'Only remove from the index, keeping the file' }),
+  new Option({ short: '-f', long: '--force', description: 'Override the up-to-date check' }),
+  new Option({ short: '-q', long: '--quiet', description: 'Do not list removed files' }),
+  new Option({
+    long: '--ignore-unmatch',
+    description: 'Exit with a zero status even if nothing matched',
+  }),
+]
+
+const MV_OPTIONS = [
+  new Option({
+    short: '-f',
+    long: '--force',
+    description: 'Force move/rename even if target exists',
+  }),
+  new Option({ short: '-k', description: 'Skip move/rename errors' }),
+  new Option({ short: '-n', long: '--dry-run', description: 'Dry run' }),
+  new Option({ short: '-v', long: '--verbose', description: 'Be verbose' }),
+]
+
+const TAG_OPTIONS = [
+  new Option({ short: '-l', long: '--list', description: 'List tag names' }),
+  // git spells the count attached (`-n2`) or not at all, never as a separate
+  // token, which is what valueOptional says: a bare -n means one line and the
+  // next word is left alone to be a pattern.
+  new Option({
+    short: '-n',
+    type: 'int',
+    valueOptional: true,
+    description: 'Print <n> lines of each tag message',
+  }),
+  new Option({ short: '-d', long: '--delete', description: 'Delete tags' }),
+  new Option({ short: '-a', long: '--annotate', description: 'Annotated tag, needs a message' }),
+  new Option({
+    short: '-m',
+    long: '--message',
+    type: 'str',
+    multiple: true,
+    description: 'Tag message (repeatable, one paragraph each)',
+  }),
+  new Option({ short: '-f', long: '--force', description: 'Replace the tag if exists' }),
+]
+
 const BRANCH_OPTIONS = [
   new Option({ short: '-a', description: 'List local and remote-tracking branches' }),
   new Option({ short: '-r', description: 'List remote-tracking branches' }),
@@ -232,6 +307,46 @@ export const GIT = new CLISpec({
       fn: checkout,
       options: CHECKOUT_OPTIONS,
       rest: REVISION,
+      write: true,
+    }),
+    new CLISpec({
+      name: 'switch',
+      description: 'Switch branches',
+      fn: switchBranch,
+      options: SWITCH_OPTIONS,
+      rest: REVISION,
+      write: true,
+    }),
+    new CLISpec({
+      name: 'restore',
+      description: 'Restore working tree files',
+      fn: restore,
+      options: RESTORE_OPTIONS,
+      rest: PATHSPEC,
+      write: true,
+    }),
+    new CLISpec({
+      name: 'rm',
+      description: 'Remove files from the working tree and the index',
+      fn: rm,
+      options: RM_OPTIONS,
+      rest: PATHSPEC,
+      write: true,
+    }),
+    new CLISpec({
+      name: 'mv',
+      description: 'Move or rename a file, a directory, or a symlink',
+      fn: mv,
+      options: MV_OPTIONS,
+      rest: PATHSPEC,
+      write: true,
+    }),
+    new CLISpec({
+      name: 'tag',
+      description: 'Create, list or delete a tag',
+      fn: tag,
+      options: TAG_OPTIONS,
+      rest: new Operand({ type: 'str' }),
       write: true,
     }),
   ],

--- a/typescript/packages/core/src/commands/cli/builtin/git/index_file.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/index_file.ts
@@ -15,6 +15,7 @@
 import { GitIndexManager } from 'isomorphic-git/managers'
 import { FileSystem } from 'isomorphic-git/models'
 
+import { ResolveIndexError } from './errors.ts'
 import { exists, under } from './io.ts'
 import type { Repo } from './repo.ts'
 import type { ConflictedEntry, Dispatch, IndexEntry, IndexState } from './types.ts'
@@ -153,4 +154,20 @@ export async function updateIndex(
       })
     }
   })
+}
+
+/**
+ * Refuse a branch move while the index still records conflict stages.
+ *
+ * Every collision check a checkout makes reads stage 0, so a path held only as
+ * stages 1-3 is invisible to all of them, and git refuses before it reads
+ * either tree. The refusal is not the moving side's alone: `git switch
+ * <current>` and `git checkout <current>` move nothing and still die on it, so
+ * a line that answers "Already on" out of a shortcut has to ask the index
+ * first. Pinned against git 2.50.1, where `git switch -c <new>` is the one line
+ * that survives an unresolved index, because it writes a ref and nothing else.
+ */
+export function refuseUnresolved(state: IndexState): void {
+  if (state.conflicts.size === 0) return
+  throw new ResolveIndexError([...state.conflicts.keys()])
 }

--- a/typescript/packages/core/src/commands/cli/builtin/git/io.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/io.ts
@@ -17,7 +17,7 @@ import type { FileStat } from '../../../../types.ts'
 import { parent, posixNormpath } from '../../../../utils/path.ts'
 import { isMissingPath } from '../../../../utils/errors.ts'
 import type { LinkView, StatPath } from '../../../../ops/types.ts'
-import { SYMLINK_MODE } from './constants.ts'
+import { PERMISSION_BITS, SYMLINK_MODE } from './constants.ts'
 import { basename } from './path.ts'
 import type { Dispatch } from './types.ts'
 
@@ -66,6 +66,16 @@ export async function entryBytes(
  * does not overwrite, so the old name is removed rather than replaced in place.
  * The check is a namespace lookup, so the ordinary file-for-file case costs
  * nothing.
+ *
+ * The permission bits are part of the entry, not decoration on it. git records
+ * exactly one of them, the owner's execute bit, and puts it back in both
+ * directions: `chmod -x` on a `100755` path is a modification `restore` undoes,
+ * and `chmod +x` on a `100644` one is a modification it undoes the other way.
+ * Writing the bytes alone left the bit as the working tree had it, so the file
+ * came back unrunnable and `status` went on calling it modified for ever. The
+ * write is unconditional rather than probed: a stat to decide costs the same op
+ * as the setattr it would save, and the backends git actually runs on apply it
+ * natively, so nothing reaches the overlay.
  */
 export async function restoreEntry(
   dispatch: Dispatch,
@@ -84,6 +94,9 @@ export async function restoreEntry(
   }
   if (linked) await removeFile(dispatch, path)
   await writeFile(dispatch, path, blob)
+  await dispatch('setattr', PathSpec.fromStrPath(path), [], {
+    mode: Number.parseInt(mode, 8) & PERMISSION_BITS,
+  })
 }
 
 /** Read a byte range of one virtual path. */

--- a/typescript/packages/core/src/commands/cli/builtin/git/io.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/io.ts
@@ -18,6 +18,7 @@ import { parent, posixNormpath } from '../../../../utils/path.ts'
 import { isMissingPath } from '../../../../utils/errors.ts'
 import type { LinkView } from '../../../../ops/types.ts'
 import { SYMLINK_MODE } from './constants.ts'
+import { basename } from './path.ts'
 import type { Dispatch } from './types.ts'
 
 /** Read one virtual path through the workspace dispatcher. */
@@ -222,6 +223,51 @@ export async function renamePath(
   target: string,
 ): Promise<void> {
   await dispatch('rename', PathSpec.fromStrPath(source), [PathSpec.fromStrPath(target)])
+}
+
+/**
+ * Delete a path and everything under it, tracked or not.
+ *
+ * git replaces a tree entry rather than merging with it, so a directory
+ * standing where the source keeps a file goes entirely. That is one of the few
+ * places git removes a file it never tracked: an untracked child keeps the
+ * directory alive after the tracked ones are gone, and restoring the file over
+ * it would otherwise fail with the index already changed.
+ *
+ * A file and an absent path both walk out through the same two steps, since
+ * `readdir` reads a non-directory as nothing there and `rmdir` refuses it.
+ *
+ * @param dispatch workspace op dispatcher
+ * @param path absolute virtual path to clear
+ */
+export async function removeTree(dispatch: Dispatch, path: string): Promise<void> {
+  let entries: string[] = []
+  try {
+    entries = await readNames(dispatch, path)
+  } catch (err) {
+    // `readNames` reads only an absent path as nothing there, where python's
+    // `read_names` folds "not a directory" in as well (MISS_ERRORS carries
+    // NotADirectoryError). A file listed as a directory is exactly what this
+    // walk expects to meet, and the unlink below is its answer.
+    if ((err as { code?: string }).code !== 'ENOTDIR') throw err
+  }
+  for (const entry of entries) {
+    // A listing answers in whole paths, so the child is rebuilt from the
+    // basename the way every other walk here does.
+    const name = basename(entry)
+    if (name === '') continue
+    await removeTree(dispatch, under(path, name))
+  }
+  try {
+    await dispatch('rmdir', PathSpec.fromStrPath(path))
+  } catch (err) {
+    // A directory the walk above was supposed to empty is a real failure and
+    // stays thrown. Everything else means this was no directory (or is
+    // already gone), so the path is whatever one file it is and unlink
+    // tolerates an absent one.
+    if ((err as { code?: string }).code === 'ENOTEMPTY') throw err
+    await removeFile(dispatch, path)
+  }
 }
 
 /**

--- a/typescript/packages/core/src/commands/cli/builtin/git/io.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/io.ts
@@ -207,3 +207,49 @@ export async function removeFile(dispatch: Dispatch, path: string): Promise<void
 export function under(base: string, ...parts: string[]): string {
   return posixNormpath(`${base}/${parts.join('/')}`)
 }
+
+/**
+ * Move one virtual path, file or directory, to another name.
+ *
+ * The mount's own rename, so a directory moves with everything under it,
+ * tracked or not, which is what `git mv` does with a directory. The
+ * destination's directory is not created: git's rename fails when it is
+ * missing, and the caller words that failure.
+ */
+export async function renamePath(
+  dispatch: Dispatch,
+  source: string,
+  target: string,
+): Promise<void> {
+  await dispatch('rename', PathSpec.fromStrPath(source), [PathSpec.fromStrPath(target)])
+}
+
+/**
+ * Drop the directories a deletion left empty, up to a root.
+ *
+ * git removes a directory the moment its last tracked file is deleted or
+ * restored away, so `rm -r docs` leaves no `docs/` behind. The walk stops at the
+ * first directory that still holds something and never touches `stop` itself.
+ *
+ * @param dispatch workspace op dispatcher
+ * @param path the file that was removed
+ * @param stop the working tree root
+ */
+export async function removeEmptyParents(
+  dispatch: Dispatch,
+  path: string,
+  stop: string,
+): Promise<void> {
+  const root = stop.replace(/\/+$/, '') || '/'
+  let current = parent(path)
+  while (current !== root && current.startsWith(root)) {
+    if ((await readNames(dispatch, current)).length > 0) return
+    try {
+      await dispatch('rmdir', PathSpec.fromStrPath(current))
+    } catch (err) {
+      if (!isMissingPath(err)) throw err
+      return
+    }
+    current = parent(current)
+  }
+}

--- a/typescript/packages/core/src/commands/cli/builtin/git/io.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/io.ts
@@ -16,8 +16,10 @@ import { FileType, LINK_TARGET_KEY, PathSpec } from '../../../../types.ts'
 import type { FileStat } from '../../../../types.ts'
 import { parent, posixNormpath } from '../../../../utils/path.ts'
 import { isMissingPath } from '../../../../utils/errors.ts'
-import type { LinkView, StatPath } from '../../../../ops/types.ts'
+import { compareCodePoints } from '../../../../utils/sort.ts'
+import type { LinkView, MountView, StatPath } from '../../../../ops/types.ts'
 import { PERMISSION_BITS, SYMLINK_MODE } from './constants.ts'
+import { MountInWayError } from './errors.ts'
 import { basename } from './path.ts'
 import type { Dispatch } from './types.ts'
 
@@ -282,6 +284,32 @@ export async function renamePath(
 }
 
 /**
+ * Refuse a removal that would take a nested mount with it.
+ *
+ * A mount nested inside the working tree is served by another resource, and
+ * `readdir` merges it into the parent's listing, so a walk that empties a
+ * directory walks straight into the child backend and unlinks what is in it.
+ * No branch ever recorded any of that, and the `rmdir` that follows takes the
+ * mount root itself. Asking the mount table is the only way to see the
+ * boundary: the parent backend cannot.
+ *
+ * Two questions, two fields, the way `MountView` says: the boundary is
+ * *avoided* by the unfiltered list, so a mount this session cannot see still
+ * blocks the removal, and it is *named* from the visible one, since naming a
+ * hidden mount is what the hide exists to prevent.
+ *
+ * @param mounts the name plane's mount boundaries, null when none is wired
+ * @param path absolute virtual path about to be removed
+ */
+export function refuseMount(mounts: MountView | null, path: string): void {
+  if (mounts === null) return
+  if (mounts.isRoot(path)) throw new MountInWayError(path, path)
+  if (mounts.descendants(path).length === 0) return
+  const named = [...mounts.visibleDescendants(path)].sort(compareCodePoints)
+  throw new MountInWayError(path, named[0] ?? null)
+}
+
+/**
  * Delete a path and everything under it, tracked or not.
  *
  * git replaces a tree entry rather than merging with it, so a directory
@@ -304,12 +332,18 @@ export async function renamePath(
  * @param dispatch workspace op dispatcher
  * @param path absolute virtual path to clear
  * @param links the name plane's link facts, null when no namespace is wired
+ * @param mounts the name plane's mount boundaries, null when none is wired
  */
 export async function removeTree(
   dispatch: Dispatch,
   path: string,
   links: LinkView | null,
+  mounts: MountView | null,
 ): Promise<void> {
+  // Before the first deletion rather than at the boundary itself, so a mount
+  // deep under the directory costs the caller nothing: the scan sees every
+  // depth at once and the tree is still whole when it refuses.
+  refuseMount(mounts, path)
   let entries: string[] = []
   try {
     entries = await readNames(dispatch, path)
@@ -330,7 +364,7 @@ export async function removeTree(
       await removeFile(dispatch, child)
       continue
     }
-    await removeTree(dispatch, child, links)
+    await removeTree(dispatch, child, links, mounts)
   }
   try {
     await dispatch('rmdir', PathSpec.fromStrPath(path))
@@ -354,15 +388,22 @@ export async function removeTree(
  * @param dispatch workspace op dispatcher
  * @param path the file that was removed
  * @param stop the working tree root
+ * @param mounts the name plane's mount boundaries, null when none is wired
  */
 export async function removeEmptyParents(
   dispatch: Dispatch,
   path: string,
   stop: string,
+  mounts: MountView | null,
 ): Promise<void> {
   const root = stop.replace(/\/+$/, '') || '/'
   let current = parent(path)
   while (current !== root && current.startsWith(root)) {
+    // A mount root is not a directory git made, and an empty one is still a
+    // whole backend: removing it here would destroy the store behind it as a
+    // side effect of tidying up. The walk stops rather than refusing, because
+    // nothing the caller asked for has failed.
+    if (mounts?.isRoot(current) === true) return
     if ((await readNames(dispatch, current)).length > 0) return
     try {
       await dispatch('rmdir', PathSpec.fromStrPath(current))

--- a/typescript/packages/core/src/commands/cli/builtin/git/io.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/io.ts
@@ -284,6 +284,39 @@ export async function renamePath(
 }
 
 /**
+ * Ask of every destination first what the write loop would meet later.
+ *
+ * `removeTree` refuses a directory holding a mount, but the loop reaches one
+ * entry at a time, so a refusal there leaves the entries already written
+ * standing on the target's content with HEAD and the index still where they
+ * were. Asking first is the shape every other collision check in these verbs
+ * already has: name what is in the way and change nothing. The condition
+ * mirrors the write loop's exactly, a link included, so a destination the loop
+ * would not clear is not refused here either.
+ *
+ * @param statPath the data plane's stat, which dereferences
+ * @param worktree absolute virtual path of the working tree root
+ * @param names repository-relative paths about to be written
+ * @param links the name plane's link facts, null when no namespace is wired
+ * @param mounts the name plane's mount boundaries, null when none is wired
+ */
+export async function refuseReplacedMounts(
+  statPath: StatPath,
+  worktree: string,
+  names: readonly string[],
+  links: LinkView | null,
+  mounts: MountView | null,
+): Promise<void> {
+  if (mounts === null) return
+  for (const name of [...names].sort(compareCodePoints)) {
+    const where = under(worktree, name)
+    if ((links?.statAt(where) ?? null) !== null) continue
+    const info = await statPath(where)
+    if (info !== null && info.type === FileType.DIRECTORY) refuseMount(mounts, where)
+  }
+}
+
+/**
  * Refuse a removal that would take a nested mount with it.
  *
  * A mount nested inside the working tree is served by another resource, and

--- a/typescript/packages/core/src/commands/cli/builtin/git/io.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/io.ts
@@ -293,10 +293,23 @@ export async function renamePath(
  * A file and an absent path both walk out through the same two steps, since
  * `readdir` reads a non-directory as nothing there and `rmdir` refuses it.
  *
+ * A child that is a symlink is unlinked, never descended into. The name plane
+ * has to say so, because `readdir` dereferences: a link to a directory lists
+ * that directory's contents, and recursing on them deletes a tree outside the
+ * one being replaced. `rm -r` does not follow a link either, so a branch
+ * recording a file where the working tree has a directory takes the link away
+ * with the directory and leaves whatever it pointed at exactly as it was.
+ * Pinned against git 2.50.1.
+ *
  * @param dispatch workspace op dispatcher
  * @param path absolute virtual path to clear
+ * @param links the name plane's link facts, null when no namespace is wired
  */
-export async function removeTree(dispatch: Dispatch, path: string): Promise<void> {
+export async function removeTree(
+  dispatch: Dispatch,
+  path: string,
+  links: LinkView | null,
+): Promise<void> {
   let entries: string[] = []
   try {
     entries = await readNames(dispatch, path)
@@ -312,7 +325,12 @@ export async function removeTree(dispatch: Dispatch, path: string): Promise<void
     // basename the way every other walk here does.
     const name = basename(entry)
     if (name === '') continue
-    await removeTree(dispatch, under(path, name))
+    const child = under(path, name)
+    if ((links?.statAt(child) ?? null) !== null) {
+      await removeFile(dispatch, child)
+      continue
+    }
+    await removeTree(dispatch, child, links)
   }
   try {
     await dispatch('rmdir', PathSpec.fromStrPath(path))

--- a/typescript/packages/core/src/commands/cli/builtin/git/io.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/io.ts
@@ -132,6 +132,50 @@ export async function keepGitlink(
   await ensureDir(dispatch, path)
 }
 
+/**
+ * Take a submodule's directory away, or say why it stays.
+ *
+ * The other direction of `keepGitlink`, and it is not an unlink: what stands at
+ * a 160000 entry is a directory, so git calls `rmdir` and warns rather than
+ * failing when that cannot be done. An empty one goes; one still holding a
+ * checked-out submodule, or anything else untracked, stays and is named; a
+ * regular file or a link at the name is the `ENOTDIR` wording of the same
+ * warning; a name with nothing at it is silent. The switch itself succeeds
+ * either way, which is the whole point of warning instead of throwing. Pinned
+ * against git 2.50.1.
+ *
+ * @param dispatch workspace op dispatcher
+ * @param statPath the data plane's stat, which dereferences
+ * @param path absolute virtual path of the submodule
+ * @param name the path as git prints it, repository-relative
+ * @param links the name plane's link facts, null when no namespace is wired
+ * @returns the warning line to write, null when there is nothing to say
+ */
+export async function dropGitlink(
+  dispatch: Dispatch,
+  statPath: StatPath,
+  path: string,
+  name: string,
+  links: LinkView | null,
+): Promise<string | null> {
+  // A link is answered before the stat, which dereferences: rmdir never follows
+  // one, so a link to a directory is ENOTDIR here even though stat would call
+  // it a directory.
+  if ((links?.statAt(path) ?? null) !== null) {
+    return `warning: unable to rmdir '${name}': Not a directory\n`
+  }
+  const info = await statPath(path)
+  if (info === null) return null
+  if (info.type !== FileType.DIRECTORY) {
+    return `warning: unable to rmdir '${name}': Not a directory\n`
+  }
+  if ((await readNames(dispatch, path)).length > 0) {
+    return `warning: unable to rmdir '${name}': Directory not empty\n`
+  }
+  await dispatch('rmdir', PathSpec.fromStrPath(path))
+  return null
+}
+
 /** Read a byte range of one virtual path. */
 export async function readRange(
   dispatch: Dispatch,

--- a/typescript/packages/core/src/commands/cli/builtin/git/io.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/io.ts
@@ -101,6 +101,37 @@ export async function restoreEntry(
   })
 }
 
+/**
+ * Leave a submodule's working tree alone, but make sure it has one.
+ *
+ * A 160000 entry names a commit in another repository, which this one does not
+ * hold: reading it as a blob is either a miss (an ordinary submodule keeps its
+ * objects in its own store) or, when the id does happen to resolve here, an
+ * empty string written over the directory. git does neither. It checks out no
+ * submodule content at all without `--recurse-submodules`, and all the entry
+ * asks of the working tree is that a directory stand at the name: an existing
+ * one is left exactly as it is, untracked work included, a regular file or a
+ * link is replaced by an empty one, and a missing one is created. Pinned
+ * against git 2.50.1.
+ *
+ * @param dispatch workspace op dispatcher
+ * @param statPath the data plane's stat, which dereferences
+ * @param path absolute virtual path of the submodule
+ * @param links the name plane's link facts, null when no namespace is wired
+ */
+export async function keepGitlink(
+  dispatch: Dispatch,
+  statPath: StatPath,
+  path: string,
+  links: LinkView | null,
+): Promise<void> {
+  const linked = (links?.statAt(path) ?? null) !== null
+  const info = linked ? null : await statPath(path)
+  if (info !== null && info.type === FileType.DIRECTORY) return
+  if (linked || info !== null) await removeFile(dispatch, path)
+  await ensureDir(dispatch, path)
+}
+
 /** Read a byte range of one virtual path. */
 export async function readRange(
   dispatch: Dispatch,

--- a/typescript/packages/core/src/commands/cli/builtin/git/io.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/io.ts
@@ -16,7 +16,7 @@ import { FileType, LINK_TARGET_KEY, PathSpec } from '../../../../types.ts'
 import type { FileStat } from '../../../../types.ts'
 import { parent, posixNormpath } from '../../../../utils/path.ts'
 import { isMissingPath } from '../../../../utils/errors.ts'
-import type { LinkView } from '../../../../ops/types.ts'
+import type { LinkView, StatPath } from '../../../../ops/types.ts'
 import { SYMLINK_MODE } from './constants.ts'
 import { basename } from './path.ts'
 import type { Dispatch } from './types.ts'
@@ -207,6 +207,49 @@ export async function removeFile(dispatch: Dispatch, path: string): Promise<void
 /** Join path segments below a git directory, POSIX style. */
 export function under(base: string, ...parts: string[]): string {
   return posixNormpath(`${base}/${parts.join('/')}`)
+}
+
+/**
+ * The nearest component above an entry that is not a directory.
+ *
+ * An entry's path is only a way through the working tree while every component
+ * above it is a directory. Anything else standing on one -- a symlink, a
+ * regular file, tracked or not -- is not a way through, and the two directions
+ * take it differently. Writing the entry *replaces* it with the directory the
+ * entry needs, leaving whatever a link pointed at exactly as it was; removing
+ * the entry does nothing at all, because the path never led there. That is
+ * git's `create_directories` and `check_leading_path`, and both halves were
+ * probed against git 2.50.1.
+ *
+ * The namespace is asked before the data plane, and the order is the whole
+ * point: `statPath` dereferences, so a link to a directory stats as a directory
+ * and the walk would carry on straight through it. Only the name plane can say
+ * that the component is a link.
+ *
+ * An exact-path lookup cannot see any of this, since what is in the way sits
+ * above the name being looked up rather than on it.
+ *
+ * @param statPath the data plane's stat, which dereferences
+ * @param worktree absolute virtual path of the working tree root
+ * @param name the entry, repository-relative
+ * @param links the name plane's link facts, null when no namespace is wired
+ * @returns the absolute virtual path of the nearest such component, null when
+ *   every component above the entry is a directory
+ */
+export async function blockingAncestor(
+  statPath: StatPath,
+  worktree: string,
+  name: string,
+  links: LinkView | null,
+): Promise<string | null> {
+  let current = worktree
+  for (const part of name.split('/').slice(0, -1)) {
+    current = under(current, part)
+    if ((links?.statAt(current) ?? null) !== null) return current
+    const info = await statPath(current)
+    if (info !== null && info.type !== FileType.DIRECTORY) return current
+  }
+  return null
 }
 
 /**

--- a/typescript/packages/core/src/commands/cli/builtin/git/log.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/log.ts
@@ -29,7 +29,7 @@ import {
 import { decorations, parseFlags, refCommits, select, type LogFlags } from './history.ts'
 import { commitFacts, opened, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
-import { checkOperands, fatal, revisionArg } from './util.ts'
+import { checkOperands, escaped, fatal, revisionArg } from './util.ts'
 import { encodeText } from '../../../../shell/bytes.ts'
 
 /**
@@ -90,7 +90,7 @@ export async function log(inv: CLIInvocation): Promise<CommandFnResult> {
   const texts = [...inv.texts]
   const fl = new FlagView(inv.flags)
   try {
-    checkOperands(texts)
+    checkOperands(texts, undefined, escaped(inv.argv))
     const parsed = parseFlags(fl)
     const repo = await opened(fl, doors)
     const starts = await startingPoints(repo, revisionArg(texts), parsed)

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -156,6 +156,15 @@ function git(repo: string, args: string[]): string {
   return execFileSync('git', ['-C', repo, ...args], { encoding: 'utf8' })
 }
 
+/** Leave one tracked path unmerged, with all three stages holding its blob. */
+function conflictIndex(repo: string, path: string): void {
+  const blob = git(repo, ['rev-parse', `HEAD:${path}`]).trim()
+  const stages = [1, 2, 3].map((stage) => `100644 ${blob} ${String(stage)}\t${path}`)
+  execFileSync('git', ['-C', repo, 'update-index', '--index-info'], {
+    input: `${stages.join('\n')}\n`,
+  })
+}
+
 /** Write into the mount, which is where the verbs under test read from. */
 async function write(h: Harness, path: string, text: string): Promise<void> {
   const target = `/repo/${path}`
@@ -1315,5 +1324,135 @@ describe('restoring an unmerged path', () => {
     const drained = await h.drain()
     expect(git(drained, ['ls-files', '-u'])).toBe('')
     expect(git(drained, ['status', '--porcelain'])).toBe('')
+  })
+})
+
+describe('a path the index left unmerged', () => {
+  it('refuses to move as a source of its own', async () => {
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'letters.txt')
+    })
+    expect(await h.run('mv letters.txt moved.txt')).toEqual([
+      128,
+      '',
+      'fatal: conflicted, source=letters.txt, destination=moved.txt\n',
+    ])
+  })
+
+  it('outranks a destination that already exists', async () => {
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'letters.txt')
+    })
+    const [, , err] = await h.run('mv letters.txt numbers.txt')
+    expect(err).toBe('fatal: conflicted, source=letters.txt, destination=numbers.txt\n')
+  })
+
+  it('refuses the directory holding it, named by the path itself', async () => {
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'docs/readme.md')
+    })
+    expect(await h.run('mv docs notes')).toEqual([
+      128,
+      '',
+      'fatal: conflicted, source=docs/readme.md, destination=notes/readme.md\n',
+    ])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('UU docs/readme.md\n')
+  })
+
+  it('is skipped under -k', async () => {
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'letters.txt')
+    })
+    expect(await h.run('mv -k letters.txt moved.txt')).toEqual([0, '', ''])
+  })
+})
+
+describe('a directory holding a symlink', () => {
+  it('carries it along when git mv renames the directory', async () => {
+    const h = await harness()
+    await h.ws.dispatch('symlink', '/repo/docs/link', [], { target: 'readme.md' })
+    await h.run('add docs')
+    await h.run('commit -m link')
+    expect(await h.run('mv docs notes')).toEqual([0, '', ''])
+    // The link is namespace state, not a backend entry, so it is read back
+    // through the workspace rather than out of the drained copy.
+    expect(await h.ws.dispatch('readlink', '/repo/notes/link')).toBe('readme.md')
+    expect(await h.run('status --porcelain')).toEqual([
+      0,
+      'R  docs/link -> notes/link\nR  docs/readme.md -> notes/readme.md\n',
+      '',
+    ])
+    // The index is asserted on the drained copy rather than its status: the
+    // drain writes files, so the link lands there as a regular file and the
+    // real binary reads the pair as a type change.
+    const rows = git(await h.drain(), ['ls-files', '-s'])
+    expect(rows).toContain('120000')
+    expect(rows).toContain('notes/link')
+    expect(rows).not.toContain('docs/link')
+  })
+})
+
+describe('git switch --detach', () => {
+  it('takes HEAD when nothing is named', async () => {
+    const h = await harness()
+    const [code, , err] = await h.run('switch --detach')
+    expect(code).toBe(0)
+    expect(err.startsWith('HEAD is now at ')).toBe(true)
+    const drained = await h.drain()
+    expect(git(drained, ['rev-parse', '--abbrev-ref', 'HEAD'])).toBe('HEAD\n')
+    expect(git(drained, ['rev-parse', 'HEAD'])).toBe(git(drained, ['rev-parse', 'main']))
+  })
+
+  it('still needs a branch when attaching', async () => {
+    const h = await harness()
+    const [code, , err] = await h.run('switch')
+    expect(code).toBe(128)
+    expect(err.startsWith('fatal: ')).toBe(true)
+  })
+})
+
+describe('a tag target that is not a commit', () => {
+  it('points a lightweight tag at a blob', async () => {
+    const h = await harness()
+    const blob = git(h.repo, ['rev-parse', 'HEAD:letters.txt']).trim()
+    expect(await h.run(`tag blobtag ${blob}`)).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['cat-file', '-t', 'blobtag'])).toBe('blob\n')
+    expect(git(drained, ['rev-parse', 'blobtag'])).toBe(`${blob}\n`)
+  })
+
+  it('records the type in an annotated tag', async () => {
+    const h = await harness()
+    const blob = git(h.repo, ['rev-parse', 'HEAD:letters.txt']).trim()
+    expect(await h.run(`tag -a annblob -m m ${blob}`)).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['cat-file', '-t', 'annblob'])).toBe('tag\n')
+    expect(git(drained, ['cat-file', '-p', 'annblob']).split('\n')[1]).toBe('type blob')
+  })
+})
+
+describe('git tag -n0', () => {
+  it('prints bare names where -n1 pads them', async () => {
+    const h = await harness()
+    await h.run("tag -a v1 -m 'the message'")
+    expect(await h.run('tag -n0')).toEqual([0, 'v1\n', ''])
+    expect(await h.run('tag -n1')).toEqual([0, 'v1              the message\n', ''])
+  })
+})
+
+describe('git restore --source', () => {
+  it('takes a raw tree id', async () => {
+    const h = await harness()
+    const tree = git(h.repo, ['rev-parse', 'HEAD^{tree}']).trim()
+    await write(h, 'letters.txt', 'edited\n')
+    expect(await h.run(`restore --source=${tree} letters.txt`)).toEqual([0, '', ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('')
+  })
+
+  it('still refuses a source that is no tree at all', async () => {
+    const h = await harness()
+    const [code, , err] = await h.run('restore --source=nosuch letters.txt')
+    expect(code).toBe(128)
+    expect(err).toBe('fatal: could not resolve nosuch\n')
   })
 })

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -15,6 +15,7 @@
 import { execFileSync } from 'node:child_process'
 import { createRequire } from 'node:module'
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -803,5 +804,352 @@ describe('commit identity', () => {
     expect((await h.run('commit -m plain'))[0]).toBe(0)
     const out = await h.drain()
     expect(git(out, ['log', '-1', '--format=%an <%ae>'])).toBe('mirage <mirage@localhost>\n')
+  })
+})
+
+describe('git switch', () => {
+  it('moves to a branch and the real binary agrees on HEAD', async () => {
+    const h = await harness()
+    expect(await h.run('switch topic')).toEqual([0, '', "Switched to branch 'topic'\n"])
+    expect(git(await h.drain(), ['rev-parse', '--abbrev-ref', 'HEAD'])).toBe('topic\n')
+  })
+
+  it('says so when already there', async () => {
+    const h = await harness()
+    expect(await h.run('switch main')).toEqual([0, '', "Already on 'main'\n"])
+  })
+
+  it('creates with -c at a start point', async () => {
+    const h = await harness()
+    expect(await h.run('switch -c older HEAD~1')).toEqual([
+      0,
+      '',
+      "Switched to a new branch 'older'\n",
+    ])
+    const drained = await h.drain()
+    expect(git(drained, ['rev-parse', 'older'])).toBe(git(drained, ['rev-parse', 'main~1']))
+  })
+
+  it('words an unknown name as an invalid reference', async () => {
+    const h = await harness()
+    expect(await h.run('switch nosuch')).toEqual([128, '', 'fatal: invalid reference: nosuch\n'])
+  })
+
+  it('refuses a bare commit without --detach', async () => {
+    const h = await harness()
+    const [code, , err] = await h.run('switch 265ec3a')
+    expect(code).toBe(128)
+    expect(err).toBe(
+      "fatal: a branch is expected, got commit '265ec3a'\n" +
+        'hint: If you want to detach HEAD at the commit, try again with the --detach option.\n',
+    )
+  })
+
+  it('detaches under --detach and names the previous position on the way back', async () => {
+    const h = await harness()
+    expect(await h.run('switch --detach HEAD~1')).toEqual([
+      0,
+      '',
+      'HEAD is now at 225f39c add docs\n',
+    ])
+    expect(await h.run('switch main')).toEqual([
+      0,
+      '',
+      "Previous HEAD position was 225f39c add docs\nSwitched to branch 'main'\n",
+    ])
+  })
+
+  it('refuses a switch that would overwrite an edit', async () => {
+    const h = await harness()
+    await write(h, 'numbers.txt', 'precious\n')
+    const [code, , err] = await h.run('switch topic')
+    expect(code).toBe(1)
+    expect(err.startsWith('error: Your local changes to the following files')).toBe(true)
+  })
+
+  it('needs exactly one operand', async () => {
+    const h = await harness()
+    expect(await h.run('switch')).toEqual([128, '', 'fatal: missing branch or commit argument\n'])
+    expect(await h.run('switch main topic')).toEqual([
+      128,
+      '',
+      'fatal: only one reference expected\n',
+    ])
+  })
+})
+
+describe('git restore', () => {
+  it('puts a worktree edit back', async () => {
+    const h = await harness()
+    await write(h, 'letters.txt', 'edited\n')
+    expect(await h.run('restore letters.txt')).toEqual([0, '', ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('')
+  })
+
+  it('unstages under --staged and keeps the edit', async () => {
+    const h = await harness()
+    await write(h, 'letters.txt', 'edited\n')
+    await h.run('add letters.txt')
+    expect(await h.run('restore --staged letters.txt')).toEqual([0, '', ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe(' M letters.txt\n')
+  })
+
+  it('restores both targets under -SW', async () => {
+    const h = await harness()
+    await write(h, 'letters.txt', 'edited\n')
+    await h.run('add letters.txt')
+    await write(h, 'letters.txt', 'again\n')
+    expect(await h.run('restore -SW letters.txt')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['status', '--porcelain'])).toBe('')
+    expect(readFileSync(join(drained, 'letters.txt'), 'utf8')).toBe('alpha\nbeta\ngamma\ndelta\n')
+  })
+
+  it('restores from --source', async () => {
+    const h = await harness()
+    expect(await h.run('restore --source HEAD~3 numbers.txt')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(readFileSync(join(drained, 'numbers.txt'), 'utf8')).toBe('one\n')
+    expect(git(drained, ['status', '--porcelain'])).toBe(' M numbers.txt\n')
+  })
+
+  it('removes a path the source lacks from both targets', async () => {
+    const h = await harness()
+    expect(await h.run('restore -s HEAD~3 -SW docs/readme.md')).toEqual([0, '', ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('D  docs/readme.md\n')
+  })
+
+  it('words an unknown path as an error, not a fatal', async () => {
+    const h = await harness()
+    expect(await h.run('restore nosuch')).toEqual([
+      1,
+      '',
+      "error: pathspec 'nosuch' did not match any file(s) known to git\n",
+    ])
+  })
+
+  it('needs a pathspec', async () => {
+    const h = await harness()
+    expect(await h.run('restore')).toEqual([
+      128,
+      '',
+      'fatal: you must specify path(s) to restore\n',
+    ])
+  })
+
+  it('refuses a source it cannot resolve', async () => {
+    const h = await harness()
+    expect(await h.run('restore -s nosuch letters.txt')).toEqual([
+      128,
+      '',
+      'fatal: could not resolve nosuch\n',
+    ])
+  })
+})
+
+describe('git rm', () => {
+  it('stages a deletion and removes the file', async () => {
+    const h = await harness()
+    expect(await h.run('rm letters.txt')).toEqual([0, "rm 'letters.txt'\n", ''])
+    const drained = await h.drain()
+    expect(git(drained, ['status', '--porcelain'])).toBe('D  letters.txt\n')
+    expect(existsSync(join(drained, 'letters.txt'))).toBe(false)
+  })
+
+  it('keeps the file under --cached', async () => {
+    const h = await harness()
+    expect(await h.run('rm --cached letters.txt')).toEqual([0, "rm 'letters.txt'\n", ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('D  letters.txt\n?? letters.txt\n')
+  })
+
+  it('refuses a directory without -r and removes it with', async () => {
+    const h = await harness()
+    expect(await h.run('rm docs')).toEqual([
+      128,
+      '',
+      "fatal: not removing 'docs' recursively without -r\n",
+    ])
+    expect(await h.run('rm -r docs')).toEqual([0, "rm 'docs/readme.md'\n", ''])
+    expect(existsSync(join(await h.drain(), 'docs'))).toBe(false)
+  })
+
+  it('refuses a local modification and names it', async () => {
+    const h = await harness()
+    await write(h, 'letters.txt', 'edited\n')
+    expect(await h.run('rm letters.txt')).toEqual([
+      1,
+      '',
+      'error: the following file has local modifications:\n    letters.txt\n' +
+        '(use --cached to keep the file, or -f to force removal)\n',
+    ])
+  })
+
+  it('groups refusals the way git prints them', async () => {
+    const h = await harness()
+    await write(h, 'letters.txt', 'edited\n')
+    await write(h, 'numbers.txt', 'edited\n')
+    await h.run('add numbers.txt')
+    const [code, , err] = await h.run('rm letters.txt numbers.txt')
+    expect(code).toBe(1)
+    expect(err).toBe(
+      'error: the following file has changes staged in the index:\n    numbers.txt\n' +
+        '(use --cached to keep the file, or -f to force removal)\n' +
+        'error: the following file has local modifications:\n    letters.txt\n' +
+        '(use --cached to keep the file, or -f to force removal)\n',
+    )
+  })
+
+  it('removes over an edit under -f', async () => {
+    const h = await harness()
+    await write(h, 'letters.txt', 'edited\n')
+    expect(await h.run('rm -f letters.txt')).toEqual([0, "rm 'letters.txt'\n", ''])
+  })
+
+  it('refuses an unknown path and a missing pathspec', async () => {
+    const h = await harness()
+    expect(await h.run('rm nosuch')).toEqual([
+      128,
+      '',
+      "fatal: pathspec 'nosuch' did not match any files\n",
+    ])
+    expect(await h.run('rm')).toEqual([
+      128,
+      '',
+      'fatal: No pathspec was given. Which files should I remove?\n',
+    ])
+  })
+})
+
+describe('git mv', () => {
+  it('renames and stages the rename', async () => {
+    const h = await harness()
+    expect(await h.run('mv letters.txt moved.txt')).toEqual([0, '', ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('R  letters.txt -> moved.txt\n')
+  })
+
+  it('moves into a directory under the same name', async () => {
+    const h = await harness()
+    expect(await h.run('mv letters.txt docs')).toEqual([0, '', ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe(
+      'R  letters.txt -> docs/letters.txt\n',
+    )
+  })
+
+  it('moves a directory with everything under it', async () => {
+    const h = await harness()
+    await write(h, 'docs/untracked.md', 'u\n')
+    expect(await h.run('mv docs notes')).toEqual([0, '', ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe(
+      'R  docs/readme.md -> notes/readme.md\n?? notes/untracked.md\n',
+    )
+  })
+
+  it('refuses an existing destination unless forced', async () => {
+    const h = await harness()
+    expect(await h.run('mv letters.txt numbers.txt')).toEqual([
+      128,
+      '',
+      'fatal: destination exists, source=letters.txt, destination=numbers.txt\n',
+    ])
+    expect(await h.run('mv -f letters.txt numbers.txt')).toEqual([0, '', ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('D  letters.txt\nM  numbers.txt\n')
+  })
+
+  it('words a bad and an untracked source the way git does', async () => {
+    const h = await harness()
+    expect(await h.run('mv nosuch dest')).toEqual([
+      128,
+      '',
+      'fatal: bad source, source=nosuch, destination=dest\n',
+    ])
+    await write(h, 'u.txt', 'u\n')
+    expect(await h.run('mv u.txt dest')).toEqual([
+      128,
+      '',
+      'fatal: not under version control, source=u.txt, destination=dest\n',
+    ])
+  })
+
+  it('prints usage for one operand and moves nothing on a dry run', async () => {
+    const h = await harness()
+    const [code, , err] = await h.run('mv letters.txt')
+    expect(code).toBe(129)
+    expect(err.startsWith('usage: git mv [-v] [-f] [-n] [-k] <source> <destination>\n')).toBe(true)
+    expect(await h.run('mv -n letters.txt moved.txt')).toEqual([
+      0,
+      "Checking rename of 'letters.txt' to 'moved.txt'\nRenaming letters.txt to moved.txt\n",
+      '',
+    ])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('')
+  })
+})
+
+describe('git tag', () => {
+  it('creates a lightweight tag the real binary resolves', async () => {
+    const h = await harness()
+    expect(await h.run('tag v1.0 HEAD~1')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['cat-file', '-t', 'v1.0'])).toBe('commit\n')
+    expect(git(drained, ['rev-parse', 'v1.0'])).toBe(git(drained, ['rev-parse', 'HEAD~1']))
+  })
+
+  it('writes an annotated tag git can read back', async () => {
+    const h = await harness()
+    expect(await h.run("tag -a v1.1 -m 'first release'")).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['cat-file', '-t', 'v1.1'])).toBe('tag\n')
+    expect(git(drained, ['tag', '-n'])).toBe('v1.1            first release\n')
+    expect(await h.run('tag -n')).toEqual([0, 'v1.1            first release\n', ''])
+  })
+
+  it('stores an empty message as git does', async () => {
+    const h = await harness()
+    expect(await h.run("tag -a v1.2 -m ''")).toEqual([0, '', ''])
+    expect(await h.run('tag -n')).toEqual([0, 'v1.2            \n', ''])
+    expect(git(await h.drain(), ['tag', '-n'])).toBe('v1.2            \n')
+  })
+
+  it('lists in byte order and filters with -l', async () => {
+    const h = await harness()
+    for (const name of ['a10', 'a9', 'B']) await h.run(`tag ${name}`)
+    expect(await h.run('tag')).toEqual([0, 'B\na10\na9\n', ''])
+    expect(await h.run("tag -l 'a*'")).toEqual([0, 'a10\na9\n', ''])
+  })
+
+  it('refuses a duplicate, a bad object and a bad name', async () => {
+    const h = await harness()
+    await h.run('tag v1.0')
+    expect(await h.run('tag v1.0')).toEqual([128, '', "fatal: tag 'v1.0' already exists\n"])
+    expect(await h.run('tag v2 nosuch')).toEqual([
+      128,
+      '',
+      "fatal: Failed to resolve 'nosuch' as a valid ref.\n",
+    ])
+    expect(await h.run("tag 'bad name'")).toEqual([
+      128,
+      '',
+      "fatal: 'bad name' is not a valid tag name.\n",
+    ])
+    expect(await h.run('tag -a v3')).toEqual([
+      128,
+      '',
+      'fatal: no tag message supplied (mirage has no editor to open; pass -m)\n',
+    ])
+  })
+
+  it('deletes, reporting a miss without stopping', async () => {
+    const h = await harness()
+    await h.run('tag v1.0')
+    const [code, out, err] = await h.run('tag -d nosuch v1.0')
+    expect(code).toBe(1)
+    expect(out).toBe("Deleted tag 'v1.0' (was 8ef2542)\n")
+    expect(err).toBe("error: tag 'nosuch' not found.\n")
+    expect(await h.run('tag')).toEqual([0, '', ''])
+  })
+
+  it('moves a tag under -f', async () => {
+    const h = await harness()
+    await h.run('tag v1.0 HEAD~1')
+    expect(await h.run('tag -f v1.0')).toEqual([0, "Updated tag 'v1.0' (was 225f39c)\n", ''])
   })
 })

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -1870,3 +1870,156 @@ describe('a tag target spelled as an object expression', () => {
     ])
   })
 })
+
+/**
+ * What `.git/HEAD` holds, read back through the mount.
+ *
+ * A repository with no commits cannot be drained and handed to the real binary:
+ * `git init` leaves `objects` and `refs` empty, the drain copies files rather
+ * than directories, and git reads the result as no repository at all. So the
+ * unborn cases assert against the mount, which is where the state they are
+ * about lives.
+ */
+async function headOf(h: Harness): Promise<string> {
+  const raw = await readOptional(h.dispatch, '/repo/.git/HEAD')
+  return raw === null ? '' : DEC.decode(raw).trim()
+}
+
+/**
+ * Replace a built fixture with a repository that has no commits.
+ *
+ * Used as a `prepare` callback: the builder's whole job is to produce
+ * history, so an unborn HEAD is reached by discarding what it made rather
+ * than by keeping a second builder in step with the first.
+ */
+function unborn(repo: string): void {
+  for (const name of readdirSync(repo)) rmSync(join(repo, name), { recursive: true, force: true })
+  execFileSync('git', ['init', '-q', '-b', 'main', repo], { stdio: 'ignore' })
+}
+
+describe('git switch on an unborn HEAD', () => {
+  it('creates the branch with no start point', async () => {
+    const h = await harness(unborn)
+    expect(await h.run('switch -c topic')).toEqual([0, '', "Switched to a new branch 'topic'\n"])
+    expect(await headOf(h)).toBe('ref: refs/heads/topic')
+    // No ref and no reflog: a branch with no commit is a name and nothing
+    // else, which is why git can make one here at all.
+    expect(await readOptional(h.dispatch, '/repo/.git/refs/heads/topic')).toBe(null)
+    expect(await readOptional(h.dispatch, '/repo/.git/logs/HEAD')).toBe(null)
+  })
+
+  it('refuses a start point', async () => {
+    const h = await harness(unborn)
+    expect(await h.run('switch -c topic main')).toEqual([
+      128,
+      '',
+      'fatal: invalid reference: main\n',
+    ])
+    expect(await headOf(h)).toBe('ref: refs/heads/main')
+  })
+
+  it('refuses an invalid branch name', async () => {
+    const h = await harness(unborn)
+    const [code, , err] = await h.run('switch -c ../../evil')
+    expect(code).toBe(128)
+    expect(err.startsWith("fatal: '../../evil' is not a valid branch name\n")).toBe(true)
+    expect(await headOf(h)).toBe('ref: refs/heads/main')
+  })
+})
+
+describe('staged work carried across a switch', () => {
+  it('keeps a staged addition staged', async () => {
+    const h = await harness()
+    expect((await h.run('branch other'))[0]).toBe(0)
+    await h.ws.execute('echo new > /repo/added.txt')
+    expect((await h.run('add added.txt'))[0]).toBe(0)
+    expect(await h.run('switch other')).toEqual([
+      0,
+      'A\tadded.txt\n',
+      "Switched to branch 'other'\n",
+    ])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('A  added.txt\n')
+  })
+
+  it('keeps a staged deletion staged', async () => {
+    const h = await harness()
+    expect((await h.run('branch other'))[0]).toBe(0)
+    expect((await h.run('rm --cached letters.txt'))[0]).toBe(0)
+    expect(await h.run('switch other')).toEqual([
+      0,
+      'D\tletters.txt\n',
+      "Switched to branch 'other'\n",
+    ])
+    // The file itself stays where it is, now untracked: git carries the
+    // staged deletion rather than writing the branch's copy back over it.
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('D  letters.txt\n?? letters.txt\n')
+  })
+
+  it('letters a carried worktree edit by where it stands', async () => {
+    const h = await harness()
+    expect((await h.run('branch other'))[0]).toBe(0)
+    await h.ws.execute('echo edited > /repo/letters.txt')
+    expect(await h.run('switch other')).toEqual([
+      0,
+      'M\tletters.txt\n',
+      "Switched to branch 'other'\n",
+    ])
+  })
+})
+
+describe('git restore before the first commit', () => {
+  it('refuses to restore the index', async () => {
+    const h = await harness(unborn)
+    await h.ws.execute('echo hi > /repo/f.txt')
+    expect((await h.run('add f.txt'))[0]).toBe(0)
+    expect(await h.run('restore --staged f.txt')).toEqual([
+      128,
+      '',
+      'fatal: could not resolve HEAD\n',
+    ])
+    // The refusal comes before the index is touched: reading the unborn
+    // HEAD as an empty tree unstaged the path and said nothing.
+    expect(await h.run('status --short')).toEqual([0, 'A  f.txt\n', ''])
+  })
+
+  it('refuses both targets together the same way', async () => {
+    const h = await harness(unborn)
+    await h.ws.execute('echo hi > /repo/f.txt')
+    expect((await h.run('add f.txt'))[0]).toBe(0)
+    expect(await h.run('restore -SW f.txt')).toEqual([128, '', 'fatal: could not resolve HEAD\n'])
+  })
+
+  it('still restores the working tree from the index', async () => {
+    const h = await harness(unborn)
+    await h.ws.execute('echo hi > /repo/f.txt')
+    expect((await h.run('add f.txt'))[0]).toBe(0)
+    await h.ws.execute('echo edited > /repo/f.txt')
+    expect(await h.run('restore f.txt')).toEqual([0, '', ''])
+    expect(DEC.decode((await h.ws.execute('cat /repo/f.txt')).stdout)).toBe('hi\n')
+  })
+})
+
+describe('a peel naming the tag type', () => {
+  it('stops at the tag object itself', async () => {
+    const h = await harness()
+    expect((await h.run('tag -a v1 -m annotated'))[0]).toBe(0)
+    expect(await h.run('tag nested v1^{tag}')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['cat-file', '-t', 'nested']).trim()).toBe('tag')
+    expect(git(drained, ['rev-parse', 'nested'])).toBe(git(drained, ['rev-parse', 'v1']))
+  })
+
+  it('still unwraps the tag for a bare peel', async () => {
+    const h = await harness()
+    expect((await h.run('tag -a v1 -m annotated'))[0]).toBe(0)
+    expect((await h.run('tag inner v1^{}'))[0]).toBe(0)
+    const drained = await h.drain()
+    expect(git(drained, ['cat-file', '-t', 'inner']).trim()).toBe('commit')
+  })
+
+  it('refuses a lightweight tag, which has no tag object to stop at', async () => {
+    const h = await harness()
+    expect((await h.run('tag light'))[0]).toBe(0)
+    expect((await h.run('tag nested light^{tag}'))[0]).toBe(128)
+  })
+})

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -1396,6 +1396,21 @@ describe('a path the index left unmerged', () => {
     })
     expect(await h.run('mv -k letters.txt moved.txt')).toEqual([0, '', ''])
   })
+
+  it('loses its stages when -f moves another file onto it', async () => {
+    // Only `-f` reaches an occupied destination, and git's answer there is one
+    // stage-0 entry holding the source: `ls-files -u` is empty afterwards. This
+    // side already answered so, because a stage-0 insert into isomorphic-git's
+    // index drops the stages with it; python's own writer lays them back over
+    // the entry, so the two disagreed until it dropped them too.
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'numbers.txt')
+    })
+    expect(await h.run('mv -f letters.txt numbers.txt')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['ls-files', '-u'])).toBe('')
+    expect(git(drained, ['status', '--porcelain'])).toBe('D  letters.txt\nM  numbers.txt\n')
+  })
 })
 
 describe('a directory holding a symlink', () => {
@@ -1681,6 +1696,77 @@ describe('a working-tree removal that would take a mount with it', () => {
     expect((await h.run('commit -m inside'))[0]).toBe(0)
     expect((await h.run('rm slot/data/x.md'))[0]).toBe(0)
     expect(await readNames(h.dispatch, '/repo/slot/data')).toEqual([])
+  })
+})
+
+describe('a mount met halfway through a worktree pass', () => {
+  it('stops the switch before the first path is written', async () => {
+    // The refusal lives in the removal that meets the mount, which the write
+    // loop reaches one entry at a time. A branch that changes an earlier path
+    // too would have had that path written already, so the fatal left the
+    // working tree on the target's content with HEAD and the index still on
+    // the branch being left.
+    const h = await harness(undefined, '/repo/slot/data')
+    await h.ws.dispatch('rmdir', '/repo/slot')
+    await write(h, '.gitignore', 'ignored.txt\n')
+    expect((await h.run('add .gitignore'))[0]).toBe(0)
+    expect((await h.run('commit -m ignores'))[0]).toBe(0)
+    expect((await h.run('checkout -b slotted'))[0]).toBe(0)
+    await write(h, 'numbers.txt', 'edited\n')
+    await h.ws.execute("printf 'v2\\n' > /repo/slot")
+    expect((await h.run('add numbers.txt slot'))[0]).toBe(0)
+    expect((await h.run('commit -m two'))[0]).toBe(0)
+    expect((await h.run('checkout main'))[0]).toBe(0)
+    // Only ignored content, so no collision list names the directory and the
+    // write loop is what would meet the mount.
+    await h.ws.dispatch('mkdir', '/repo/slot')
+    await h.ws.execute("printf 'x\\n' > /repo/slot/ignored.txt")
+    const before = await readOptional(h.dispatch, '/repo/numbers.txt')
+    const [code, , err] = await h.run('checkout slotted')
+    expect([code, err]).toEqual([
+      128,
+      "fatal: cannot remove '/repo/slot': '/repo/slot/data' is a mount root\n",
+    ])
+    // Nothing moved: the earlier path still holds what it held.
+    expect(await readOptional(h.dispatch, '/repo/numbers.txt')).toEqual(before)
+    expect(await h.run('status --porcelain')).toEqual([0, '', ''])
+  })
+
+  it('leaves the index alone when -SW cannot finish', async () => {
+    // -SW stages first and restores after, so a refusal in the second pass
+    // used to leave the index moved and the working tree exactly as it was: a
+    // fatal that changed something, which this verb has no wording for.
+    const h = await harness(undefined, '/repo/slot/data')
+    await write(h, 'slot/data/precious.md', 'precious\n')
+    await h.ws.dispatch('rmdir', '/repo/slot')
+    await h.ws.execute("printf 'i am a file\\n' > /repo/slot")
+    expect((await h.run('add slot'))[0]).toBe(0)
+    expect((await h.run('commit -m slotted'))[0]).toBe(0)
+    await h.ws.dispatch('unlink', '/repo/slot')
+    await h.ws.dispatch('mkdir', '/repo/slot')
+    expect((await h.run('rm --cached slot'))[0]).toBe(0)
+    const before = (await h.run('status --porcelain'))[1]
+    expect(before).toContain('D  slot\n')
+    const [code, , err] = await h.run('restore -SW slot')
+    expect([code, err]).toEqual([
+      128,
+      "fatal: cannot remove '/repo/slot': '/repo/slot/data' is a mount root\n",
+    ])
+    expect((await h.run('status --porcelain'))[1]).toBe(before)
+    expect(await readOptional(h.dispatch, '/repo/slot/data/precious.md')).not.toBeNull()
+  })
+
+  it('lets --staged through, since it never touches the working tree', async () => {
+    const h = await harness(undefined, '/repo/slot/data')
+    await h.ws.dispatch('rmdir', '/repo/slot')
+    await h.ws.execute("printf 'i am a file\\n' > /repo/slot")
+    expect((await h.run('add slot'))[0]).toBe(0)
+    expect((await h.run('commit -m slotted'))[0]).toBe(0)
+    await h.ws.dispatch('unlink', '/repo/slot')
+    await h.ws.dispatch('mkdir', '/repo/slot')
+    expect((await h.run('rm --cached slot'))[0]).toBe(0)
+    expect(await h.run('restore --staged slot')).toEqual([0, '', ''])
+    expect((await h.run('status --porcelain'))[1]).toContain(' D slot\n')
   })
 })
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -1604,6 +1604,106 @@ describe('a rename that would leave a mount behind', () => {
     expect(await h.run('mv -k docs notes')).toEqual([0, '', ''])
     expect(await h.run('status --porcelain')).toEqual([0, '', ''])
   })
+
+  it('refuses a file moving into another mount', async () => {
+    // The source is an ordinary tracked file, so neither "is a mount root"
+    // nor "holds one" catches it. The rename op binds to the backend serving
+    // the source, so the write would land in the repository's own mount at a
+    // path the inner one serves: the file ends up hidden behind that mount
+    // while the index names the new path.
+    const h = await harness(undefined, '/repo/inner')
+    await write(h, 'one.md', 'x\n')
+    await h.run('add one.md')
+    const [code, , err] = await h.run('mv one.md inner/one.md')
+    expect(code).toBe(128)
+    expect(err).toBe("fatal: renaming 'one.md' failed: Device or resource busy\n")
+  })
+
+  it('refuses a file moving out of a nested mount', async () => {
+    const h = await harness(undefined, '/repo/inner')
+    await write(h, 'inner/one.md', 'x\n')
+    await h.run('add inner/one.md')
+    const [code, , err] = await h.run('mv inner/one.md one.md')
+    expect(code).toBe(128)
+    expect(err).toBe("fatal: renaming 'inner/one.md' failed: Device or resource busy\n")
+  })
+
+  it('still moves inside one mount', async () => {
+    // The destination check compares the two ends, so an ordinary move that
+    // never leaves the repository's own mount is untouched by it.
+    const h = await harness(undefined, '/repo/inner')
+    await write(h, 'one.md', 'x\n')
+    await h.run('add one.md')
+    expect(await h.run('mv one.md docs/one.md')).toEqual([0, '', ''])
+  })
+})
+
+describe('a restore source spelled as a tree expression', () => {
+  it('takes a tree peel', async () => {
+    // git's own help says --source <tree-ish>, and a peel is the ordinary way
+    // to spell one. Probed on git 2.50.1: exit 0.
+    const h = await harness()
+    await write(h, 'letters.txt', 'edited\n')
+    expect(await h.run('restore --source=HEAD^{tree} letters.txt')).toEqual([0, '', ''])
+  })
+
+  it('takes a tag peel', async () => {
+    const h = await harness((repo) => {
+      git(repo, ['tag', 'v1'])
+    })
+    await write(h, 'letters.txt', 'edited\n')
+    expect(await h.run('restore --source=v1^{tree} letters.txt')).toEqual([0, '', ''])
+  })
+
+  it('takes a subtree named at a path', async () => {
+    const h = await harness((repo) => {
+      mkdirSync(join(repo, 'sub'))
+      writeFileSync(join(repo, 'sub', 'letters.txt'), 'nested\n')
+      git(repo, ['add', 'sub'])
+      git(repo, ['commit', '-m', 'nested'])
+    })
+    expect(await h.run('restore --source=HEAD:sub letters.txt')).toEqual([0, '', ''])
+    expect(DEC.decode((await readOptional(h.dispatch, '/repo/letters.txt')) ?? undefined)).toBe(
+      'nested\n',
+    )
+  })
+
+  it('names the object by its id when it is no tree', async () => {
+    // git reports the object it reached, not the spelling: the name resolved
+    // fine and what it found was the problem.
+    const h = await harness()
+    const [code, , err] = await h.run('restore --source=HEAD:letters.txt letters.txt')
+    expect(code).toBe(128)
+    expect(err).toMatch(/^fatal: unable to read tree \([0-9a-f]{40}\)\n$/)
+  })
+
+  it('names the spelling when the peel resolves to nothing', async () => {
+    const h = await harness()
+    const [code, , err] = await h.run('restore --source=nosuch^{tree} letters.txt')
+    expect(code).toBe(128)
+    expect(err).toBe('fatal: could not resolve nosuch^{tree}\n')
+  })
+})
+
+describe('a restore writing a file over an occupied directory', () => {
+  it('replaces the directory, untracked child and all', async () => {
+    // The source keeps letters.txt as a file, the index keeps
+    // letters.txt/child, and an untracked letters.txt/keep holds the
+    // directory open. git replaces the whole directory here and exits 0
+    // (probed on git 2.50.1); the write would otherwise fail with the index
+    // already changed.
+    const h = await harness()
+    const tree = (await h.run('rev-parse HEAD^{tree}'))[1].trim()
+    await h.run('rm --cached letters.txt')
+    await h.ws.dispatch('unlink', '/repo/letters.txt')
+    await write(h, 'letters.txt/child', 'inner\n')
+    await h.run('add letters.txt/child')
+    await write(h, 'letters.txt/keep', 'untracked\n')
+    expect(await h.run(`restore --source=${tree} -SW letters.txt`)).toEqual([0, '', ''])
+    expect(DEC.decode((await readOptional(h.dispatch, '/repo/letters.txt')) ?? undefined)).toBe(
+      'alpha\nbeta\ngamma\ndelta\n',
+    )
+  })
 })
 
 describe('a switch while the index is unmerged', () => {

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -36,7 +36,8 @@ import { createShellParser, type ShellParser } from '../../../../shell/parse/ind
 import { MountMode } from '../../../../types.ts'
 import { Workspace } from '../../../../workspace/workspace/workspace.ts'
 import { GIT } from './index.ts'
-import { ensureDir, readNames, readOptional } from './io.ts'
+import { blockingRef } from './refs.ts'
+import { ensureDir, readNames, readOptional, removeTree } from './io.ts'
 import type { Dispatch } from './types.ts'
 
 const BUILDER = fileURLToPath(
@@ -2012,6 +2013,220 @@ describe('git restore before the first commit', () => {
     await h.ws.execute('echo edited > /repo/f.txt')
     expect(await h.run('restore f.txt')).toEqual([0, '', ''])
     expect(DEC.decode((await h.ws.execute('cat /repo/f.txt')).stdout)).toBe('hi\n')
+  })
+})
+
+describe('blockingRef', () => {
+  it('finds a ref above the new one, at any depth', () => {
+    const known = new Set(['refs/tags/foo', 'refs/heads/main'])
+    expect(blockingRef(known, 'refs/tags/foo/bar')).toBe('refs/tags/foo')
+    expect(blockingRef(known, 'refs/tags/foo/bar/baz')).toBe('refs/tags/foo')
+  })
+
+  it('finds a ref below the new one, in an ordered walk', () => {
+    // git names one ref, so the answer must not depend on iteration order.
+    const known = new Set(['refs/tags/foo/c', 'refs/tags/foo/a'])
+    expect(blockingRef(known, 'refs/tags/foo')).toBe('refs/tags/foo/a')
+  })
+
+  it('leaves a ref with no collision alone', () => {
+    const known = new Set(['refs/tags/foo', 'refs/heads/main'])
+    expect(blockingRef(known, 'refs/tags/other')).toBeNull()
+    // A prefix that is not a whole path segment is not a collision, and the
+    // ref itself existing is a different refusal.
+    expect(blockingRef(known, 'refs/tags/foobar')).toBeNull()
+    expect(blockingRef(known, 'refs/tags/foo')).toBeNull()
+  })
+})
+
+describe('removeTree meeting a link', () => {
+  /** A dispatcher that lists one link and records every op it is asked for. */
+  function recorder(): { calls: [string, string][]; dispatch: Dispatch } {
+    const calls: [string, string][] = []
+    const dispatch = ((op: string, path: unknown) => {
+      const where = typeof path === 'string' ? path : (path as { virtual: string }).virtual
+      calls.push([op, where])
+      if (op === 'readdir') {
+        if (where === '/repo/slot') return Promise.resolve([['/repo/slot/link'], new IOResult()])
+        // readdir answers through the link the way the real one does: the name
+        // plane owns links, so the data plane resolves and lists the target.
+        if (where === '/repo/slot/link') {
+          return Promise.resolve([['/repo/outside/keep.txt'], new IOResult()])
+        }
+        return Promise.resolve([[], new IOResult()])
+      }
+      if (op === 'rmdir' && where !== '/repo/slot') {
+        return Promise.reject(Object.assign(new Error(where), { code: 'ENOTDIR' }))
+      }
+      return Promise.resolve([null, new IOResult()])
+    }) as unknown as Dispatch
+    return { calls, dispatch }
+  }
+
+  const links = {
+    statAt: (path: string) => (path === '/repo/slot/link' ? { name: 'link' } : null),
+  } as never
+
+  it('unlinks it without descending', async () => {
+    const { calls, dispatch } = recorder()
+    await removeTree(dispatch, '/repo/slot', links)
+    expect(calls).toContainEqual(['unlink', '/repo/slot/link'])
+    // The whole point: readdir dereferences, so listing the link at all is the
+    // walk stepping outside the directory being replaced.
+    expect(calls).not.toContainEqual(['readdir', '/repo/slot/link'])
+    expect(calls.every(([, where]) => !where.startsWith('/repo/outside'))).toBe(true)
+  })
+
+  it('has nothing to ask without a namespace', async () => {
+    const { calls, dispatch } = recorder()
+    await removeTree(dispatch, '/repo/slot', null)
+    expect(calls).toContainEqual(['readdir', '/repo/slot/link'])
+  })
+})
+
+describe('a staged path inside a directory the branch replaces', () => {
+  it('is refused, and the staged blob stays the only copy', async () => {
+    const h = await harness()
+    expect((await h.run('checkout -b filebranch'))[0]).toBe(0)
+    await write(h, 'slot', 'FILE\n')
+    expect((await h.run('add slot'))[0]).toBe(0)
+    expect((await h.run('commit -m file'))[0]).toBe(0)
+    expect((await h.run('checkout main'))[0]).toBe(0)
+    await h.ws.execute('rm /repo/slot')
+    await write(h, 'slot/child', 'c\n')
+    expect((await h.run('add slot/child'))[0]).toBe(0)
+    const [code, , err] = await h.run('checkout filebranch')
+    expect(code).toBe(1)
+    expect(err).toContain('slot/child')
+    expect(DEC.decode((await h.ws.execute('cat /repo/slot/child')).stdout)).toBe('c\n')
+  })
+})
+
+describe('a peel naming the object type', () => {
+  it('keeps whatever type it finds, unwrapping nothing', async () => {
+    const h = await harness()
+    expect((await h.run('tag -a v1 -m annotated'))[0]).toBe(0)
+    // `^{object}` is an existence check, not a type: every object reports a
+    // concrete type name, so comparing one against the word would refuse every
+    // expression that spells it.
+    expect(await h.run('tag copy HEAD^{object}')).toEqual([0, '', ''])
+    expect(await h.run('tag wrapped v1^{object}')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['cat-file', '-t', 'copy']).trim()).toBe('commit')
+    // The one thing that separates it from `^{}`: the named object comes back,
+    // so a tag stays a tag rather than being unwrapped.
+    expect(git(drained, ['cat-file', '-t', 'wrapped']).trim()).toBe('tag')
+    expect(git(drained, ['rev-parse', 'wrapped'])).toBe(git(drained, ['rev-parse', 'v1']))
+  })
+
+  it('is still a commit-ish where a commit is what is wanted', async () => {
+    const h = await harness()
+    expect((await h.run('tag -a v1 -m annotated'))[0]).toBe(0)
+    expect(await h.run('branch nb v1^{object}')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['rev-parse', 'nb'])).toBe(git(drained, ['rev-parse', 'HEAD']))
+  })
+})
+
+describe('a ref whose path another ref already holds', () => {
+  it('refuses a tag below one that exists', async () => {
+    const h = await harness()
+    expect((await h.run('tag foo'))[0]).toBe(0)
+    expect(await h.run('tag foo/bar')).toEqual([
+      128,
+      '',
+      "fatal: cannot lock ref 'refs/tags/foo/bar': 'refs/tags/foo' exists; " +
+        "cannot create 'refs/tags/foo/bar'\n",
+    ])
+  })
+
+  it('refuses a tag above one that exists', async () => {
+    const h = await harness()
+    expect((await h.run('tag baz/qux'))[0]).toBe(0)
+    expect(await h.run('tag baz')).toEqual([
+      128,
+      '',
+      "fatal: cannot lock ref 'refs/tags/baz': 'refs/tags/baz/qux' exists; " +
+        "cannot create 'refs/tags/baz'\n",
+    ])
+  })
+
+  it('is not opened by -f, since the obstacle is the path', async () => {
+    const h = await harness()
+    expect((await h.run('tag foo'))[0]).toBe(0)
+    expect((await h.run('tag -f foo/bar'))[0]).toBe(128)
+  })
+
+  it('refuses a branch below one that exists', async () => {
+    const h = await harness()
+    expect((await h.run('branch bb'))[0]).toBe(0)
+    expect(await h.run('branch bb/cc')).toEqual([
+      128,
+      '',
+      "fatal: cannot lock ref 'refs/heads/bb/cc': 'refs/heads/bb' exists; " +
+        "cannot create 'refs/heads/bb/cc'\n",
+    ])
+  })
+
+  it('refuses switch -c before the working tree moves', async () => {
+    const h = await harness()
+    expect((await h.run('branch bb'))[0]).toBe(0)
+    expect((await h.run('switch -c bb/cc'))[0]).toBe(128)
+    expect(git(await h.drain(), ['rev-parse', '--abbrev-ref', 'HEAD']).trim()).toBe('main')
+  })
+
+  it('reports a bad start point first, since the lock is taken last', async () => {
+    const h = await harness()
+    expect((await h.run('branch bb'))[0]).toBe(0)
+    const [, , err] = await h.run('branch bb/cc nosuchrev')
+    expect(err).not.toContain('cannot lock ref')
+  })
+})
+
+describe('mv given a directory and something inside it', () => {
+  async function withOverlap(): Promise<Harness> {
+    const h = await harness()
+    await write(h, 'dir/file', 'z\n')
+    await write(h, 'dest/keep.txt', 'k\n')
+    await h.run('add dir dest')
+    await h.run('commit -m dir')
+    return h
+  }
+
+  it('is refused before anything moves', async () => {
+    const h = await withOverlap()
+    expect(await h.run('mv dir dir/file dest')).toEqual([
+      128,
+      '',
+      "fatal: cannot move both 'dir/file' and its parent directory 'dir'\n",
+    ])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('')
+  })
+
+  it('names the child first whatever the order', async () => {
+    const h = await withOverlap()
+    const [, , err] = await h.run('mv dir/file dir dest')
+    expect(err).toBe("fatal: cannot move both 'dir/file' and its parent directory 'dir'\n")
+  })
+
+  it('is not skipped by -k', async () => {
+    const h = await withOverlap()
+    expect((await h.run('mv -k dir dir/file dest'))[0]).toBe(128)
+  })
+
+  it("lets a source's own fault outrank it", async () => {
+    const h = await withOverlap()
+    const [, , err] = await h.run('mv dir dir/file nosuch dest')
+    expect(err).toBe('fatal: bad source, source=nosuch, destination=dest/nosuch\n')
+  })
+
+  it('is not reached for a source -k already took out', async () => {
+    const h = await withOverlap()
+    await write(h, 'dir/other', 'o\n')
+    expect(await h.run('mv -k dir dir/other dest')).toEqual([0, '', ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe(
+      'R  dir/file -> dest/dir/file\n?? dest/dir/other\n',
+    )
   })
 })
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -37,7 +37,15 @@ import { MountMode } from '../../../../types.ts'
 import { Workspace } from '../../../../workspace/workspace/workspace.ts'
 import { GIT } from './index.ts'
 import { blockingRef } from './refs.ts'
-import { ensureDir, readNames, readOptional, removeTree } from './io.ts'
+import {
+  ensureDir,
+  readNames,
+  readOptional,
+  refuseMount,
+  removeEmptyParents,
+  removeTree,
+} from './io.ts'
+import type { MountView } from '../../../../ops/types.ts'
 import type { Dispatch } from './types.ts'
 
 const BUILDER = fileURLToPath(
@@ -1639,6 +1647,111 @@ describe('a rename that would leave a mount behind', () => {
   })
 })
 
+describe('a working-tree removal that would take a mount with it', () => {
+  it('refuses to replace a directory holding one', async () => {
+    // The tree records a file where the working tree has a directory, so
+    // restoring it means removing the directory whole. A nested mount inside
+    // is another backend entirely: readdir merges it into the listing, so the
+    // walk would empty a store no branch recorded and then take its root.
+    const h = await harness(undefined, '/repo/slot/data')
+    await write(h, 'slot/data/precious.md', 'precious\n')
+    // The harness creates the mount's parent so `ensureDir` cannot stop at
+    // it; dropped again here, because what is committed at this name is a
+    // file and only the parent backend can hold it.
+    await h.ws.dispatch('rmdir', '/repo/slot')
+    await h.ws.execute("printf 'i am a file\n' > /repo/slot")
+    expect((await h.run('add slot'))[0]).toBe(0)
+    expect((await h.run('commit -m slotted'))[0]).toBe(0)
+    await h.ws.dispatch('unlink', '/repo/slot')
+    await h.ws.dispatch('mkdir', '/repo/slot')
+    const [code, , err] = await h.run('restore slot')
+    expect([code, err]).toEqual([
+      128,
+      "fatal: cannot remove '/repo/slot': '/repo/slot/data' is a mount root\n",
+    ])
+    expect(await readOptional(h.dispatch, '/repo/slot/data/precious.md')).not.toBeNull()
+  })
+
+  it('leaves a mount root alone when pruning empty parents', async () => {
+    // The other removal path: git drops a directory the moment its last
+    // tracked file leaves it, and the mount root is not git's to drop.
+    const h = await harness(undefined, '/repo/slot/data')
+    await write(h, 'slot/data/x.md', 'x\n')
+    expect((await h.run('add slot/data/x.md'))[0]).toBe(0)
+    expect((await h.run('commit -m inside'))[0]).toBe(0)
+    expect((await h.run('rm slot/data/x.md'))[0]).toBe(0)
+    expect(await readNames(h.dispatch, '/repo/slot/data')).toEqual([])
+  })
+})
+
+describe('git rm meeting a link above the tracked path', () => {
+  it('refuses it as a local modification', async () => {
+    // The walk lstats, so the link hides the tracked file and the path reads
+    // as deleted, which is what git's own status says too. git rm does not
+    // read it that way: its lstat resolves the leading component and finds
+    // another file entirely.
+    const h = await harness()
+    await h.ws.execute('mkdir /repo/slot')
+    await write(h, 'slot/child', 'tracked\n')
+    await h.ws.execute('mkdir /repo/away')
+    await h.ws.execute("printf 'other\n' > /repo/away/child")
+    expect((await h.run('add slot/child'))[0]).toBe(0)
+    expect((await h.run('commit -m slotted'))[0]).toBe(0)
+    await h.ws.execute('rm -rf /repo/slot')
+    await h.ws.execute('ln -s /repo/away /repo/slot')
+    expect((await h.run('status --short'))[1]).toContain(' D slot/child\n')
+    const [code, , err] = await h.run('rm slot/child')
+    expect([code, err]).toEqual([
+      1,
+      'error: the following file has local modifications:\n' +
+        '    slot/child\n' +
+        '(use --cached to keep the file, or -f to force removal)\n',
+    ])
+    expect(await readOptional(h.dispatch, '/repo/away/child')).not.toBeNull()
+  })
+
+  it('removes it when the link points past it', async () => {
+    // Nothing at the other end, so git has nothing to lose and stages the
+    // deletion.
+    const h = await harness()
+    await h.ws.execute('mkdir /repo/slot')
+    await write(h, 'slot/child', 'tracked\n')
+    await h.ws.execute('mkdir /repo/away')
+    expect((await h.run('add slot/child'))[0]).toBe(0)
+    expect((await h.run('commit -m slotted'))[0]).toBe(0)
+    await h.ws.execute('rm -rf /repo/slot')
+    await h.ws.execute('ln -s /repo/away /repo/slot')
+    expect(await h.run('rm slot/child')).toEqual([0, "rm 'slot/child'\n", ''])
+  })
+})
+
+describe('git tag -n with a count git reserves', () => {
+  it('refuses anything below the sentinel', async () => {
+    const h = await harness()
+    await h.run('tag v1')
+    expect(await h.run('tag -n-2')).toEqual([
+      128,
+      '',
+      'fatal: positive value expected contents:lines=-2\n',
+    ])
+    // The format is parsed before any ref is read, so a pattern matching
+    // nothing does not get the line off the hook.
+    expect((await h.run('tag -n-5 nosuch'))[0]).toBe(128)
+    // And the list-mode refusal still outranks it.
+    expect((await h.run('tag -d -n-2 v1'))[2]).toBe(
+      "fatal: the '-n' option is only allowed in list mode\n",
+    )
+  })
+
+  it('reads -n-1 as no -n at all', async () => {
+    const h = await harness()
+    await h.run('tag v1')
+    expect((await h.run('tag -d -n-1 v1'))[0]).toBe(0)
+    expect(await h.run('tag -n-1 -a later -m m')).toEqual([0, '', ''])
+    expect(await h.run('tag -n-1')).toEqual([0, 'later\n', ''])
+  })
+})
+
 describe('a restore source spelled as a tree expression', () => {
   it('takes a tree peel', async () => {
     // git's own help says --source <tree-ish>, and a peel is the ordinary way
@@ -2069,7 +2182,7 @@ describe('removeTree meeting a link', () => {
 
   it('unlinks it without descending', async () => {
     const { calls, dispatch } = recorder()
-    await removeTree(dispatch, '/repo/slot', links)
+    await removeTree(dispatch, '/repo/slot', links, null)
     expect(calls).toContainEqual(['unlink', '/repo/slot/link'])
     // The whole point: readdir dereferences, so listing the link at all is the
     // walk stepping outside the directory being replaced.
@@ -2079,8 +2192,100 @@ describe('removeTree meeting a link', () => {
 
   it('has nothing to ask without a namespace', async () => {
     const { calls, dispatch } = recorder()
-    await removeTree(dispatch, '/repo/slot', null)
+    await removeTree(dispatch, '/repo/slot', null, null)
     expect(calls).toContainEqual(['readdir', '/repo/slot/link'])
+  })
+})
+
+describe('a removal meeting a mount boundary', () => {
+  /** A mount view over a fixed list of roots. */
+  function mountsOver(roots: string[], hidden: string[] = []): MountView {
+    const unseen = new Set(hidden)
+    return {
+      descendants: (path: string) => roots.filter((root) => root.startsWith(`${path}/`)),
+      visibleDescendants: (path: string) =>
+        roots.filter((root) => root.startsWith(`${path}/`) && !unseen.has(root)),
+      isRoot: (path: string) => roots.includes(path),
+      rootOf: () => null,
+    } as unknown as MountView
+  }
+
+  it('refuses the mount root itself', () => {
+    expect(() => {
+      refuseMount(mountsOver(['/repo/slot']), '/repo/slot')
+    }).toThrow("cannot remove '/repo/slot': it is a mount root")
+  })
+
+  it('names a nested mount, in order', () => {
+    expect(() => {
+      refuseMount(mountsOver(['/repo/slot/z', '/repo/slot/a']), '/repo/slot')
+    }).toThrow("cannot remove '/repo/slot': '/repo/slot/a' is a mount root")
+  })
+
+  it('refuses a hidden mount without naming it', () => {
+    // Avoiding a boundary and naming one are two different questions, and a
+    // hidden mount's name is what the hide exists to withhold.
+    expect(() => {
+      refuseMount(mountsOver(['/repo/slot/data'], ['/repo/slot/data']), '/repo/slot')
+    }).toThrow("cannot remove '/repo/slot': it holds a mount root")
+  })
+
+  it('lets an unobstructed path through', () => {
+    expect(() => {
+      refuseMount(mountsOver(['/other/mount']), '/repo/slot')
+    }).not.toThrow()
+    expect(() => {
+      refuseMount(null, '/repo/slot')
+    }).not.toThrow()
+  })
+
+  it('refuses before the walk deletes anything', async () => {
+    const { calls, dispatch } = (() => {
+      const seen: [string, string][] = []
+      const fn = ((op: string, path: unknown) => {
+        const where = typeof path === 'string' ? path : (path as { virtual: string }).virtual
+        seen.push([op, where])
+        if (op === 'readdir') return Promise.resolve([[], new IOResult()])
+        return Promise.resolve([null, new IOResult()])
+      }) as unknown as Dispatch
+      return { calls: seen, dispatch: fn }
+    })()
+    await expect(
+      removeTree(dispatch, '/repo/slot', null, mountsOver(['/repo/slot/data'])),
+    ).rejects.toThrow('is a mount root')
+    // Nothing at all: the refusal is the first thing the walk does, so the
+    // directory is still whole when the caller hears about it.
+    expect(calls).toEqual([])
+  })
+
+  it('stops pruning empty parents at a mount root', async () => {
+    const calls: [string, string][] = []
+    const dispatch = ((op: string, path: unknown) => {
+      const where = typeof path === 'string' ? path : (path as { virtual: string }).virtual
+      calls.push([op, where])
+      if (op === 'readdir') return Promise.resolve([[], new IOResult()])
+      return Promise.resolve([null, new IOResult()])
+    }) as unknown as Dispatch
+    await removeEmptyParents(
+      dispatch,
+      '/repo/slot/data/x.txt',
+      '/repo',
+      mountsOver(['/repo/slot/data']),
+    )
+    expect(calls).not.toContainEqual(['rmdir', '/repo/slot/data'])
+    expect(calls).not.toContainEqual(['rmdir', '/repo/slot'])
+  })
+
+  it('still prunes an ordinary directory', async () => {
+    const calls: [string, string][] = []
+    const dispatch = ((op: string, path: unknown) => {
+      const where = typeof path === 'string' ? path : (path as { virtual: string }).virtual
+      calls.push([op, where])
+      if (op === 'readdir') return Promise.resolve([[], new IOResult()])
+      return Promise.resolve([null, new IOResult()])
+    }) as unknown as Dispatch
+    await removeEmptyParents(dispatch, '/repo/docs/x.txt', '/repo', mountsOver([]))
+    expect(calls).toContainEqual(['rmdir', '/repo/docs'])
   })
 })
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -1806,6 +1806,57 @@ describe('a gitlink in the tree', () => {
     expect(await readOptional(h.dispatch, '/repo/sub/keep.md')).not.toBeNull()
   })
 
+  it('rmdirs an empty one the source drops', async () => {
+    // What stands at a 160000 entry is a directory, so removing the entry is
+    // an rmdir: the unlink died on it with the index already written.
+    const h = await harness((repo) => {
+      gitlinkIndex(repo, 'sub')
+    })
+    await h.ws.dispatch('unlink', '/repo/sub/keep.md')
+    expect(await h.run('restore --source=HEAD~1 --staged --worktree sub')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(existsSync(join(drained, 'sub'))).toBe(false)
+  })
+
+  it('warns and keeps one that is not empty', async () => {
+    // git warns and goes on rather than failing: the checkout succeeded, and
+    // what is left is a directory it will not empty for anyone.
+    const h = await harness((repo) => {
+      gitlinkIndex(repo, 'sub')
+    })
+    expect(await h.run('restore --source=HEAD~1 --staged --worktree sub')).toEqual([
+      0,
+      '',
+      "warning: unable to rmdir 'sub': Directory not empty\n",
+    ])
+    expect(await readOptional(h.dispatch, '/repo/sub/keep.md')).not.toBeNull()
+  })
+
+  it('rmdirs one a branch switch drops', async () => {
+    const h = await harness((repo) => {
+      git(repo, ['branch', 'plain'])
+      gitlinkIndex(repo, 'sub')
+    })
+    await h.ws.dispatch('unlink', '/repo/sub/keep.md')
+    const [code, , err] = await h.run('checkout plain')
+    expect([code, err]).toEqual([0, "Switched to branch 'plain'\n"])
+    const drained = await h.drain()
+    expect(existsSync(join(drained, 'sub'))).toBe(false)
+  })
+
+  it('warns on a branch switch that cannot empty it', async () => {
+    const h = await harness((repo) => {
+      git(repo, ['branch', 'plain'])
+      gitlinkIndex(repo, 'sub')
+    })
+    const [code, , err] = await h.run('checkout plain')
+    expect([code, err]).toEqual([
+      0,
+      "warning: unable to rmdir 'sub': Directory not empty\nSwitched to branch 'plain'\n",
+    ])
+    expect(await readOptional(h.dispatch, '/repo/sub/keep.md')).not.toBeNull()
+  })
+
   it('still refuses an untracked file where it lands', async () => {
     // The other half of git's rule: the directory cannot be made without
     // deleting the file, so this one is named and refused.
@@ -1816,6 +1867,33 @@ describe('a gitlink in the tree', () => {
     const [code, , err] = await h.run('checkout linked')
     expect(code).toBe(1)
     expect(err).toContain('would be overwritten by checkout:\n\tsub\n')
+  })
+})
+
+describe('a peel in the middle of a revision', () => {
+  it('walks on from the commit it peeled to', async () => {
+    // A peel used to be read only at the end of a revision, so every chain
+    // that went on after one was refused although git takes it.
+    const h = await harness()
+    expect(await h.run('tag chained HEAD^{commit}~1')).toEqual([0, '', ''])
+    expect(await h.run('tag plain HEAD~1')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['rev-parse', 'chained'])).toBe(git(drained, ['rev-parse', 'plain']))
+  })
+
+  it('peels what a step arrived at', async () => {
+    const h = await harness()
+    expect(await h.run('tag treeish HEAD~1^{commit}')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['rev-parse', 'treeish'])).toBe(git(drained, ['rev-parse', 'HEAD~1']))
+  })
+
+  it('refuses a step off something that is no commit', async () => {
+    // git dies here too: a tree has no parent, so the step has nothing to
+    // walk.
+    const h = await harness()
+    expect((await h.run('tag broken HEAD^{tree}~1'))[0]).toBe(128)
+    expect(await h.run('tag -l')).toEqual([0, '', ''])
   })
 })
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -200,6 +200,27 @@ function conflictIndex(repo: string, path: string, stages: number[] = [1, 2, 3])
   })
 }
 
+/**
+ * Record a gitlink at a path and commit it, with content under the name.
+ *
+ * It points at this repository's own HEAD so the commit it names resolves
+ * here: an ordinary submodule's does not, and the two failure modes differ.
+ */
+function gitlinkIndex(repo: string, path: string): void {
+  const head = git(repo, ['rev-parse', 'HEAD']).trim()
+  mkdirSync(join(repo, path), { recursive: true })
+  writeFileSync(join(repo, path, 'keep.md'), 'keep\n')
+  execFileSync('git', [
+    '-C',
+    repo,
+    'update-index',
+    '--add',
+    '--cacheinfo',
+    `160000,${head},${path}`,
+  ])
+  execFileSync('git', ['-C', repo, 'commit', '-q', '-m', 'gitlink'], { stdio: 'ignore' })
+}
+
 /** Write into the mount, which is where the verbs under test read from. */
 async function write(h: Harness, path: string, text: string): Promise<void> {
   const target = `/repo/${path}`
@@ -1696,6 +1717,68 @@ describe('a working-tree removal that would take a mount with it', () => {
     expect((await h.run('commit -m inside'))[0]).toBe(0)
     expect((await h.run('rm slot/data/x.md'))[0]).toBe(0)
     expect(await readNames(h.dispatch, '/repo/slot/data')).toEqual([])
+  })
+})
+
+describe('a gitlink in the tree', () => {
+  it('leaves the working tree it already has alone', async () => {
+    // A 160000 entry names a commit in another repository. git checks out no
+    // submodule content without --recurse-submodules, so all the entry asks of
+    // the working tree is that a directory stand at the name: reading it as a
+    // blob wrote an empty file over the whole directory, untracked work
+    // included.
+    const h = await harness((repo) => {
+      gitlinkIndex(repo, 'sub')
+    })
+    expect(await h.run('restore sub')).toEqual([0, '', ''])
+    expect(await readOptional(h.dispatch, '/repo/sub/keep.md')).not.toBeNull()
+  })
+
+  it('makes a directory when nothing is there', async () => {
+    const h = await harness((repo) => {
+      gitlinkIndex(repo, 'sub')
+    })
+    await removeTree(h.dispatch, '/repo/sub', null, null)
+    expect(await h.run('restore sub')).toEqual([0, '', ''])
+    expect(await readNames(h.dispatch, '/repo/sub')).toEqual([])
+    // A directory, not a file: readNames answers empty for both, so the write
+    // that used to land here is ruled out by asking for the file back.
+    expect(await readOptional(h.dispatch, '/repo/sub')).toBeNull()
+  })
+
+  it('replaces a regular file standing at the name', async () => {
+    const h = await harness((repo) => {
+      gitlinkIndex(repo, 'sub')
+    })
+    await removeTree(h.dispatch, '/repo/sub', null, null)
+    await h.ws.execute("printf 'i am a file\\n' > /repo/sub")
+    expect(await h.run('restore sub')).toEqual([0, '', ''])
+    expect(await readOptional(h.dispatch, '/repo/sub')).toBeNull()
+  })
+})
+
+describe('an ancestry suffix that is not a step', () => {
+  it('writes no tag', async () => {
+    // Every character used to count as another first-parent hop, so `HEAD^x`
+    // resolved to `HEAD^^` and the tag landed on a commit nobody named.
+    const h = await harness()
+    expect(await h.run('tag release HEAD^x')).toEqual([
+      128,
+      '',
+      "fatal: Failed to resolve 'HEAD^x' as a valid ref.\n",
+    ])
+    expect(await h.run('tag -l')).toEqual([0, '', ''])
+    // The unicode digit is the same refusal: the count scans ASCII only, so
+    // what is left over is not another step either.
+    expect((await h.run('tag release main~٣'))[0]).toBe(128)
+  })
+
+  it('still takes the steps git does take', async () => {
+    const h = await harness()
+    expect(await h.run('tag first HEAD^')).toEqual([0, '', ''])
+    expect(await h.run('tag here HEAD^0')).toEqual([0, '', ''])
+    expect(await h.run('tag mixed HEAD^~')).toEqual([0, '', ''])
+    expect(await h.run('tag -l')).toEqual([0, 'first\nhere\nmixed\n', ''])
   })
 })
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -102,7 +102,7 @@ interface Harness {
  * index) starts from one git itself wrote rather than from bytes this file
  * hand-rolled.
  */
-async function harness(prepare?: (repo: string) => void): Promise<Harness> {
+async function harness(prepare?: (repo: string) => void, nested?: string): Promise<Harness> {
   const repo = mkdtempSync(join(tmp, 'repo-'))
   roots.push(repo)
   execFileSync('bash', [BUILDER, repo], { stdio: 'ignore' })
@@ -111,14 +111,33 @@ async function harness(prepare?: (repo: string) => void): Promise<Harness> {
   const ram = new RAMResource()
   const registry = new OpsRegistry()
   registry.registerResource(ram)
-  const ws = new Workspace(
-    { '/repo': ram },
-    { mode: MountMode.WRITE, ops: registry, shellParser: parser },
-  )
+  // `nested` mounts a second resource inside the repository, which is the
+  // one shape a verb cannot rename: its keys live in another resource, so
+  // the backend holding the parent path cannot carry them along.
+  const mounts: Record<string, RAMResource> = { '/repo': ram }
+  if (nested !== undefined) {
+    const child = new RAMResource()
+    registry.registerResource(child)
+    mounts[nested] = child
+  }
+  const ws = new Workspace(mounts, {
+    mode: MountMode.WRITE,
+    ops: registry,
+    shellParser: parser,
+  })
   const dispatch: Dispatch = async (op, path, args = [], kwargs = {}) => [
     await ws.dispatch(op, path.virtual, args, kwargs),
     new IOResult(),
   ]
+  // A mount's ancestors read as existing directories the moment the child is
+  // mounted, so `ensureDir` stops at one and the parent backend never gets the
+  // key. Created directly here, before anything is copied in.
+  if (nested !== undefined) {
+    const parts = nested.slice('/repo/'.length).split('/').slice(0, -1)
+    for (let n = 1; n <= parts.length; n += 1) {
+      await ws.dispatch('mkdir', `/repo/${parts.slice(0, n).join('/')}`)
+    }
+  }
   for (const rel of walkDisk(repo)) {
     const target = `/repo/${rel}`
     await ensureDir(dispatch, target.slice(0, target.lastIndexOf('/')))
@@ -1454,5 +1473,132 @@ describe('git restore --source', () => {
     const [code, , err] = await h.run('restore --source=nosuch letters.txt')
     expect(code).toBe(128)
     expect(err).toBe('fatal: could not resolve nosuch\n')
+  })
+})
+
+describe('a name that is a file on one side and a directory on the other', () => {
+  it('replaces the file with the directory the source holds', async () => {
+    let dir = ''
+    const h = await harness((repo) => {
+      mkdirSync(join(repo, 'slot'))
+      writeFileSync(join(repo, 'slot/child'), 'inner\n')
+      git(repo, ['add', 'slot'])
+      git(repo, ['commit', '-q', '-m', 'dir'])
+      dir = git(repo, ['rev-parse', 'HEAD^{tree}']).trim()
+      git(repo, ['rm', '-q', '-r', 'slot'])
+      writeFileSync(join(repo, 'slot'), 'flat\n')
+      git(repo, ['add', 'slot'])
+      git(repo, ['commit', '-q', '-m', 'flat'])
+    })
+    expect(await h.run(`restore --source=${dir} -SW slot`)).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['ls-files', 'slot'])).toBe('slot/child\n')
+    expect(readFileSync(join(drained, 'slot/child'), 'utf8')).toBe('inner\n')
+  })
+
+  it('replaces the directory with the file the source holds', async () => {
+    let flat = ''
+    const h = await harness((repo) => {
+      writeFileSync(join(repo, 'slot'), 'flat\n')
+      git(repo, ['add', 'slot'])
+      git(repo, ['commit', '-q', '-m', 'flat'])
+      flat = git(repo, ['rev-parse', 'HEAD^{tree}']).trim()
+      git(repo, ['rm', '-q', 'slot'])
+      mkdirSync(join(repo, 'slot'))
+      writeFileSync(join(repo, 'slot/child'), 'inner\n')
+      git(repo, ['add', 'slot'])
+      git(repo, ['commit', '-q', '-m', 'dir'])
+    })
+    expect(await h.run(`restore --source=${flat} -SW slot`)).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['ls-files', 'slot'])).toBe('slot\n')
+    expect(readFileSync(join(drained, 'slot'), 'utf8')).toBe('flat\n')
+  })
+})
+
+describe('an untracked path that collides with the target tree', () => {
+  it('refuses a file standing where the target holds a directory', async () => {
+    const h = await harness((repo) => {
+      git(repo, ['checkout', '-q', '-b', 'other'])
+      mkdirSync(join(repo, 'slot'))
+      writeFileSync(join(repo, 'slot/file'), 'theirs\n')
+      git(repo, ['add', 'slot'])
+      git(repo, ['commit', '-q', '-m', 'dir'])
+      git(repo, ['checkout', '-q', 'main'])
+    })
+    await write(h, 'slot', 'mine\n')
+    const [code, , err] = await h.run('switch other')
+    expect(code).toBe(1)
+    expect(err).toBe(
+      'error: The following untracked working tree files would be overwritten by ' +
+        'checkout:\n\tslot\nPlease move or remove them before you switch branches.\nAborting\n',
+    )
+  })
+
+  it('refuses a directory standing where the target holds a file', async () => {
+    const h = await harness((repo) => {
+      git(repo, ['checkout', '-q', '-b', 'other'])
+      writeFileSync(join(repo, 'slot'), 'theirs\n')
+      git(repo, ['add', 'slot'])
+      git(repo, ['commit', '-q', '-m', 'file'])
+      git(repo, ['checkout', '-q', 'main'])
+    })
+    await write(h, 'slot/file', 'mine\n')
+    const [code, , err] = await h.run('switch other')
+    expect(code).toBe(1)
+    expect(err).toBe(
+      'error: Updating the following directories would lose untracked files in ' +
+        'them:\n\tslot\n\nAborting\n',
+    )
+  })
+})
+
+describe('a pathspec that begins with a dash', () => {
+  it('moves it when the line escapes it with --', async () => {
+    const h = await harness()
+    await write(h, '-draft', 'x\n')
+    await h.run('add -- -draft')
+    expect(await h.run('mv -- -draft kept.txt')).toEqual([0, '', ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('A  kept.txt\n')
+  })
+
+  it('removes it when the line escapes it with --', async () => {
+    const h = await harness()
+    await write(h, '-draft', 'x\n')
+    await h.run('add -- -draft')
+    await h.run('commit -m draft')
+    expect(await h.run('rm -- -draft')).toEqual([0, "rm '-draft'\n", ''])
+  })
+
+  it('is still an unknown switch unescaped', async () => {
+    const h = await harness()
+    const [code, , err] = await h.run('rm -draft')
+    expect(code).toBe(129)
+    expect(err).toBe("error: unknown switch `draft'\n")
+  })
+})
+
+describe('a rename that would leave a mount behind', () => {
+  it('refuses a directory holding one', async () => {
+    const h = await harness(undefined, '/repo/docs/inner')
+    const [code, , err] = await h.run('mv docs notes')
+    expect(code).toBe(128)
+    expect(err).toBe("fatal: renaming 'docs' failed: Device or resource busy\n")
+    expect(await h.run('status --porcelain')).toEqual([0, '', ''])
+  })
+
+  it('refuses the mount root itself', async () => {
+    const h = await harness(undefined, '/repo/inner')
+    await write(h, 'inner/one.md', 'x\n')
+    await h.run('add inner')
+    const [code, , err] = await h.run('mv inner elsewhere')
+    expect(code).toBe(128)
+    expect(err).toBe("fatal: renaming 'inner' failed: Device or resource busy\n")
+  })
+
+  it('skips it under -k', async () => {
+    const h = await harness(undefined, '/repo/docs/inner')
+    expect(await h.run('mv -k docs notes')).toEqual([0, '', ''])
+    expect(await h.run('status --porcelain')).toEqual([0, '', ''])
   })
 })

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -94,10 +94,19 @@ interface Harness {
   drain(): Promise<string>
 }
 
-async function harness(): Promise<Harness> {
+/**
+ * A workspace holding the fixture repository, copied into a RAM mount.
+ *
+ * `prepare` runs against the repository on disk, before the copy, so a test
+ * needing a shape only the real binary can build (packed refs, an unmerged
+ * index) starts from one git itself wrote rather than from bytes this file
+ * hand-rolled.
+ */
+async function harness(prepare?: (repo: string) => void): Promise<Harness> {
   const repo = mkdtempSync(join(tmp, 'repo-'))
   roots.push(repo)
   execFileSync('bash', [BUILDER, repo], { stdio: 'ignore' })
+  prepare?.(repo)
 
   const ram = new RAMResource()
   const registry = new OpsRegistry()
@@ -1151,5 +1160,160 @@ describe('git tag', () => {
     const h = await harness()
     await h.run('tag v1.0 HEAD~1')
     expect(await h.run('tag -f v1.0')).toEqual([0, "Updated tag 'v1.0' (was 225f39c)\n", ''])
+  })
+})
+
+describe('a name that escapes the ref tree', () => {
+  it('is refused by switch -c, leaving the config alone', async () => {
+    const h = await harness()
+    const before = await readOptional(h.dispatch, '/repo/.git/config')
+    expect(await h.run('switch -c ../../config')).toEqual([
+      128,
+      '',
+      "fatal: '../../config' is not a valid branch name\n" +
+        'hint: See `man git check-ref-format`\n' +
+        'hint: Disable this message with "git config set advice.refSyntax false"\n',
+    ])
+    expect(await readOptional(h.dispatch, '/repo/.git/config')).toEqual(before)
+  })
+
+  it('is refused by branch, before its start point resolves', async () => {
+    const h = await harness()
+    const [code, , err] = await h.run('branch ../../config nosuchstart')
+    expect(code).toBe(128)
+    expect(err.startsWith("fatal: '../../config' is not a valid branch name")).toBe(true)
+  })
+
+  it('lets switch name an unresolvable start point first', async () => {
+    const h = await harness()
+    expect(await h.run('switch -c ../../config nosuchstart')).toEqual([
+      128,
+      '',
+      'fatal: invalid reference: nosuchstart\n',
+    ])
+  })
+})
+
+describe('two mv sources landing on one name', () => {
+  async function withTwo(): Promise<Harness> {
+    const h = await harness()
+    await write(h, 'a/x', 'ax\n')
+    await write(h, 'b/x', 'bx\n')
+    await write(h, 'dest/keep.txt', 'k\n')
+    await h.run('add a b')
+    await h.run('commit -m two')
+    return h
+  }
+
+  it('is refused, and nothing moves', async () => {
+    const h = await withTwo()
+    expect(await h.run('mv a/x b/x dest')).toEqual([
+      128,
+      '',
+      'fatal: multiple sources for the same target, source=b/x, destination=dest/x\n',
+    ])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('?? dest/\n')
+  })
+
+  it('is reported by the colliding path when directories carry it', async () => {
+    const h = await harness()
+    await write(h, 'a/sub/f', '1\n')
+    await write(h, 'b/sub/f', '2\n')
+    await write(h, 'dest/keep.txt', 'k\n')
+    await h.run('add a b')
+    await h.run('commit -m dirs')
+    const [, , err] = await h.run('mv a/sub b/sub dest')
+    expect(err).toBe(
+      'fatal: multiple sources for the same target, source=b/sub/f, destination=dest/sub/f\n',
+    )
+  })
+
+  it('is skipped under -k, moving the first', async () => {
+    const h = await withTwo()
+    expect(await h.run('mv -k a/x b/x dest')).toEqual([0, '', ''])
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe(
+      'R  a/x -> dest/x\n?? dest/keep.txt\n',
+    )
+  })
+})
+
+describe('git tag creation options', () => {
+  it.each(['tag -a', 'tag -m msg', 'tag -f'])('need a name: %s', async (line) => {
+    const h = await harness()
+    expect(await h.run(line)).toEqual([
+      129,
+      '',
+      'usage: git tag [-a] [-f] [-m <msg>] <tagname> [<commit> | <object>]\n' +
+        '   or: git tag -d <tagname>...\n' +
+        '   or: git tag [-n[<num>]] -l [<pattern>...]\n',
+    ])
+  })
+
+  it.each(['tag -l -a v1', 'tag -d -a v1', 'tag -n -f'])(
+    'cannot list or delete: %s',
+    async (line) => {
+      const h = await harness()
+      const [code, , err] = await h.run(line)
+      expect(code).toBe(129)
+      expect(err.startsWith('usage: git tag [-a] [-f] [-m <msg>]')).toBe(true)
+    },
+  )
+
+  it('leave listing and deleting able to take no name', async () => {
+    const h = await harness()
+    expect(await h.run('tag')).toEqual([0, '', ''])
+    expect(await h.run('tag -d')).toEqual([0, '', ''])
+  })
+})
+
+describe('a ref that lives only in packed-refs', () => {
+  it('is really deleted by tag -d', async () => {
+    const h = await harness((repo) => {
+      git(repo, ['tag', 'lw'])
+      git(repo, ['tag', '-a', 'ann', '-m', 'msg'])
+      git(repo, ['pack-refs', '--all'])
+      // One loose ref, made after the pack, so `.git/refs` still holds a file:
+      // a directory with none is not copied out of the mount, and git reads a
+      // tree without `refs/` as not a repository at all.
+      git(repo, ['branch', 'keepme'])
+    })
+    expect(await h.run('tag')).toEqual([0, 'ann\nlw\n', ''])
+    expect((await h.run('tag -d lw'))[0]).toBe(0)
+    expect((await h.run('tag -d ann'))[0]).toBe(0)
+    expect(await h.run('tag')).toEqual([0, '', ''])
+    const packed = DEC.decode(
+      (await readOptional(h.dispatch, '/repo/.git/packed-refs')) ?? undefined,
+    )
+    expect(packed).not.toContain('refs/tags/')
+    expect(packed).not.toContain('^')
+    expect(packed).toContain('refs/heads/main')
+    expect(git(await h.drain(), ['tag', '-l'])).toBe('')
+  })
+
+  it('is really deleted by branch -D', async () => {
+    const h = await harness((repo) => {
+      git(repo, ['pack-refs', '--all'])
+      git(repo, ['branch', 'keepme'])
+    })
+    expect((await h.run('branch -D topic'))[0]).toBe(0)
+    expect(await h.run('branch')).toEqual([0, '  keepme\n* main\n', ''])
+    expect(git(await h.drain(), ['branch', '--list'])).toBe('  keepme\n* main\n')
+  })
+})
+
+describe('restoring an unmerged path', () => {
+  it('clears its conflict stages', async () => {
+    const h = await harness((repo) => {
+      const blob = git(repo, ['rev-parse', 'HEAD:letters.txt']).trim()
+      const stages = [1, 2, 3].map((stage) => `100644 ${blob} ${String(stage)}\tletters.txt`)
+      execFileSync('git', ['-C', repo, 'update-index', '--index-info'], {
+        input: `${stages.join('\n')}\n`,
+      })
+    })
+    expect(git(await h.drain(), ['status', '--porcelain'])).toBe('UU letters.txt\n')
+    expect(await h.run('restore --staged letters.txt')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['ls-files', '-u'])).toBe('')
+    expect(git(drained, ['status', '--porcelain'])).toBe('')
   })
 })

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -1925,6 +1925,22 @@ describe('git switch on an unborn HEAD', () => {
     expect(err.startsWith("fatal: '../../evil' is not a valid branch name\n")).toBe(true)
     expect(await headOf(h)).toBe('ref: refs/heads/main')
   })
+
+  it('is not already on the branch HEAD names', async () => {
+    // HEAD names it, but the ref has never been written, so there is no
+    // commit to be on. Reading the name alone answered "Already on" at exit
+    // 0; git resolves it first and dies, which is what leaves `switch -c` as
+    // the only line an unborn HEAD accepts.
+    const h = await harness(unborn)
+    expect(await h.run('switch main')).toEqual([128, '', 'fatal: invalid reference: main\n'])
+    expect(await headOf(h)).toBe('ref: refs/heads/main')
+  })
+
+  it('refuses the branch it just created, for the same reason', async () => {
+    const h = await harness(unborn)
+    expect((await h.run('switch -c topic'))[0]).toBe(0)
+    expect(await h.run('switch topic')).toEqual([128, '', 'fatal: invalid reference: topic\n'])
+  })
 })
 
 describe('staged work carried across a switch', () => {
@@ -2356,5 +2372,87 @@ describe('a switch onto a branch recording a directory', () => {
         'Please commit your changes or stash them before you switch branches.\nAborting\n',
     ])
     expect((await h.run('status --short'))[1]).toBe('A  slot\n')
+  })
+})
+
+describe('a directory standing where the target records a file', () => {
+  it('takes an ignored one with it', async () => {
+    // It holds only ignored files, so the check that refuses a directory is
+    // silent (it is about the untracked files one would lose), and git
+    // updates ignored files by default.
+    const h = await harness()
+    await write(h, '.gitignore', 'slot/\n')
+    expect((await h.run('add .gitignore'))[0]).toBe(0)
+    expect((await h.run('commit -m ignore'))[0]).toBe(0)
+    expect((await h.run('switch -c other'))[0]).toBe(0)
+    await write(h, 'slot', 'asfile\n')
+    expect((await h.run('add -f slot'))[0]).toBe(0)
+    expect((await h.run('commit -m file'))[0]).toBe(0)
+    expect((await h.run('switch main'))[0]).toBe(0)
+    await write(h, 'slot/keep', 'keep\n')
+    expect((await h.run('switch other'))[0]).toBe(0)
+    const landed = await readOptional(h.dispatch, '/repo/slot')
+    expect(landed === null ? '' : DEC.decode(landed)).toBe('asfile\n')
+  })
+
+  it('refuses one holding untracked files', async () => {
+    // The other side of the same split, and the reason the removal above
+    // cannot be unconditional.
+    const h = await harness()
+    expect((await h.run('switch -c other'))[0]).toBe(0)
+    await write(h, 'slot', 'asfile\n')
+    expect((await h.run('add slot'))[0]).toBe(0)
+    expect((await h.run('commit -m file'))[0]).toBe(0)
+    expect((await h.run('switch main'))[0]).toBe(0)
+    await write(h, 'slot/keep', 'keep\n')
+    expect(await h.run('switch other')).toEqual([
+      1,
+      '',
+      'error: Updating the following directories would lose untracked files in them:\n' +
+        '\tslot\n\nAborting\n',
+    ])
+    const kept = await readOptional(h.dispatch, '/repo/slot/keep')
+    expect(kept === null ? '' : DEC.decode(kept)).toBe('keep\n')
+  })
+})
+
+describe('the executable bit a tree entry records', () => {
+  it('comes back with the content on restore', async () => {
+    // git records exactly one permission bit and restores it. Writing the
+    // bytes alone left the file unrunnable and left status calling it
+    // modified for ever, since the mode is half of what the index staged.
+    const h = await harness()
+    await write(h, 's.sh', '#!/bin/sh\n')
+    await h.ws.execute('chmod 755 /repo/s.sh')
+    expect((await h.run('add s.sh'))[0]).toBe(0)
+    expect((await h.run('commit -m script'))[0]).toBe(0)
+    await h.ws.execute('chmod 644 /repo/s.sh')
+    expect((await h.run('status --short'))[1]).toBe(' M s.sh\n')
+    expect(await h.run('restore s.sh')).toEqual([0, '', ''])
+    expect((await h.run('status --short'))[1]).toBe('')
+    expect(git(await h.drain(), ['ls-files', '-s', 's.sh']).trim()).toMatch(/^100755 /)
+  })
+
+  it('is cleared the other way too', async () => {
+    const h = await harness()
+    await write(h, 'p.txt', 'plain\n')
+    expect((await h.run('add p.txt'))[0]).toBe(0)
+    expect((await h.run('commit -m plain'))[0]).toBe(0)
+    await h.ws.execute('chmod 755 /repo/p.txt')
+    expect((await h.run('status --short'))[1]).toBe(' M p.txt\n')
+    expect(await h.run('restore p.txt')).toEqual([0, '', ''])
+    expect((await h.run('status --short'))[1]).toBe('')
+  })
+
+  it('survives a branch switch', async () => {
+    const h = await harness()
+    expect((await h.run('switch -c other'))[0]).toBe(0)
+    await write(h, 's.sh', '#!/bin/sh\n')
+    await h.ws.execute('chmod 755 /repo/s.sh')
+    expect((await h.run('add s.sh'))[0]).toBe(0)
+    expect((await h.run('commit -m script'))[0]).toBe(0)
+    expect((await h.run('switch main'))[0]).toBe(0)
+    expect((await h.run('switch other'))[0]).toBe(0)
+    expect((await h.run('status --short'))[1]).toBe('')
   })
 })

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -2247,3 +2247,76 @@ describe('a moved path that the node table knows about', () => {
     expect((await h.ws.execute('readlink /repo/notes/link')).exitCode).not.toBe(0)
   })
 })
+
+describe('a component on the way that is not a directory', () => {
+  it('replaces a regular file standing where a directory belongs', async () => {
+    // The symlink case's other half, and the commoner one. git's
+    // create_directories unlinks any leading non-directory and makes the
+    // directory, so the restore succeeds and the file is gone. Left
+    // unhandled, the write failed with a raw ENOTDIR.
+    const h = await harness()
+    await h.ws.execute('rm -r /repo/docs && echo untracked > /repo/docs')
+    expect(await h.run('restore docs/readme.md')).toEqual([0, '', ''])
+    const back = await readOptional(h.dispatch, '/repo/docs/readme.md')
+    expect(back === null ? '' : DEC.decode(back)).toBe('notes\n')
+  })
+
+  it('attempts no removal through one', async () => {
+    // The removal direction takes it the other way, exactly as it takes a
+    // link: git checks the leading path and removes nothing.
+    const h = await harness()
+    await h.ws.execute('rm -r /repo/docs && echo untracked > /repo/docs')
+    expect(await h.run('restore --source=HEAD~2 docs/readme.md')).toEqual([0, '', ''])
+    const kept = await readOptional(h.dispatch, '/repo/docs')
+    expect(kept === null ? '' : DEC.decode(kept)).toBe('untracked\n')
+  })
+})
+
+describe('a switch onto a branch recording a directory', () => {
+  it('replaces an ignored link rather than writing through it', async () => {
+    // An ignored path is in neither tree and in no collision list, so it
+    // reaches the write. Writing through the link landed the blob in the
+    // link's target, corrupting a path no branch named while the link
+    // survived; git replaces the link instead.
+    const h = await harness()
+    await write(h, '.gitignore', 'slot\n')
+    expect((await h.run('add .gitignore'))[0]).toBe(0)
+    expect((await h.run('commit -m ignore'))[0]).toBe(0)
+    expect((await h.run('switch -c other'))[0]).toBe(0)
+    await write(h, 'slot/child', 'kid\n')
+    expect((await h.run('add -f slot/child'))[0]).toBe(0)
+    expect((await h.run('commit -m child'))[0]).toBe(0)
+    expect((await h.run('switch main'))[0]).toBe(0)
+    await write(h, 'away/child', 'outside\n')
+    await h.ws.execute('ln -s /repo/away /repo/slot')
+    expect((await h.run('switch other'))[0]).toBe(0)
+    const kid = await readOptional(h.dispatch, '/repo/slot/child')
+    expect(kid === null ? '' : DEC.decode(kid)).toBe('kid\n')
+    // The link's target tree is untouched, and the link itself is gone.
+    const other = await readOptional(h.dispatch, '/repo/away/child')
+    expect(other === null ? '' : DEC.decode(other)).toBe('outside\n')
+    expect((await h.ws.execute('readlink /repo/slot')).exitCode).not.toBe(0)
+  })
+
+  it('refuses a staged file standing in the way', async () => {
+    // git allows this and discards the staged addition in silence; this
+    // refuses and names it. What must not happen either way is the old
+    // answer: a raw ENOTDIR after earlier entries were already written.
+    const h = await harness()
+    expect((await h.run('switch -c other'))[0]).toBe(0)
+    await write(h, 'slot/child', 'kid\n')
+    expect((await h.run('add slot/child'))[0]).toBe(0)
+    expect((await h.run('commit -m child'))[0]).toBe(0)
+    expect((await h.run('switch main'))[0]).toBe(0)
+    await write(h, 'slot', 'staged\n')
+    expect((await h.run('add slot'))[0]).toBe(0)
+    expect(await h.run('switch other')).toEqual([
+      1,
+      '',
+      'error: Your local changes to the following files would be overwritten by checkout:\n' +
+        '\tslot\n' +
+        'Please commit your changes or stash them before you switch branches.\nAborting\n',
+    ])
+    expect((await h.run('status --short'))[1]).toBe('A  slot\n')
+  })
+})

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -2172,3 +2172,78 @@ describe('a lightweight tag as an annotated tag target', () => {
     expect(git(drained, ['cat-file', '-p', 'fromlight']).split('\n')[1]).toBe('type commit')
   })
 })
+
+describe('git tag -d given a display option', () => {
+  it('refuses -n and leaves the tag standing', async () => {
+    const h = await harness()
+    expect((await h.run('tag v'))[0]).toBe(0)
+    expect(await h.run('tag -d -n1 v')).toEqual([
+      128,
+      '',
+      "fatal: the '-n' option is only allowed in list mode\n",
+    ])
+    expect(await h.run('tag -l')).toEqual([0, 'v\n', ''])
+  })
+
+  it('still reads -n alone as a listing', async () => {
+    // The refusal above is about -d having already chosen the mode:
+    // with nothing else on the line -n makes it a listing, so an
+    // operand is a pattern and one that matches nothing exits 0.
+    const h = await harness()
+    expect((await h.run('tag v'))[0]).toBe(0)
+    expect(await h.run('tag -n1 nosuch')).toEqual([0, '', ''])
+    expect(await h.run('tag -l')).toEqual([0, 'v\n', ''])
+  })
+})
+
+describe('git tag -d naming one tag twice', () => {
+  it('deletes nothing at all', async () => {
+    const h = await harness()
+    expect((await h.run('tag v'))[0]).toBe(0)
+    expect((await h.run('tag w'))[0]).toBe(0)
+    // One ref transaction holds every deletion on the line, and two
+    // updates for one ref are refused before any of them applies.
+    expect(await h.run('tag -d v w v')).toEqual([
+      1,
+      '',
+      "error: could not delete references: multiple updates for ref 'refs/tags/v' not allowed\n",
+    ])
+    expect(await h.run('tag -l')).toEqual([0, 'v\nw\n', ''])
+  })
+
+  it('reports a name that is not there before the conflict', async () => {
+    const h = await harness()
+    expect((await h.run('tag v'))[0]).toBe(0)
+    expect(await h.run('tag -d v v nosuch')).toEqual([
+      1,
+      '',
+      "error: tag 'nosuch' not found.\n" +
+        "error: could not delete references: multiple updates for ref 'refs/tags/v' not allowed\n",
+    ])
+    expect(await h.run('tag -l')).toEqual([0, 'v\n', ''])
+  })
+
+  it('blames the first ref in ref order, not the first typed', async () => {
+    const h = await harness()
+    expect((await h.run('tag v'))[0]).toBe(0)
+    expect((await h.run('tag w'))[0]).toBe(0)
+    expect((await h.run('tag -d w w v v'))[2]).toBe(
+      "error: could not delete references: multiple updates for ref 'refs/tags/v' not allowed\n",
+    )
+  })
+})
+
+describe('a moved path that the node table knows about', () => {
+  it('carries a link below a moved directory', async () => {
+    const h = await harness()
+    await h.ws.execute('mkdir /repo/notes && echo t > /repo/t.txt')
+    await h.ws.execute('ln -s /repo/t.txt /repo/notes/link')
+    expect((await h.run('add notes'))[0]).toBe(0)
+    expect(await h.run('mv notes moved')).toEqual([0, '', ''])
+    // A link is namespace state, so the question goes to the namespace
+    // rather than to the drained copy, which never holds one.
+    const told = await h.ws.execute('readlink /repo/moved/link')
+    expect([told.exitCode, DEC.decode(told.stdout)]).toEqual([0, '/repo/t.txt\n'])
+    expect((await h.ws.execute('readlink /repo/notes/link')).exitCode).not.toBe(0)
+  })
+})

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -175,12 +175,19 @@ function git(repo: string, args: string[]): string {
   return execFileSync('git', ['-C', repo, ...args], { encoding: 'utf8' })
 }
 
-/** Leave one tracked path unmerged, with all three stages holding its blob. */
-function conflictIndex(repo: string, path: string): void {
-  const blob = git(repo, ['rev-parse', `HEAD:${path}`]).trim()
-  const stages = [1, 2, 3].map((stage) => `100644 ${blob} ${String(stage)}\t${path}`)
+/** Leave one staged path unmerged, its stages all holding the blob it has. */
+function conflictIndex(repo: string, path: string, stages: number[] = [1, 2, 3]): void {
+  const blob = git(repo, ['rev-parse', `:${path}`]).trim()
+  // A merge replaces the stage-0 entry rather than sitting beside it, and
+  // `--index-info` removes one only when told to, so the zero id goes first.
+  // Left in, the path reads as staged and unmerged at once, which is a state
+  // no merge produces and which hides every refusal that reads stage 0.
+  const lines = [
+    `0 ${'0'.repeat(40)}\t${path}`,
+    ...stages.map((stage) => `100644 ${blob} ${String(stage)}\t${path}`),
+  ]
   execFileSync('git', ['-C', repo, 'update-index', '--index-info'], {
-    input: `${stages.join('\n')}\n`,
+    input: `${lines.join('\n')}\n`,
   })
 }
 
@@ -1332,11 +1339,7 @@ describe('a ref that lives only in packed-refs', () => {
 describe('restoring an unmerged path', () => {
   it('clears its conflict stages', async () => {
     const h = await harness((repo) => {
-      const blob = git(repo, ['rev-parse', 'HEAD:letters.txt']).trim()
-      const stages = [1, 2, 3].map((stage) => `100644 ${blob} ${String(stage)}\tletters.txt`)
-      execFileSync('git', ['-C', repo, 'update-index', '--index-info'], {
-        input: `${stages.join('\n')}\n`,
-      })
+      conflictIndex(repo, 'letters.txt')
     })
     expect(git(await h.drain(), ['status', '--porcelain'])).toBe('UU letters.txt\n')
     expect(await h.run('restore --staged letters.txt')).toEqual([0, '', ''])
@@ -1600,5 +1603,170 @@ describe('a rename that would leave a mount behind', () => {
     const h = await harness(undefined, '/repo/docs/inner')
     expect(await h.run('mv -k docs notes')).toEqual([0, '', ''])
     expect(await h.run('status --porcelain')).toEqual([0, '', ''])
+  })
+})
+
+describe('a switch while the index is unmerged', () => {
+  it('refuses before it moves anything', async () => {
+    const h = await harness((repo) => {
+      git(repo, ['branch', 'sidebar'])
+      conflictIndex(repo, 'letters.txt')
+    })
+    expect(await h.run('switch sidebar')).toEqual([
+      1,
+      'letters.txt: needs merge\n',
+      'error: you need to resolve your current index first\n',
+    ])
+    const drained = await h.drain()
+    expect(git(drained, ['rev-parse', '--abbrev-ref', 'HEAD'])).toBe('main\n')
+    expect(git(drained, ['status', '--porcelain'])).toBe('UU letters.txt\n')
+  })
+
+  it('refuses a detach at the commit HEAD already names', async () => {
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'letters.txt')
+    })
+    const [code, out] = await h.run('switch --detach HEAD')
+    expect([code, out]).toEqual([1, 'letters.txt: needs merge\n'])
+  })
+
+  it('lets a branch created here through, because nothing moves', async () => {
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'letters.txt')
+    })
+    expect(await h.run('switch -c sidebar')).toEqual([
+      0,
+      '',
+      "Switched to a new branch 'sidebar'\n",
+    ])
+    const drained = await h.drain()
+    expect(git(drained, ['rev-parse', '--abbrev-ref', 'HEAD'])).toBe('sidebar\n')
+    expect(git(drained, ['status', '--porcelain'])).toBe('UU letters.txt\n')
+  })
+
+  it('refuses the same branch once a start point is named', async () => {
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'letters.txt')
+    })
+    const [code, out] = await h.run('switch -c sidebar HEAD')
+    expect([code, out]).toEqual([1, 'letters.txt: needs merge\n'])
+  })
+})
+
+describe('a name that swaps between file and directory across branches', () => {
+  it('switches from the file to the directory', async () => {
+    const h = await harness((repo) => {
+      // Both trees are built with the real binary, because a swap this
+      // shape is exactly what the verbs under test used to get wrong.
+      writeFileSync(join(repo, 'slot'), 'flat\n')
+      git(repo, ['add', 'slot'])
+      git(repo, ['commit', '-m', 'flat'])
+      git(repo, ['checkout', '-q', '-b', 'other'])
+      git(repo, ['rm', '-q', 'slot'])
+      mkdirSync(join(repo, 'slot'))
+      writeFileSync(join(repo, 'slot', 'child'), 'deep\n')
+      git(repo, ['add', 'slot'])
+      git(repo, ['commit', '-m', 'deep'])
+      git(repo, ['checkout', '-q', 'main'])
+    })
+    expect(await h.run('switch other')).toEqual([0, '', "Switched to branch 'other'\n"])
+    const drained = await h.drain()
+    expect(readFileSync(join(drained, 'slot', 'child'), 'utf8')).toBe('deep\n')
+    expect(git(drained, ['status', '--porcelain'])).toBe('')
+  })
+
+  it('switches from the directory back to the file', async () => {
+    const h = await harness((repo) => {
+      mkdirSync(join(repo, 'slot'))
+      writeFileSync(join(repo, 'slot', 'child'), 'deep\n')
+      git(repo, ['add', 'slot'])
+      git(repo, ['commit', '-m', 'deep'])
+      git(repo, ['checkout', '-q', '-b', 'other'])
+      git(repo, ['rm', '-q', 'slot/child'])
+      writeFileSync(join(repo, 'slot'), 'flat\n')
+      git(repo, ['add', 'slot'])
+      git(repo, ['commit', '-m', 'flat'])
+      git(repo, ['checkout', '-q', 'main'])
+    })
+    expect(await h.run('switch other')).toEqual([0, '', "Switched to branch 'other'\n"])
+    const drained = await h.drain()
+    expect(readFileSync(join(drained, 'slot'), 'utf8')).toBe('flat\n')
+    expect(git(drained, ['status', '--porcelain'])).toBe('')
+  })
+})
+
+describe('a restore naming an unmerged path', () => {
+  it('refuses when the source holds nothing to put back', async () => {
+    const h = await harness((repo) => {
+      // Added on this side only, so HEAD holds nothing to restore from
+      // and the index holds no stage 0 either.
+      writeFileSync(join(repo, 'fresh.txt'), 'mine\n')
+      git(repo, ['add', 'fresh.txt'])
+      conflictIndex(repo, 'fresh.txt', [2, 3])
+    })
+    expect(await h.run('restore --staged fresh.txt')).toEqual([
+      1,
+      '',
+      "error: path 'fresh.txt' is unmerged\n",
+    ])
+    expect(git(await h.drain(), ['ls-files', '-u'])).not.toBe('')
+  })
+
+  it('refuses a working-tree restore, whose source is the index', async () => {
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'letters.txt')
+    })
+    expect(await h.run('restore letters.txt')).toEqual([
+      1,
+      '',
+      "error: path 'letters.txt' is unmerged\n",
+    ])
+  })
+
+  it('names every one it cannot restore', async () => {
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'letters.txt')
+      conflictIndex(repo, 'numbers.txt')
+    })
+    const [code, , err] = await h.run('restore letters.txt numbers.txt')
+    expect([code, err]).toEqual([
+      1,
+      "error: path 'letters.txt' is unmerged\nerror: path 'numbers.txt' is unmerged\n",
+    ])
+  })
+})
+
+describe('a tag target spelled as an object expression', () => {
+  it('takes a tree', async () => {
+    const h = await harness()
+    expect(await h.run('tag treetag HEAD^{tree}')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['cat-file', '-t', 'treetag']).trim()).toBe('tree')
+    expect(git(drained, ['rev-parse', 'treetag'])).toBe(git(drained, ['rev-parse', 'HEAD^{tree}']))
+  })
+
+  it('takes a blob at a path', async () => {
+    const h = await harness()
+    expect(await h.run('tag blobtag HEAD:letters.txt')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['cat-file', '-t', 'blobtag']).trim()).toBe('blob')
+    expect(git(drained, ['rev-parse', 'blobtag'])).toBe(
+      git(drained, ['rev-parse', 'HEAD:letters.txt']),
+    )
+  })
+
+  it('records the type on an annotated tag', async () => {
+    const h = await harness()
+    expect((await h.run('tag -a -m msg noted HEAD:letters.txt'))[0]).toBe(0)
+    expect(git(await h.drain(), ['cat-file', '-p', 'noted'])).toContain('type blob')
+  })
+
+  it('refuses one that resolves to nothing', async () => {
+    const h = await harness()
+    expect(await h.run('tag missed HEAD:nosuch')).toEqual([
+      128,
+      '',
+      "fatal: Failed to resolve 'HEAD:nosuch' as a valid ref.\n",
+    ])
   })
 })

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -2023,3 +2023,152 @@ describe('a peel naming the tag type', () => {
     expect((await h.run('tag nested light^{tag}'))[0]).toBe(128)
   })
 })
+
+describe('git rm over a directory', () => {
+  it('refuses the path and leaves the index as it stood', async () => {
+    const h = await harness()
+    await h.ws.execute('rm /repo/numbers.txt && mkdir /repo/numbers.txt')
+    await write(h, 'numbers.txt/keep', 'k\n')
+    const [code, out, err] = await h.run('rm numbers.txt')
+    expect(code).toBe(128)
+    expect(err).toBe("fatal: git rm: 'numbers.txt': Is a directory\n")
+    // git prints the line for every selected path before it deletes
+    // anything, so it is printed whether the line goes through or not.
+    expect(out).toBe("rm 'numbers.txt'\n")
+    // The index is written last, so the entry is still staged.
+    expect(git(await h.drain(), ['ls-files', 'numbers.txt'])).toBe('numbers.txt\n')
+  })
+
+  it('tolerates the refusal once a deletion has been made', async () => {
+    const h = await harness()
+    await h.ws.execute('rm /repo/numbers.txt && mkdir /repo/numbers.txt')
+    await write(h, 'numbers.txt/keep', 'k\n')
+    // letters.txt sorts first and goes, so numbers.txt's failure is
+    // swallowed and the whole line succeeds with both entries unstaged.
+    const [code, out, err] = await h.run('rm -f letters.txt numbers.txt')
+    expect([code, err]).toEqual([0, ''])
+    expect(out).toBe("rm 'letters.txt'\nrm 'numbers.txt'\n")
+    const drained = await h.drain()
+    expect(git(drained, ['ls-files', 'letters.txt', 'numbers.txt'])).toBe('')
+  })
+
+  it('stands when nothing has gone yet', async () => {
+    const h = await harness()
+    await h.ws.execute('rm /repo/letters.txt && mkdir /repo/letters.txt')
+    const [code, , err] = await h.run('rm -f letters.txt numbers.txt')
+    expect(code).toBe(128)
+    expect(err).toBe("fatal: git rm: 'letters.txt': Is a directory\n")
+    // numbers.txt is never reached, in the working tree or the index.
+    expect(await readOptional(h.dispatch, '/repo/numbers.txt')).not.toBeNull()
+  })
+
+  it('unstages a directory under --cached without touching it', async () => {
+    const h = await harness()
+    await h.ws.execute('rm /repo/numbers.txt && mkdir /repo/numbers.txt')
+    await write(h, 'numbers.txt/keep', 'k\n')
+    expect(await h.run('rm --cached numbers.txt')).toEqual([0, "rm 'numbers.txt'\n", ''])
+    expect(await readOptional(h.dispatch, '/repo/numbers.txt/keep')).not.toBeNull()
+  })
+
+  it('removes a tracked link to a directory as the link it is', async () => {
+    const h = await harness()
+    await h.ws.execute('ln -s docs /repo/slot')
+    expect((await h.run('add -A'))[0]).toBe(0)
+    expect((await h.run('commit -m linked'))[0]).toBe(0)
+    expect(await h.run('rm slot')).toEqual([0, "rm 'slot'\n", ''])
+    // The link went; the directory it pointed at stayed.
+    expect(await readOptional(h.dispatch, '/repo/docs/readme.md')).not.toBeNull()
+  })
+})
+
+describe('restore across a symlink ancestor', () => {
+  it('replaces a link standing where a directory belongs', async () => {
+    const h = await harness()
+    await h.ws.execute('mkdir /repo/elsewhere')
+    await write(h, 'elsewhere/readme.md', 'old\n')
+    await h.ws.execute('rm -r /repo/docs && ln -s elsewhere /repo/docs')
+    expect(await h.run('restore docs/readme.md')).toEqual([0, '', ''])
+    // Writing through the link would have landed the content in
+    // elsewhere/readme.md, a file no branch named, and left the link.
+    const restored = await readOptional(h.dispatch, '/repo/docs/readme.md')
+    expect(restored === null ? '' : DEC.decode(restored)).toBe('notes\n')
+    const other = await readOptional(h.dispatch, '/repo/elsewhere/readme.md')
+    expect(other === null ? '' : DEC.decode(other)).toBe('old\n')
+    // A link is namespace state, so whether it is gone is a question
+    // for the namespace rather than for the drained copy.
+    expect((await h.ws.execute('readlink /repo/docs')).exitCode).not.toBe(0)
+  })
+
+  it('attempts no removal through one', async () => {
+    const h = await harness()
+    await h.ws.execute('mkdir /repo/elsewhere')
+    await write(h, 'elsewhere/readme.md', 'old\n')
+    await h.ws.execute('rm -r /repo/docs && ln -s elsewhere /repo/docs')
+    // HEAD~2 predates the entry, so restoring from it removes the path;
+    // the unlink would resolve past the link and delete a file inside
+    // whatever it points at. git checks the leading path and removes
+    // nothing, link and target both left as they stand.
+    expect(await h.run('restore --source=HEAD~2 docs/readme.md')).toEqual([0, '', ''])
+    const other = await readOptional(h.dispatch, '/repo/elsewhere/readme.md')
+    expect(other === null ? '' : DEC.decode(other)).toBe('old\n')
+    const told = await h.ws.execute('readlink /repo/docs')
+    expect([told.exitCode, DEC.decode(told.stdout)]).toEqual([0, 'elsewhere\n'])
+  })
+})
+
+describe('a tag named by a bare id', () => {
+  it('is the tag object, not the commit behind it', async () => {
+    const h = await harness()
+    expect((await h.run('tag -a v1 -m annotated'))[0]).toBe(0)
+    const held = git(await h.drain(), ['rev-parse', 'v1']).trim()
+    expect((await h.run(`tag -a nested -m x ${held}`))[0]).toBe(0)
+    const drained = await h.drain()
+    // git reads a bare id as that exact object, so the new tag points
+    // at the tag rather than at the commit behind it.
+    expect(git(drained, ['cat-file', '-p', 'nested']).split('\n')[1]).toBe('type tag')
+    expect(git(drained, ['fsck'])).toBe('')
+  })
+
+  it('still names a source tree for restore', async () => {
+    const h = await harness()
+    expect((await h.run('tag -a v1 -m annotated'))[0]).toBe(0)
+    const held = git(await h.drain(), ['rev-parse', 'v1']).trim()
+    await write(h, 'letters.txt', 'edited\n')
+    // The id names the tag object itself, which is no tree-ish; a
+    // source unwraps it, so this reads what `--source=v1` reads.
+    expect(await h.run(`restore --source=${held} letters.txt`)).toEqual([0, '', ''])
+    const back = await readOptional(h.dispatch, '/repo/letters.txt')
+    expect(back === null ? '' : DEC.decode(back)).toBe('alpha\nbeta\ngamma\ndelta\n')
+  })
+})
+
+describe('a lightweight tag as an annotated tag target', () => {
+  it('keeps the blob type it points at', async () => {
+    const h = await harness()
+    expect((await h.run('tag blobtag HEAD:letters.txt'))[0]).toBe(0)
+    expect(await h.run('tag -a release -m x blobtag')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    // `type commit` beside a blob id is a tag object git show and git
+    // fsck both reject.
+    expect(git(drained, ['cat-file', '-p', 'release']).split('\n')[1]).toBe('type blob')
+    expect(git(drained, ['fsck'])).toBe('')
+    expect(git(drained, ['show', 'release'])).toContain('alpha')
+  })
+
+  it('keeps the tree type it points at', async () => {
+    const h = await harness()
+    expect((await h.run('tag treetag HEAD^{tree}'))[0]).toBe(0)
+    expect(await h.run('tag -a treerel -m x treetag')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['cat-file', '-p', 'treerel']).split('\n')[1]).toBe('type tree')
+    expect(git(drained, ['fsck'])).toBe('')
+  })
+
+  it('still records a commit for a lightweight tag on one', async () => {
+    const h = await harness()
+    expect((await h.run('tag light'))[0]).toBe(0)
+    expect(await h.run('tag -a fromlight -m x light')).toEqual([0, '', ''])
+    const drained = await h.drain()
+    expect(git(drained, ['cat-file', '-p', 'fromlight']).split('\n')[1]).toBe('type commit')
+  })
+})

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -2298,6 +2298,44 @@ describe('a switch onto a branch recording a directory', () => {
     expect((await h.ws.execute('readlink /repo/slot')).exitCode).not.toBe(0)
   })
 
+  it('replaces an ignored regular file the same way', async () => {
+    const h = await harness()
+    await write(h, '.gitignore', 'slot\n')
+    expect((await h.run('add .gitignore'))[0]).toBe(0)
+    expect((await h.run('commit -m ignore'))[0]).toBe(0)
+    expect((await h.run('switch -c other'))[0]).toBe(0)
+    await write(h, 'slot/child', 'kid\n')
+    expect((await h.run('add -f slot/child'))[0]).toBe(0)
+    expect((await h.run('commit -m child'))[0]).toBe(0)
+    expect((await h.run('switch main'))[0]).toBe(0)
+    await write(h, 'slot', 'ignored\n')
+    expect((await h.run('switch other'))[0]).toBe(0)
+    const kid = await readOptional(h.dispatch, '/repo/slot/child')
+    expect(kid === null ? '' : DEC.decode(kid)).toBe('kid\n')
+    expect((await h.run('status --short'))[1]).toBe('')
+  })
+
+  it('still refuses an untracked file standing in the way', async () => {
+    // Untracked and not ignored is the case git does refuse, with its own
+    // wording: the replacement above must not reach it.
+    const h = await harness()
+    expect((await h.run('switch -c other'))[0]).toBe(0)
+    await write(h, 'slot/child', 'kid\n')
+    expect((await h.run('add slot/child'))[0]).toBe(0)
+    expect((await h.run('commit -m child'))[0]).toBe(0)
+    expect((await h.run('switch main'))[0]).toBe(0)
+    await write(h, 'slot', 'untracked\n')
+    expect(await h.run('switch other')).toEqual([
+      1,
+      '',
+      'error: The following untracked working tree files would be overwritten by checkout:\n' +
+        '\tslot\n' +
+        'Please move or remove them before you switch branches.\nAborting\n',
+    ])
+    const kept = await readOptional(h.dispatch, '/repo/slot')
+    expect(kept === null ? '' : DEC.decode(kept)).toBe('untracked\n')
+  })
+
   it('refuses a staged file standing in the way', async () => {
     // git allows this and discards the staged addition in silence; this
     // refuses and names it. What must not happen either way is the old

--- a/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mutate.test.ts
@@ -221,6 +221,29 @@ function gitlinkIndex(repo: string, path: string): void {
   execFileSync('git', ['-C', repo, 'commit', '-q', '-m', 'gitlink'], { stdio: 'ignore' })
 }
 
+/**
+ * Write a branch whose tree records a gitlink, leaving HEAD and the index as
+ * they were.
+ *
+ * A branch switch onto a gitlink is only reachable while the current branch
+ * does not carry one, so the index is put back where it was afterwards.
+ */
+function gitlinkBranch(repo: string, branch: string, path: string): void {
+  const head = git(repo, ['rev-parse', 'HEAD']).trim()
+  execFileSync('git', [
+    '-C',
+    repo,
+    'update-index',
+    '--add',
+    '--cacheinfo',
+    `160000,${head},${path}`,
+  ])
+  const tree = git(repo, ['write-tree']).trim()
+  const commit = git(repo, ['commit-tree', tree, '-p', head, '-m', 'gitlink']).trim()
+  git(repo, ['update-ref', `refs/heads/${branch}`, commit])
+  git(repo, ['reset', '-q', '--mixed', head])
+}
+
 /** Write into the mount, which is where the verbs under test read from. */
 async function write(h: Harness, path: string, text: string): Promise<void> {
   const target = `/repo/${path}`
@@ -1755,6 +1778,45 @@ describe('a gitlink in the tree', () => {
     expect(await h.run('restore sub')).toEqual([0, '', ''])
     expect(await readOptional(h.dispatch, '/repo/sub')).toBeNull()
   })
+
+  it('keeps a child the restored source drops', async () => {
+    // The entry asks for the directory and nothing under it: git drops the
+    // child's index entry and leaves the file alone. Removing it here loses
+    // content nothing has a copy of, since the source tree never held it.
+    const h = await harness((repo) => {
+      gitlinkIndex(repo, 'sub')
+    })
+    await write(h, 'sub/child.md', 'child\n')
+    expect((await h.run('add sub/child.md'))[0]).toBe(0)
+    expect(await h.run('restore --staged --worktree sub')).toEqual([0, '', ''])
+    expect(await readOptional(h.dispatch, '/repo/sub/child.md')).not.toBeNull()
+    const drained = await h.drain()
+    expect(git(drained, ['ls-files', 'sub/child.md'])).toBe('')
+  })
+
+  it('lands over a directory holding untracked files', async () => {
+    // A gitlink asks for a directory, so the one already standing is what it
+    // asked for and nothing in it is lost. The collision check read it as a
+    // file replacing the directory and aborted a switch git takes.
+    const h = await harness((repo) => {
+      gitlinkBranch(repo, 'linked', 'sub')
+    })
+    await write(h, 'sub/keep.md', 'keep\n')
+    expect((await h.run('checkout linked'))[0]).toBe(0)
+    expect(await readOptional(h.dispatch, '/repo/sub/keep.md')).not.toBeNull()
+  })
+
+  it('still refuses an untracked file where it lands', async () => {
+    // The other half of git's rule: the directory cannot be made without
+    // deleting the file, so this one is named and refused.
+    const h = await harness((repo) => {
+      gitlinkBranch(repo, 'linked', 'sub')
+    })
+    await h.ws.execute("printf 'mine\\n' > /repo/sub")
+    const [code, , err] = await h.run('checkout linked')
+    expect(code).toBe(1)
+    expect(err).toContain('would be overwritten by checkout:\n\tsub\n')
+  })
 })
 
 describe('an ancestry suffix that is not a step', () => {
@@ -2033,6 +2095,33 @@ describe('a switch while the index is unmerged', () => {
     })
     const [code, out] = await h.run('switch -c sidebar HEAD')
     expect([code, out]).toEqual([1, 'letters.txt: needs merge\n'])
+  })
+
+  it('refuses the branch HEAD already names', async () => {
+    // The shortcut moves nothing, which is not the same as having nothing to
+    // check: git reads the index before it answers, so "Already on" cannot be
+    // read as proof the repository is in a state anything can be built on.
+    const clean = await harness()
+    expect(await clean.run('switch main')).toEqual([0, '', "Already on 'main'\n"])
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'letters.txt')
+    })
+    expect(await h.run('switch main')).toEqual([
+      1,
+      'letters.txt: needs merge\n',
+      'error: you need to resolve your current index first\n',
+    ])
+  })
+
+  it('refuses a checkout of the branch HEAD already names', async () => {
+    const h = await harness((repo) => {
+      conflictIndex(repo, 'letters.txt')
+    })
+    expect(await h.run('checkout main')).toEqual([
+      1,
+      'letters.txt: needs merge\n',
+      'error: you need to resolve your current index first\n',
+    ])
   })
 })
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
@@ -204,10 +204,18 @@ export async function check(
  * same problem one level up, since the table still points at the old prefix.
  * Neither is something the verb can repair afterwards, so both are refused
  * before anything moves.
+ *
+ * The destination is the same fault read from the other end, and it catches an
+ * ordinary file the first two questions pass: the op is bound to the backend
+ * serving the source, so a landing another mount serves is written into the
+ * source's backend at a path it does not own. The file is then hidden behind
+ * the other mount while the index names the new path, which is the same broken
+ * pair one level down.
  */
-function spanning(mounts: MountView | null, path: string): boolean {
+function spanning(mounts: MountView | null, path: string, landing: string): boolean {
   if (mounts === null) return false
-  return mounts.isRoot(path) || mounts.descendants(path).length > 0
+  if (mounts.isRoot(path) || mounts.descendants(path).length > 0) return true
+  return mounts.rootOf(path) !== mounts.rootOf(landing)
 }
 
 /**
@@ -275,7 +283,10 @@ export async function plan(
         named = clash
       }
     }
-    if (reason === null && spanning(mounts, under(location.worktree, source))) {
+    if (
+      reason === null &&
+      spanning(mounts, under(location.worktree, source), under(location.worktree, landing))
+    ) {
       // Last, after every check git itself makes, so a source git would refuse
       // anyway is refused in git's own words. `-k` skips it like any other
       // rename this source cannot survive.

--- a/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
@@ -1,0 +1,274 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { IOResult } from '../../../../io/types.ts'
+import type { LinkView, StatPath } from '../../../../ops/types.ts'
+import { FileType, type FileStat } from '../../../../types.ts'
+import { isMissingPath } from '../../../../utils/errors.ts'
+import type { CommandFnResult } from '../../../config.ts'
+import { FlagView } from '../../../spec/types.ts'
+import type { CLIInvocation } from '../../types.ts'
+import {
+  GitError,
+  MoveRefusedError,
+  MoveUsageError,
+  NotADirectoryDestinationError,
+  NoWorkspaceError,
+  RenameFailedError,
+  UnknownSwitchError,
+} from './errors.ts'
+import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
+import { removeFile, renamePath, under } from './io.ts'
+import { basename } from './path.ts'
+import { repoRelative } from './pathspec.ts'
+import { opened } from './repo.ts'
+import type { Dispatch, IndexEntry, RepoLocation } from './types.ts'
+import { checkOperands, fatal, startPoint } from './util.ts'
+import { compareCodePoints } from '../../../../utils/sort.ts'
+
+const ENC = new TextEncoder()
+
+// git's own wording for each way a source can be refused, in the shape
+// `fatal: <reason>, source=<src>, destination=<dst>`.
+const BAD_SOURCE = 'bad source'
+const INTO_ITSELF = 'can not move directory into itself'
+const DESTINATION_EXISTS = 'destination exists'
+const DESTINATION_ALREADY_EXISTS = 'destination already exists'
+const SOURCE_DIRECTORY_EMPTY = 'source directory is empty'
+const NOT_UNDER_VERSION_CONTROL = 'not under version control'
+
+/** The parsed shape of a `git mv` invocation. */
+export interface MvFlags {
+  /** `-f`, overwrite an existing destination file. */
+  readonly force: boolean
+  /** `-k`, skip a source that cannot move rather than refusing the line. */
+  readonly skip: boolean
+  /** `-n`, report what would move and move nothing. */
+  readonly dryRun: boolean
+  /** `-v`, print one line per move; implied by `-n`. */
+  readonly verbose: boolean
+}
+
+/** Read the raw mv flag kwargs into a frozen struct. */
+function parseFlags(fl: FlagView): MvFlags {
+  const dryRun = fl.asBool('dry_run')
+  return {
+    force: fl.asBool('force'),
+    skip: fl.asBool('k'),
+    dryRun,
+    verbose: fl.asBool('verbose') || dryRun,
+  }
+}
+
+/** One source and where it goes. */
+export interface Move {
+  /** Repository-relative path being moved. */
+  readonly source: string
+  /**
+   * Repository-relative path it moves to, already joined with the source's
+   * basename when the destination was a directory.
+   */
+  readonly destination: string
+  /**
+   * The tracked paths that move with it: the source itself for a file,
+   * everything under it for a directory.
+   */
+  readonly paths: readonly string[]
+  /** Whether the source is a directory. */
+  readonly directory: boolean
+}
+
+/** What one refusal check found: a reason, or the paths that move. */
+interface Verdict {
+  readonly reason: string | null
+  readonly paths: readonly string[]
+  readonly directory: boolean
+}
+
+/** What sits at a path, without following a link. */
+async function lstat(
+  statPath: StatPath,
+  links: LinkView | null,
+  path: string,
+): Promise<FileStat | null> {
+  const link = links?.statAt(path) ?? null
+  if (link !== null) return link
+  return statPath(path)
+}
+
+/** Whether a repository-relative path sits inside a directory. */
+function inside(path: string, directory: string): boolean {
+  return directory === '' || path.startsWith(`${directory}/`)
+}
+
+/** Where one tracked path lands after a move. */
+export function movedPath(move: Move, path: string): string {
+  if (!move.directory) return move.destination
+  return `${move.destination}${path.slice(move.source.length)}`
+}
+
+/** Whether one source can move, in git's own order of refusals. */
+export async function check(
+  statPath: StatPath,
+  links: LinkView | null,
+  location: RepoLocation,
+  source: string,
+  destination: string,
+  tracked: ReadonlySet<string>,
+  force: boolean,
+): Promise<Verdict> {
+  const info = await lstat(statPath, links, under(location.worktree, source))
+  if (info === null) return { reason: BAD_SOURCE, paths: [], directory: false }
+  if (destination === source || destination.startsWith(`${source}/`)) {
+    return { reason: INTO_ITSELF, paths: [], directory: false }
+  }
+  const target = await lstat(statPath, links, under(location.worktree, destination))
+  if (info.type === FileType.DIRECTORY) {
+    if (target !== null) return { reason: DESTINATION_ALREADY_EXISTS, paths: [], directory: true }
+    const held = [...tracked].filter((path) => inside(path, source)).sort(compareCodePoints)
+    if (held.length === 0) return { reason: SOURCE_DIRECTORY_EMPTY, paths: [], directory: true }
+    return { reason: null, paths: held, directory: true }
+  }
+  if (!tracked.has(source))
+    return { reason: NOT_UNDER_VERSION_CONTROL, paths: [], directory: false }
+  if (target !== null && (!force || target.type === FileType.DIRECTORY)) {
+    return { reason: DESTINATION_EXISTS, paths: [], directory: false }
+  }
+  return { reason: null, paths: [source], directory: false }
+}
+
+/**
+ * Decide every move before making any, which is git's order too.
+ *
+ * The last operand is the destination. With several sources it has to be a
+ * directory that exists; with one, an existing directory takes the source
+ * under its own name and anything else is the new name.
+ */
+export async function plan(
+  statPath: StatPath,
+  links: LinkView | null,
+  location: RepoLocation,
+  start: string,
+  operands: readonly string[],
+  tracked: ReadonlySet<string>,
+  flags: MvFlags,
+): Promise<Move[]> {
+  const destination = repoRelative(location, start, operands[operands.length - 1] ?? '')
+  const target = await lstat(statPath, links, under(location.worktree, destination))
+  const into = destination === '' || target?.type === FileType.DIRECTORY
+  if (operands.length > 2 && !into) throw new NotADirectoryDestinationError(destination)
+  const moves: Move[] = []
+  for (const operand of operands.slice(0, -1)) {
+    const source = repoRelative(location, start, operand)
+    const landing = into
+      ? destination === ''
+        ? basename(source)
+        : `${destination}/${basename(source)}`
+      : destination
+    const verdict = await check(statPath, links, location, source, landing, tracked, flags.force)
+    if (verdict.reason !== null) {
+      if (flags.skip) continue
+      throw new MoveRefusedError(verdict.reason, source, landing)
+    }
+    moves.push({ source, destination: landing, paths: verdict.paths, directory: verdict.directory })
+  }
+  return moves
+}
+
+/**
+ * Make one move in the working tree.
+ *
+ * The mount's own rename, so a directory carries its untracked files along.
+ * Under `-f` a file already at the destination goes first, since not every
+ * mount renames over one.
+ */
+async function apply(
+  dispatch: Dispatch,
+  location: RepoLocation,
+  move: Move,
+  force: boolean,
+): Promise<void> {
+  const source = under(location.worktree, move.source)
+  const destination = under(location.worktree, move.destination)
+  if (force && !move.directory) await removeFile(dispatch, destination)
+  try {
+    await renamePath(dispatch, source, destination)
+  } catch (err) {
+    if (isMissingPath(err)) throw new RenameFailedError(move.source)
+    throw err
+  }
+}
+
+/**
+ * Move or rename a file or directory, and stage the move.
+ *
+ * The index entries are re-keyed with their blob ids and modes untouched, which
+ * is what lets `status` read the result as a rename rather than a delete beside
+ * an add.
+ */
+export async function mv(inv: CLIInvocation): Promise<CommandFnResult> {
+  const doors = inv.doors ?? {}
+  const texts = [...inv.texts]
+  const fl = new FlagView(inv.flags)
+  const lines: string[] = []
+  try {
+    const dispatch = doors.dispatch
+    const statPath = doors.statPath
+    if (statPath === undefined || dispatch === undefined) {
+      throw new NoWorkspaceError()
+    }
+    checkOperands(texts, UnknownSwitchError)
+    const flags = parseFlags(fl)
+    if (texts.length < 2) throw new MoveUsageError()
+    const repo = await opened(fl, doors)
+    const state = await readIndex(repo, dispatch)
+    const tracked = new Set(state.entries.keys())
+    const moves = await plan(
+      statPath,
+      doors.ns?.links ?? null,
+      repo.location,
+      startPoint(fl),
+      texts,
+      tracked,
+      flags,
+    )
+    if (flags.dryRun) {
+      for (const move of moves) {
+        lines.push(`Checking rename of '${move.source}' to '${move.destination}'`)
+      }
+    }
+    if (flags.verbose) {
+      for (const move of moves) lines.push(`Renaming ${move.source} to ${move.destination}`)
+    }
+    if (!flags.dryRun) {
+      const staged = new Map<string, StagedEntry>()
+      const removed: string[] = []
+      for (const move of moves) {
+        await apply(dispatch, repo.location, move, flags.force)
+        for (const path of move.paths) {
+          const entry: IndexEntry | undefined = state.entries.get(path)
+          if (entry === undefined) continue
+          removed.push(path)
+          staged.set(movedPath(move, path), { oid: entry.oid, mode: entry.mode, size: entry.size })
+        }
+      }
+      await updateIndex(repo, staged, removed)
+    }
+  } catch (err) {
+    if (err instanceof GitError) return fatal(err)
+    throw err
+  }
+  if (lines.length === 0) return [null, new IOResult()]
+  return [ENC.encode(lines.map((line) => `${line}\n`).join('')), new IOResult()]
+}

--- a/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
@@ -21,6 +21,7 @@ import { FlagView } from '../../../spec/types.ts'
 import type { CLIInvocation } from '../../types.ts'
 import {
   GitError,
+  MoveOverlapError,
   MoveRefusedError,
   MoveUsageError,
   NotADirectoryDestinationError,
@@ -145,6 +146,26 @@ export function clashing(move: Move, claimed: ReadonlySet<string>): [string, str
   for (const path of move.paths) {
     const landing = movedPath(move, path)
     if (claimed.has(landing)) return [path, landing]
+  }
+  return null
+}
+
+/**
+ * The first source that sits inside another source in the same line.
+ *
+ * git reads this off the whole line once every source has passed its own
+ * checks, which is why a source with a fault of its own is still refused for
+ * that fault first, and why `-k` skipping a source takes it out of this
+ * comparison too. The pair reported is the first directory source in operand
+ * order and the first source under it, named child first whatever order the
+ * line put them in.
+ */
+export function overlapping(moves: readonly Move[]): [string, string] | null {
+  for (const move of moves) {
+    if (!move.directory) continue
+    for (const other of moves) {
+      if (inside(other.source, move.source)) return [other.source, move.source]
+    }
   }
   return null
 }
@@ -300,6 +321,14 @@ export async function plan(
     for (const path of move.paths) claimed.add(movedPath(move, path))
     moves.push(move)
   }
+  // After the per-source loop rather than inside it, which is git's order and
+  // observable twice over: a source with a fault of its own outranks this, and
+  // so does a same-target collision anywhere on the line. `-k` does not reach
+  // it, since an overlap is not a rename this source could survive being
+  // skipped for: moving the directory first is what makes the other source
+  // disappear.
+  const overlap = overlapping(moves)
+  if (overlap !== null) throw new MoveOverlapError(overlap[0], overlap[1])
   return moves
 }
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
@@ -48,6 +48,7 @@ const DESTINATION_ALREADY_EXISTS = 'destination already exists'
 const SOURCE_DIRECTORY_EMPTY = 'source directory is empty'
 const NOT_UNDER_VERSION_CONTROL = 'not under version control'
 const MULTIPLE_SOURCES = 'multiple sources for the same target'
+const CONFLICTED = 'conflicted'
 
 /** The parsed shape of a `git mv` invocation. */
 export interface MvFlags {
@@ -120,6 +121,20 @@ export function movedPath(move: Move, path: string): string {
 }
 
 /**
+ * The first path in a move that the index left unmerged.
+ *
+ * Named the way the collision is named, by the path itself rather than by the
+ * operand that carried it, which is what git reports for a directory holding
+ * one.
+ */
+export function conflicting(move: Move, conflicted: ReadonlySet<string>): [string, string] | null {
+  for (const path of move.paths) {
+    if (conflicted.has(path)) return [path, movedPath(move, path)]
+  }
+  return null
+}
+
+/**
  * The first path in a move that lands where an earlier one already does.
  *
  * Landings are compared one tracked path at a time rather than one operand at a
@@ -135,7 +150,14 @@ export function clashing(move: Move, claimed: ReadonlySet<string>): [string, str
   return null
 }
 
-/** Whether one source can move, in git's own order of refusals. */
+/**
+ * Whether one source can move, in git's own order of refusals.
+ *
+ * The index is read before the destination is looked at, which is git's order
+ * and observable: a conflicted source is refused as conflicted even when the
+ * destination is occupied, and a directory holding an unmerged path is refused
+ * for that rather than for a destination that already exists.
+ */
 export async function check(
   statPath: StatPath,
   links: LinkView | null,
@@ -143,6 +165,7 @@ export async function check(
   source: string,
   destination: string,
   tracked: ReadonlySet<string>,
+  conflicted: ReadonlySet<string>,
   force: boolean,
 ): Promise<Verdict> {
   const info = await lstat(statPath, links, under(location.worktree, source))
@@ -150,15 +173,22 @@ export async function check(
   if (destination === source || destination.startsWith(`${source}/`)) {
     return { reason: INTO_ITSELF, paths: [], directory: false }
   }
-  const target = await lstat(statPath, links, under(location.worktree, destination))
+  const landing = under(location.worktree, destination)
   if (info.type === FileType.DIRECTORY) {
-    if (target !== null) return { reason: DESTINATION_ALREADY_EXISTS, paths: [], directory: true }
     const held = [...tracked].filter((path) => inside(path, source)).sort(compareCodePoints)
+    if (held.some((path) => conflicted.has(path))) {
+      return { reason: CONFLICTED, paths: held, directory: true }
+    }
+    if ((await lstat(statPath, links, landing)) !== null) {
+      return { reason: DESTINATION_ALREADY_EXISTS, paths: [], directory: true }
+    }
     if (held.length === 0) return { reason: SOURCE_DIRECTORY_EMPTY, paths: [], directory: true }
     return { reason: null, paths: held, directory: true }
   }
   if (!tracked.has(source))
     return { reason: NOT_UNDER_VERSION_CONTROL, paths: [], directory: false }
+  if (conflicted.has(source)) return { reason: CONFLICTED, paths: [source], directory: false }
+  const target = await lstat(statPath, links, landing)
   if (target !== null && (!force || target.type === FileType.DIRECTORY)) {
     return { reason: DESTINATION_EXISTS, paths: [], directory: false }
   }
@@ -179,6 +209,7 @@ export async function plan(
   start: string,
   operands: readonly string[],
   tracked: ReadonlySet<string>,
+  conflicted: ReadonlySet<string>,
   flags: MvFlags,
 ): Promise<Move[]> {
   const destination = repoRelative(location, start, operands[operands.length - 1] ?? '')
@@ -194,7 +225,16 @@ export async function plan(
         ? basename(source)
         : `${destination}/${basename(source)}`
       : destination
-    const verdict = await check(statPath, links, location, source, landing, tracked, flags.force)
+    const verdict = await check(
+      statPath,
+      links,
+      location,
+      source,
+      landing,
+      tracked,
+      conflicted,
+      flags.force,
+    )
     const move: Move = {
       source,
       destination: landing,
@@ -203,6 +243,12 @@ export async function plan(
     }
     let reason = verdict.reason
     let named: [string, string] = [source, landing]
+    if (reason === CONFLICTED) {
+      // git names the unmerged path, which for a directory is one of the paths
+      // inside rather than the operand.
+      const found = conflicting(move, conflicted)
+      if (found !== null) named = found
+    }
     if (reason === null) {
       // Last of the per-source refusals, which is git's order: a source with a
       // fault of its own is refused for that fault even when it also collides
@@ -270,7 +316,11 @@ export async function mv(inv: CLIInvocation): Promise<CommandFnResult> {
     if (texts.length < 2) throw new MoveUsageError()
     const repo = await opened(fl, doors)
     const state = await readIndex(repo, dispatch)
-    const tracked = new Set(state.entries.keys())
+    const conflicted = new Set(state.conflicts.keys())
+    // An unmerged path holds no ordinary entry, so a tracked set built from the
+    // entries alone would call it untracked and let a directory holding one
+    // move with its stages left behind.
+    const tracked = new Set([...state.entries.keys(), ...conflicted])
     const moves = await plan(
       statPath,
       doors.ns?.links ?? null,
@@ -278,6 +328,7 @@ export async function mv(inv: CLIInvocation): Promise<CommandFnResult> {
       startPoint(fl),
       texts,
       tracked,
+      conflicted,
       flags,
     )
     if (flags.dryRun) {

--- a/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
@@ -13,7 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { IOResult } from '../../../../io/types.ts'
-import type { LinkView, StatPath } from '../../../../ops/types.ts'
+import type { LinkView, MountView, StatPath } from '../../../../ops/types.ts'
 import { FileType, type FileStat } from '../../../../types.ts'
 import { isMissingPath } from '../../../../utils/errors.ts'
 import type { CommandFnResult } from '../../../config.ts'
@@ -31,10 +31,10 @@ import {
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
 import { removeFile, renamePath, under } from './io.ts'
 import { basename } from './path.ts'
-import { repoRelative } from './pathspec.ts'
+import { repoRelative, under as inside } from './pathspec.ts'
 import { opened } from './repo.ts'
 import type { Dispatch, IndexEntry, RepoLocation } from './types.ts'
-import { checkOperands, fatal, startPoint } from './util.ts'
+import { checkOperands, escaped, fatal, startPoint } from './util.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
 const ENC = new TextEncoder()
@@ -49,6 +49,10 @@ const SOURCE_DIRECTORY_EMPTY = 'source directory is empty'
 const NOT_UNDER_VERSION_CONTROL = 'not under version control'
 const MULTIPLE_SOURCES = 'multiple sources for the same target'
 const CONFLICTED = 'conflicted'
+// Not one of git's, because git has no concept to word: a mount is mirage's own
+// boundary, so the refusal borrows the strerror the kernel gives for a rename it
+// will not perform.
+const BUSY = 'Device or resource busy'
 
 /** The parsed shape of a `git mv` invocation. */
 export interface MvFlags {
@@ -107,11 +111,6 @@ async function lstat(
   const link = links?.statAt(path) ?? null
   if (link !== null) return link
   return statPath(path)
-}
-
-/** Whether a repository-relative path sits inside a directory. */
-function inside(path: string, directory: string): boolean {
-  return directory === '' || path.startsWith(`${directory}/`)
 }
 
 /** Where one tracked path lands after a move. */
@@ -196,6 +195,22 @@ export async function check(
 }
 
 /**
+ * Whether renaming a path would leave a mount behind.
+ *
+ * A mount nested in the repository is served by another resource, and the
+ * rename op reaches only the backend holding the parent path: that backend
+ * cannot see the child's keys, so it moves everything except them and the index
+ * is then re-keyed onto files that never moved. The mount root itself is the
+ * same problem one level up, since the table still points at the old prefix.
+ * Neither is something the verb can repair afterwards, so both are refused
+ * before anything moves.
+ */
+function spanning(mounts: MountView | null, path: string): boolean {
+  if (mounts === null) return false
+  return mounts.isRoot(path) || mounts.descendants(path).length > 0
+}
+
+/**
  * Decide every move before making any, which is git's order too.
  *
  * The last operand is the destination. With several sources it has to be a
@@ -205,6 +220,7 @@ export async function check(
 export async function plan(
   statPath: StatPath,
   links: LinkView | null,
+  mounts: MountView | null,
   location: RepoLocation,
   start: string,
   operands: readonly string[],
@@ -259,6 +275,13 @@ export async function plan(
         named = clash
       }
     }
+    if (reason === null && spanning(mounts, under(location.worktree, source))) {
+      // Last, after every check git itself makes, so a source git would refuse
+      // anyway is refused in git's own words. `-k` skips it like any other
+      // rename this source cannot survive.
+      if (flags.skip) continue
+      throw new RenameFailedError(source, BUSY)
+    }
     if (reason !== null) {
       if (flags.skip) continue
       throw new MoveRefusedError(reason, named[0], named[1])
@@ -311,7 +334,7 @@ export async function mv(inv: CLIInvocation): Promise<CommandFnResult> {
     if (statPath === undefined || dispatch === undefined) {
       throw new NoWorkspaceError()
     }
-    checkOperands(texts, UnknownSwitchError)
+    checkOperands(texts, UnknownSwitchError, escaped(inv.argv))
     const flags = parseFlags(fl)
     if (texts.length < 2) throw new MoveUsageError()
     const repo = await opened(fl, doors)
@@ -324,6 +347,7 @@ export async function mv(inv: CLIInvocation): Promise<CommandFnResult> {
     const moves = await plan(
       statPath,
       doors.ns?.links ?? null,
+      doors.ns?.mounts ?? null,
       repo.location,
       startPoint(fl),
       texts,

--- a/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/mv.ts
@@ -47,6 +47,7 @@ const DESTINATION_EXISTS = 'destination exists'
 const DESTINATION_ALREADY_EXISTS = 'destination already exists'
 const SOURCE_DIRECTORY_EMPTY = 'source directory is empty'
 const NOT_UNDER_VERSION_CONTROL = 'not under version control'
+const MULTIPLE_SOURCES = 'multiple sources for the same target'
 
 /** The parsed shape of a `git mv` invocation. */
 export interface MvFlags {
@@ -118,6 +119,22 @@ export function movedPath(move: Move, path: string): string {
   return `${move.destination}${path.slice(move.source.length)}`
 }
 
+/**
+ * The first path in a move that lands where an earlier one already does.
+ *
+ * Landings are compared one tracked path at a time rather than one operand at a
+ * time, because a directory operand moves every path under it and two
+ * directories sharing a child name collide there and nowhere else. git reports
+ * that collision by the colliding path too, not by the operand that carried it.
+ */
+export function clashing(move: Move, claimed: ReadonlySet<string>): [string, string] | null {
+  for (const path of move.paths) {
+    const landing = movedPath(move, path)
+    if (claimed.has(landing)) return [path, landing]
+  }
+  return null
+}
+
 /** Whether one source can move, in git's own order of refusals. */
 export async function check(
   statPath: StatPath,
@@ -169,6 +186,7 @@ export async function plan(
   const into = destination === '' || target?.type === FileType.DIRECTORY
   if (operands.length > 2 && !into) throw new NotADirectoryDestinationError(destination)
   const moves: Move[] = []
+  const claimed = new Set<string>()
   for (const operand of operands.slice(0, -1)) {
     const source = repoRelative(location, start, operand)
     const landing = into
@@ -177,11 +195,30 @@ export async function plan(
         : `${destination}/${basename(source)}`
       : destination
     const verdict = await check(statPath, links, location, source, landing, tracked, flags.force)
-    if (verdict.reason !== null) {
-      if (flags.skip) continue
-      throw new MoveRefusedError(verdict.reason, source, landing)
+    const move: Move = {
+      source,
+      destination: landing,
+      paths: verdict.paths,
+      directory: verdict.directory,
     }
-    moves.push({ source, destination: landing, paths: verdict.paths, directory: verdict.directory })
+    let reason = verdict.reason
+    let named: [string, string] = [source, landing]
+    if (reason === null) {
+      // Last of the per-source refusals, which is git's order: a source with a
+      // fault of its own is refused for that fault even when it also collides
+      // with an earlier one.
+      const clash = clashing(move, claimed)
+      if (clash !== null) {
+        reason = MULTIPLE_SOURCES
+        named = clash
+      }
+    }
+    if (reason !== null) {
+      if (flags.skip) continue
+      throw new MoveRefusedError(reason, named[0], named[1])
+    }
+    for (const path of move.paths) claimed.add(movedPath(move, path))
+    moves.push(move)
   }
   return moves
 }

--- a/typescript/packages/core/src/commands/cli/builtin/git/pathspec.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/pathspec.ts
@@ -59,18 +59,24 @@ export function repoRelative(location: RepoLocation, start: string, operand: str
  * @param path repository-relative path
  * @param directory repository-relative directory
  */
-function under(path: string, directory: string): boolean {
+export function under(path: string, directory: string): boolean {
   return directory === '' || path.startsWith(`${directory}/`)
 }
 
 /**
- * Every path a single operand selects: itself, or a whole subtree.
+ * Every path a single operand selects: itself and its whole subtree.
+ *
+ * Both, not one or the other. A pathspec matches a path that equals it
+ * and a path it is a leading directory of, and the two are not exclusive
+ * as soon as the candidates come from more than one tree: restoring
+ * `slot` where the index holds the file `slot` and the source holds
+ * `slot/child` has to select both, or the file is deleted and the
+ * directory never written. git 2.50.1 replaces one with the other in
+ * either direction.
  *
  * @param paths the candidate paths, repository-relative
  * @param target the operand, repository-relative
  */
 export function matched(paths: Iterable<string>, target: string): Set<string> {
-  const all = [...paths]
-  if (all.includes(target)) return new Set([target])
-  return new Set(all.filter((path) => under(path, target)))
+  return new Set([...paths].filter((path) => path === target || under(path, target)))
 }

--- a/typescript/packages/core/src/commands/cli/builtin/git/refs.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/refs.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { compareCodePoints } from '../../../../utils/sort.ts'
 import { basename } from './path.ts'
 import {
   isDirectory,
@@ -223,6 +224,35 @@ export const TAG_PREFIX = 'refs/tags/'
 // revision, and the backslash.
 const FORBIDDEN_IN_REF = new Set([' ', '~', '^', ':', '?', '*', '[', '\\'])
 const LOCK_SUFFIX = '.lock'
+
+/**
+ * The existing ref that stops a new one from being written.
+ *
+ * A ref is a path, so two of them cannot coexist when one spells a directory
+ * the other spells a file: with `refs/tags/foo` already there,
+ * `refs/tags/foo/bar` has no directory to live in, and with `refs/tags/foo/bar`
+ * there, `refs/tags/foo` has a directory standing on its name. git refuses both
+ * and names the ref already written; a repository can only ever hold one of the
+ * two shapes, so the two searches cannot both answer.
+ *
+ * Nothing below git's own storage can be relied on to say so. A disk mount
+ * raises whatever its host filesystem raises, which reaches the user as neither
+ * git's wording nor git's exit code, and a prefix store takes both keys happily
+ * and leaves a ref the loose-ref walk cannot find.
+ *
+ * @param known every ref the repository holds
+ * @param ref the full ref name about to be written
+ */
+export function blockingRef(known: ReadonlySet<string>, ref: string): string | null {
+  const parts = ref.split('/')
+  for (let depth = 1; depth < parts.length; depth += 1) {
+    const above = parts.slice(0, depth).join('/')
+    if (known.has(above)) return above
+  }
+  const below = `${ref}/`
+  const found = [...known].filter((name) => name.startsWith(below)).sort(compareCodePoints)
+  return found[0] ?? null
+}
 
 /**
  * Whether a name passes git's ref rules (`git check-ref-format`).

--- a/typescript/packages/core/src/commands/cli/builtin/git/refs.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/refs.ts
@@ -178,3 +178,34 @@ export async function loadRefs(
   else if (head.commit !== null) refs.set(HEAD_FILE, head.commit)
   return refs
 }
+
+export const TAG_PREFIX = 'refs/tags/'
+
+// Every character git forbids anywhere in a ref name, on top of the control
+// characters: the shell metacharacters that would make a name unusable as a
+// revision, and the backslash.
+const FORBIDDEN_IN_REF = new Set([' ', '~', '^', ':', '?', '*', '[', '\\'])
+const LOCK_SUFFIX = '.lock'
+
+/**
+ * Whether a name passes git's ref rules (`git check-ref-format`).
+ *
+ * The rules, in git's own order: no component may start with `.` or end with
+ * `.lock`; `..` may not appear; no control character, space or shell
+ * metacharacter; no leading, trailing or doubled `/`; no trailing `.`; and no
+ * `@{`. Empty is refused too. A bare `@` is refused only as a whole ref, and a
+ * name here always sits below `refs/`, so it passes. Pinned against git 2.50.1.
+ *
+ * @param name the name below `refs/heads/` or `refs/tags/`
+ */
+export function validRefName(name: string): boolean {
+  if (name === '' || name.startsWith('/') || name.endsWith('/')) return false
+  if (name.includes('//') || name.includes('..') || name.includes('@{') || name.endsWith('.')) {
+    return false
+  }
+  for (const ch of name) {
+    const code = ch.codePointAt(0) ?? 0
+    if (code < 0x20 || code === 0x7f || FORBIDDEN_IN_REF.has(ch)) return false
+  }
+  return name.split('/').every((part) => !part.startsWith('.') && !part.endsWith(LOCK_SUFFIX))
+}

--- a/typescript/packages/core/src/commands/cli/builtin/git/refs.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/refs.ts
@@ -99,14 +99,51 @@ export async function writeRef(
 }
 
 /**
- * Remove a loose ref file.
+ * `packed-refs` with one ref's lines removed, null if it held none.
  *
- * Only the loose copy is removed. A ref that also sits in `packed-refs` would
- * come back, which is a real gap rather than a silent one: `branch -d` refuses
- * unless the loose file is what actually holds the branch.
+ * A packed ref is two lines rather than one when it is an annotated tag: the tag
+ * object's own id, then a `^` line holding the commit it peels to. The peeled
+ * line belongs to the ref above it, so dropping a ref drops the `^` line that
+ * follows it and nothing else.
+ */
+export function withoutPacked(text: string, ref: string): string | null {
+  const kept: string[] = []
+  let dropped = false
+  let found = false
+  for (const line of text.split('\n')) {
+    if (line.startsWith('^')) {
+      if (!dropped) kept.push(line)
+      continue
+    }
+    dropped = false
+    if (line !== '' && !line.startsWith('#')) {
+      const space = line.indexOf(' ')
+      if (space !== -1 && line.slice(space + 1).trim() === ref) {
+        dropped = true
+        found = true
+        continue
+      }
+    }
+    kept.push(line)
+  }
+  return found ? kept.join('\n') : null
+}
+
+/**
+ * Remove a ref, loose copy and packed copy alike.
+ *
+ * Both are removed because either alone can be what holds the ref, and removing
+ * only the loose one would report a deletion the next read undoes: after
+ * `git pack-refs` a ref exists nowhere else, and a force-updated one exists in
+ * both, where dropping the loose file would resurrect the older packed value.
  */
 export async function deleteRef(dispatch: Dispatch, commondir: string, ref: string): Promise<void> {
   await removeFile(dispatch, under(commondir, ref))
+  const path = under(commondir, PACKED_REFS)
+  const data = await readOptional(dispatch, path)
+  if (data === null) return
+  const rewritten = withoutPacked(DEC.decode(data), ref)
+  if (rewritten !== null) await writeFile(dispatch, path, ENC.encode(rewritten))
 }
 
 /** Point HEAD at a branch, symbolically. */

--- a/typescript/packages/core/src/commands/cli/builtin/git/reset.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/reset.ts
@@ -29,7 +29,7 @@ import { matched, repoRelative } from './pathspec.ts'
 import { opened, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
 import type { TreeEntry } from './tree.ts'
-import { checkOperands, fatal, startPoint } from './util.ts'
+import { checkOperands, escaped, fatal, startPoint } from './util.ts'
 import { scan, UNTRACKED_NO } from './worktree.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
@@ -87,7 +87,7 @@ export async function reset(inv: CLIInvocation): Promise<CommandFnResult> {
     if (statPath === undefined || dispatch === undefined) {
       throw new NoWorkspaceError()
     }
-    checkOperands(texts, UnknownSwitchError)
+    checkOperands(texts, UnknownSwitchError, escaped(inv.argv))
     const repo = await opened(fl, doors)
     const state = await readIndex(repo, dispatch)
     const tree = (await headEntries(repo)) ?? new Map<string, TreeEntry>()

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -20,7 +20,7 @@ import type { CommandFnResult } from '../../../config.ts'
 import { FlagView } from '../../../spec/types.ts'
 import type { CLIInvocation } from '../../types.ts'
 import { headEntries } from './changes.ts'
-import { HEAD } from './constants.ts'
+import { GITLINK_MODE, HEAD } from './constants.ts'
 import {
   GitError,
   NoRestorePathsError,
@@ -34,6 +34,7 @@ import {
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
 import {
   blockingAncestor,
+  keepGitlink,
   refuseReplacedMounts,
   removeEmptyParents,
   removeFile,
@@ -177,8 +178,13 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
     // stages first and restores after, so a refusal in the working-tree pass
     // would leave the index moved and the tree exactly as it was, which is the
     // one outcome this verb has no wording for.
+    // A gitlink is not written into the working tree at all, so it is neither
+    // read as a blob nor allowed to clear what stands at the name; keepGitlink
+    // is the whole of what the entry asks for, and the preflight has nothing
+    // to say about it either.
+    const replacing = present.filter((name) => tree.get(name)?.mode !== GITLINK_MODE)
     if (flags.worktree) {
-      await refuseReplacedMounts(statPath, repo.location.worktree, present, links, mounts)
+      await refuseReplacedMounts(statPath, repo.location.worktree, replacing, links, mounts)
     }
     if (flags.staged) {
       const staged = new Map<string, StagedEntry>()
@@ -210,8 +216,12 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
       for (const name of present) {
         const entry = tree.get(name)
         if (entry === undefined) continue
-        const { blob } = await git.readBlob({ ...repoArgs(repo), oid: entry.oid })
         const where = under(repo.location.worktree, name)
+        if (entry.mode === GITLINK_MODE) {
+          await keepGitlink(dispatch, statPath, where, links)
+          continue
+        }
+        const { blob } = await git.readBlob({ ...repoArgs(repo), oid: entry.oid })
         // The write direction takes the same component the other way round:
         // the entry needs a directory where it stands, so git replaces it with
         // one rather than writing through it. A link's target tree is left

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -15,6 +15,7 @@
 import git from 'isomorphic-git'
 
 import { IOResult } from '../../../../io/types.ts'
+import { FileType } from '../../../../types.ts'
 import type { CommandFnResult } from '../../../config.ts'
 import { FlagView } from '../../../spec/types.ts'
 import type { CLIInvocation } from '../../types.ts'
@@ -26,16 +27,17 @@ import {
   UnknownPathspecError,
   UnknownSwitchError,
   UnmergedPathError,
+  UnreadableTreeError,
   UnresolvableSourceError,
 } from './errors.ts'
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
-import { removeEmptyParents, removeFile, restoreEntry, under } from './io.ts'
+import { removeEmptyParents, removeFile, removeTree, restoreEntry, under } from './io.ts'
 import { matched, repoRelative } from './pathspec.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { restored } from './reset.ts'
-import { resolveCommit } from './revparse.ts'
+import { COMMIT, TREE, resolveObject } from './revparse.ts'
 import { commitEntries, treeEntries, type TreeEntry } from './tree.ts'
-import type { IndexEntry } from './types.ts'
+import type { GitObject, IndexEntry } from './types.ts'
 import { checkOperands, escaped, fatal, startPoint } from './util.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
@@ -79,19 +81,16 @@ export function indexTree(entries: ReadonlyMap<string, IndexEntry>): Map<string,
  * reading resolves is unresolvable.
  */
 export async function sourceTree(repo: Repo, revision: string): Promise<Map<string, TreeEntry>> {
+  let found: GitObject
   try {
-    return await commitEntries(repo, await resolveCommit(repo, revision))
-  } catch {
-    // Not a commit-ish. The id is read as a tree before the revision is called
-    // unresolvable, never instead of reporting it: the throw below is what a
-    // spelling neither reading accepts still gets.
-  }
-  try {
-    const oid = await git.expandOid({ ...repoArgs(repo), oid: revision })
-    return await treeEntries(repo, oid)
+    found = await resolveObject(repo, revision)
   } catch {
     throw new UnresolvableSourceError(revision)
   }
+  // git's one implicit peel: a commit stands for its tree here.
+  if (found.type === COMMIT) return await commitEntries(repo, found.oid)
+  if (found.type !== TREE) throw new UnreadableTreeError(found.oid)
+  return await treeEntries(repo, found.oid)
 }
 
 /**
@@ -171,17 +170,25 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
         await removeFile(dispatch, path)
         await removeEmptyParents(dispatch, path, repo.location.worktree)
       }
+      const links = doors.ns?.links ?? null
       for (const name of present) {
         const entry = tree.get(name)
         if (entry === undefined) continue
         const { blob } = await git.readBlob({ ...repoArgs(repo), oid: entry.oid })
-        await restoreEntry(
-          dispatch,
-          under(repo.location.worktree, name),
-          entry.mode,
-          blob,
-          doors.ns?.links ?? null,
-        )
+        const where = under(repo.location.worktree, name)
+        // A directory can still stand here after the loop above: it removed
+        // the tracked children, but an untracked one keeps it alive and the
+        // write would fail on it with the index already updated. git replaces
+        // the whole directory, untracked children included. A link is left to
+        // restoreEntry, which retargets it; following one to a directory here
+        // would delete a tree no branch named.
+        if ((links?.statAt(where) ?? null) === null) {
+          const info = await statPath(where)
+          if (info !== null && info.type === FileType.DIRECTORY) {
+            await removeTree(dispatch, where)
+          }
+        }
+        await restoreEntry(dispatch, where, entry.mode, blob, links)
       }
     }
   } catch (err) {

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -34,6 +34,7 @@ import {
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
 import {
   blockingAncestor,
+  dropGitlink,
   keepGitlink,
   refuseReplacedMounts,
   removeEmptyParents,
@@ -66,6 +67,8 @@ interface RestoreFlags {
    */
   readonly source: string | undefined
 }
+
+const ENC = new TextEncoder()
 
 /** Read the raw restore flag kwargs into a frozen struct. */
 function parseFlags(fl: FlagView): RestoreFlags {
@@ -121,6 +124,7 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
   const doors = inv.doors ?? {}
   const texts = [...inv.texts]
   const fl = new FlagView(inv.flags)
+  const notes: string[] = []
   try {
     const dispatch = doors.dispatch
     const statPath = doors.statPath
@@ -218,7 +222,16 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
         // this.
         const blocked = await blockingAncestor(statPath, repo.location.worktree, name, links)
         if (blocked !== null) continue
-        await removeFile(dispatch, path)
+        // What stands at a gitlink is a directory, so taking it away is an
+        // rmdir that may legitimately fail: unlink died on it with the index
+        // already written, which is the half-restore this verb has no wording
+        // for.
+        if (held.get(name)?.mode === GITLINK_MODE) {
+          const warned = await dropGitlink(dispatch, statPath, path, name, links)
+          if (warned !== null) notes.push(warned)
+        } else {
+          await removeFile(dispatch, path)
+        }
         await removeEmptyParents(dispatch, path, repo.location.worktree, mounts)
       }
       for (const name of present) {
@@ -257,5 +270,6 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
     if (err instanceof GitError) return fatal(err)
     throw err
   }
-  return [null, new IOResult()]
+  const told = notes.join('')
+  return [null, told === '' ? new IOResult() : new IOResult({ stderr: ENC.encode(told) })]
 }

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -186,6 +186,7 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
       // where the directory still sits. Nothing is read back from the
       // working tree, so emptying it first is free.
       const links = doors.ns?.links ?? null
+      const mounts = doors.ns?.mounts ?? null
       for (const name of absent) {
         const path = under(repo.location.worktree, name)
         // A component above the entry that is not a directory is not a way
@@ -196,7 +197,7 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
         const blocked = await blockingAncestor(statPath, repo.location.worktree, name, links)
         if (blocked !== null) continue
         await removeFile(dispatch, path)
-        await removeEmptyParents(dispatch, path, repo.location.worktree)
+        await removeEmptyParents(dispatch, path, repo.location.worktree, mounts)
       }
       for (const name of present) {
         const entry = tree.get(name)
@@ -220,7 +221,7 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
         if ((links?.statAt(where) ?? null) === null) {
           const info = await statPath(where)
           if (info !== null && info.type === FileType.DIRECTORY) {
-            await removeTree(dispatch, where, links)
+            await removeTree(dispatch, where, links, mounts)
           }
         }
         await restoreEntry(dispatch, where, entry.mode, blob, links)

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -36,10 +36,11 @@ import { removeEmptyParents, removeFile, removeTree, restoreEntry, under } from 
 import { matched, repoRelative } from './pathspec.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { restored } from './reset.ts'
-import { COMMIT, TREE, resolveObject } from './revparse.ts'
+import { COMMIT, TREE, resolveObject, unwrapped } from './revparse.ts'
 import { commitEntries, treeEntries, type TreeEntry } from './tree.ts'
 import type { GitObject, IndexEntry } from './types.ts'
 import { checkOperands, escaped, fatal, startPoint } from './util.ts'
+import type { LinkView } from '../../../../ops/types.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
 /** The parsed shape of a `git restore` invocation. */
@@ -88,10 +89,47 @@ export async function sourceTree(repo: Repo, revision: string): Promise<Map<stri
   } catch {
     throw new UnresolvableSourceError(revision)
   }
+  // A bare id names the object itself, so an annotated tag arrives as the tag
+  // rather than as what it points at. A tag is no tree-ish, and unwrapping it
+  // is what makes `--source=<tag-id>` read the same tree `--source=v1` reads.
+  found = await unwrapped(repo, found, revision)
   // git's one implicit peel: a commit stands for its tree here.
   if (found.type === COMMIT) return await commitEntries(repo, found.oid)
   if (found.type !== TREE) throw new UnreadableTreeError(found.oid)
   return await treeEntries(repo, found.oid)
+}
+
+/**
+ * The nearest directory above an entry that is really a symlink.
+ *
+ * An entry's path is only a way through the working tree while every component
+ * above it is a directory. A link standing on one is not, and neither a write
+ * nor a removal may be attempted through it: both resolve past the link and
+ * land in whatever tree it points at, damaging files no branch named while the
+ * link itself stays. git checks the leading path for exactly this and takes the
+ * two directions differently, which is what the callers do here.
+ *
+ * Exact-path link lookups cannot see this, since the link sits above the name
+ * being looked up rather than on it.
+ *
+ * @param worktree absolute virtual path of the working tree root
+ * @param name the entry, repository-relative
+ * @param links the name plane's link facts, null when no namespace is wired
+ * @returns the absolute virtual path of the nearest such link, null when every
+ *   component above the entry is a directory
+ */
+export function linkedAncestor(
+  worktree: string,
+  name: string,
+  links: LinkView | null,
+): string | null {
+  if (links === null) return null
+  let current = worktree
+  for (const part of name.split('/').slice(0, -1)) {
+    current = under(current, part)
+    if (links.statAt(current) !== null) return current
+  }
+  return null
 }
 
 /**
@@ -174,17 +212,28 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
       // file `slot` still sits, and the other direction writes the file
       // where the directory still sits. Nothing is read back from the
       // working tree, so emptying it first is free.
+      const links = doors.ns?.links ?? null
       for (const name of absent) {
         const path = under(repo.location.worktree, name)
+        // A link above the entry is not a way through to it: the unlink would
+        // resolve past the link and delete a file inside whatever it points
+        // at, which no branch named. git checks the leading path and removes
+        // nothing when it finds one, so neither does this.
+        if (linkedAncestor(repo.location.worktree, name, links) !== null) continue
         await removeFile(dispatch, path)
         await removeEmptyParents(dispatch, path, repo.location.worktree)
       }
-      const links = doors.ns?.links ?? null
       for (const name of present) {
         const entry = tree.get(name)
         if (entry === undefined) continue
         const { blob } = await git.readBlob({ ...repoArgs(repo), oid: entry.oid })
         const where = under(repo.location.worktree, name)
+        // The write direction takes the same link the other way round: the
+        // entry needs a directory where the link stands, so git replaces the
+        // link with one rather than writing through it. The tree the link
+        // pointed at is left exactly as it was.
+        const held = linkedAncestor(repo.location.worktree, name, links)
+        if (held !== null) await removeFile(dispatch, held)
         // A directory can still stand here after the loop above: it removed
         // the tracked children, but an untracked one keeps it alive and the
         // write would fail on it with the index already updated. git replaces

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -20,6 +20,7 @@ import type { CommandFnResult } from '../../../config.ts'
 import { FlagView } from '../../../spec/types.ts'
 import type { CLIInvocation } from '../../types.ts'
 import { headEntries } from './changes.ts'
+import { HEAD } from './constants.ts'
 import {
   GitError,
   NoRestorePathsError,
@@ -123,7 +124,15 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
     if (flags.source !== undefined) {
       source = await sourceTree(repo, flags.source)
     } else if (flags.staged) {
-      source = (await headEntries(repo)) ?? new Map<string, TreeEntry>()
+      // Before the first commit there is no HEAD to restore the index from, and
+      // reading that as an empty tree unstaged every selected path and reported
+      // success. git refuses the whole line instead, index untouched. The
+      // working tree restores from the index, so it is only the implicit HEAD
+      // source that has nothing to read: `--source` naming a tree still works
+      // in the same repository.
+      const found = await headEntries(repo)
+      if (found === null) throw new UnresolvableSourceError(HEAD)
+      source = found
     } else {
       source = null
     }

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -34,6 +34,7 @@ import {
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
 import {
   blockingAncestor,
+  refuseReplacedMounts,
   removeEmptyParents,
   removeFile,
   removeTree,
@@ -170,6 +171,15 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
     // simply removed.
     const unmerged = absent.filter((name) => state.conflicts.has(name))
     if (unmerged.length > 0) throw new UnmergedPathError(unmerged)
+    const links = doors.ns?.links ?? null
+    const mounts = doors.ns?.mounts ?? null
+    // Before the index is written, not at the entry that meets it: `-SW`
+    // stages first and restores after, so a refusal in the working-tree pass
+    // would leave the index moved and the tree exactly as it was, which is the
+    // one outcome this verb has no wording for.
+    if (flags.worktree) {
+      await refuseReplacedMounts(statPath, repo.location.worktree, present, links, mounts)
+    }
     if (flags.staged) {
       const staged = new Map<string, StagedEntry>()
       for (const name of present) {
@@ -185,8 +195,6 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
       // file `slot` still sits, and the other direction writes the file
       // where the directory still sits. Nothing is read back from the
       // working tree, so emptying it first is free.
-      const links = doors.ns?.links ?? null
-      const mounts = doors.ns?.mounts ?? null
       for (const name of absent) {
         const path = under(repo.location.worktree, name)
         // A component above the entry that is not a directory is not a way

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -32,7 +32,14 @@ import {
   UnresolvableSourceError,
 } from './errors.ts'
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
-import { removeEmptyParents, removeFile, removeTree, restoreEntry, under } from './io.ts'
+import {
+  blockingAncestor,
+  removeEmptyParents,
+  removeFile,
+  removeTree,
+  restoreEntry,
+  under,
+} from './io.ts'
 import { matched, repoRelative } from './pathspec.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { restored } from './reset.ts'
@@ -40,7 +47,6 @@ import { COMMIT, TREE, resolveObject, unwrapped } from './revparse.ts'
 import { commitEntries, treeEntries, type TreeEntry } from './tree.ts'
 import type { GitObject, IndexEntry } from './types.ts'
 import { checkOperands, escaped, fatal, startPoint } from './util.ts'
-import type { LinkView } from '../../../../ops/types.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
 /** The parsed shape of a `git restore` invocation. */
@@ -97,39 +103,6 @@ export async function sourceTree(repo: Repo, revision: string): Promise<Map<stri
   if (found.type === COMMIT) return await commitEntries(repo, found.oid)
   if (found.type !== TREE) throw new UnreadableTreeError(found.oid)
   return await treeEntries(repo, found.oid)
-}
-
-/**
- * The nearest directory above an entry that is really a symlink.
- *
- * An entry's path is only a way through the working tree while every component
- * above it is a directory. A link standing on one is not, and neither a write
- * nor a removal may be attempted through it: both resolve past the link and
- * land in whatever tree it points at, damaging files no branch named while the
- * link itself stays. git checks the leading path for exactly this and takes the
- * two directions differently, which is what the callers do here.
- *
- * Exact-path link lookups cannot see this, since the link sits above the name
- * being looked up rather than on it.
- *
- * @param worktree absolute virtual path of the working tree root
- * @param name the entry, repository-relative
- * @param links the name plane's link facts, null when no namespace is wired
- * @returns the absolute virtual path of the nearest such link, null when every
- *   component above the entry is a directory
- */
-export function linkedAncestor(
-  worktree: string,
-  name: string,
-  links: LinkView | null,
-): string | null {
-  if (links === null) return null
-  let current = worktree
-  for (const part of name.split('/').slice(0, -1)) {
-    current = under(current, part)
-    if (links.statAt(current) !== null) return current
-  }
-  return null
 }
 
 /**
@@ -215,11 +188,13 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
       const links = doors.ns?.links ?? null
       for (const name of absent) {
         const path = under(repo.location.worktree, name)
-        // A link above the entry is not a way through to it: the unlink would
-        // resolve past the link and delete a file inside whatever it points
-        // at, which no branch named. git checks the leading path and removes
-        // nothing when it finds one, so neither does this.
-        if (linkedAncestor(repo.location.worktree, name, links) !== null) continue
+        // A component above the entry that is not a directory is not a way
+        // through to it: the unlink would resolve past it and delete a file
+        // inside whatever it points at, which no branch named. git checks the
+        // leading path and removes nothing when it finds one, so neither does
+        // this.
+        const blocked = await blockingAncestor(statPath, repo.location.worktree, name, links)
+        if (blocked !== null) continue
         await removeFile(dispatch, path)
         await removeEmptyParents(dispatch, path, repo.location.worktree)
       }
@@ -228,12 +203,14 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
         if (entry === undefined) continue
         const { blob } = await git.readBlob({ ...repoArgs(repo), oid: entry.oid })
         const where = under(repo.location.worktree, name)
-        // The write direction takes the same link the other way round: the
-        // entry needs a directory where the link stands, so git replaces the
-        // link with one rather than writing through it. The tree the link
-        // pointed at is left exactly as it was.
-        const held = linkedAncestor(repo.location.worktree, name, links)
-        if (held !== null) await removeFile(dispatch, held)
+        // The write direction takes the same component the other way round:
+        // the entry needs a directory where it stands, so git replaces it with
+        // one rather than writing through it. A link's target tree is left
+        // exactly as it was, and an untracked file standing there is replaced
+        // in silence, which is what git's create_directories does to any
+        // leading non-directory.
+        const above = await blockingAncestor(statPath, repo.location.worktree, name, links)
+        if (above !== null) await removeFile(dispatch, above)
         // A directory can still stand here after the loop above: it removed
         // the tracked children, but an untracked one keeps it alive and the
         // write would fail on it with the index already updated. git replaces

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -25,6 +25,7 @@ import {
   NoWorkspaceError,
   UnknownPathspecError,
   UnknownSwitchError,
+  UnmergedPathError,
   UnresolvableSourceError,
 } from './errors.ts'
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
@@ -128,7 +129,12 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
       source = null
     }
     const tree = source ?? held
-    const names = new Set([...held.keys(), ...tree.keys()])
+    // The conflict stages name paths too. An unmerged path has no stage-0
+    // entry, so neither the index nor HEAD carries it and the pathspec would
+    // miss what git matches: to git it is an index entry like any other.
+    // Selecting it is what lets a source holding it put it back, stages and
+    // all, and what lets the refusal below name it when none does.
+    const names = new Set([...held.keys(), ...tree.keys(), ...state.conflicts.keys()])
     const start = startPoint(fl)
     const selected = new Set<string>()
     for (const operand of texts) {
@@ -138,6 +144,13 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
     }
     const present = [...selected].filter((name) => tree.has(name)).sort(compareCodePoints)
     const absent = [...selected].filter((name) => !tree.has(name)).sort(compareCodePoints)
+    // A selected path the source does not hold and the index still holds
+    // stages for cannot be restored either way: there is no stage-0 content to
+    // write into the working tree and no entry to stage. git names every one of
+    // them and does none of the work, where an absent path with no stages is
+    // simply removed.
+    const unmerged = absent.filter((name) => state.conflicts.has(name))
+    if (unmerged.length > 0) throw new UnmergedPathError(unmerged)
     if (flags.staged) {
       const staged = new Map<string, StagedEntry>()
       for (const name of present) {

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -30,10 +30,10 @@ import {
 import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
 import { removeEmptyParents, removeFile, restoreEntry, under } from './io.ts'
 import { matched, repoRelative } from './pathspec.ts'
-import { opened, repoArgs } from './repo.ts'
+import { opened, repoArgs, type Repo } from './repo.ts'
 import { restored } from './reset.ts'
 import { resolveCommit } from './revparse.ts'
-import { commitEntries, type TreeEntry } from './tree.ts'
+import { commitEntries, treeEntries, type TreeEntry } from './tree.ts'
 import type { IndexEntry } from './types.ts'
 import { checkOperands, fatal, startPoint } from './util.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
@@ -69,6 +69,31 @@ export function indexTree(entries: ReadonlyMap<string, IndexEntry>): Map<string,
 }
 
 /**
+ * Every path a `--source` names, commit-ish or tree-ish.
+ *
+ * git takes any tree-ish here, so a raw tree id
+ * (`--source=$(git rev-parse HEAD^{tree})`) is as good as a branch. A
+ * commit-ish is tried first because it is what the option is normally spelled
+ * with and it is the only form carrying ancestry suffixes; a revision neither
+ * reading resolves is unresolvable.
+ */
+export async function sourceTree(repo: Repo, revision: string): Promise<Map<string, TreeEntry>> {
+  try {
+    return await commitEntries(repo, await resolveCommit(repo, revision))
+  } catch {
+    // Not a commit-ish. The id is read as a tree before the revision is called
+    // unresolvable, never instead of reporting it: the throw below is what a
+    // spelling neither reading accepts still gets.
+  }
+  try {
+    const oid = await git.expandOid({ ...repoArgs(repo), oid: revision })
+    return await treeEntries(repo, oid)
+  } catch {
+    throw new UnresolvableSourceError(revision)
+  }
+}
+
+/**
  * Put paths back to what a source records.
  *
  * Two targets and one source, git's own model. `--staged` restores the index
@@ -96,13 +121,7 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
     const held = indexTree(state.entries)
     let source: Map<string, TreeEntry> | null
     if (flags.source !== undefined) {
-      let oid: string
-      try {
-        oid = await resolveCommit(repo, flags.source)
-      } catch {
-        throw new UnresolvableSourceError(flags.source)
-      }
-      source = await commitEntries(repo, oid)
+      source = await sourceTree(repo, flags.source)
     } else if (flags.staged) {
       source = (await headEntries(repo)) ?? new Map<string, TreeEntry>()
     } else {

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -35,7 +35,7 @@ import { restored } from './reset.ts'
 import { resolveCommit } from './revparse.ts'
 import { commitEntries, treeEntries, type TreeEntry } from './tree.ts'
 import type { IndexEntry } from './types.ts'
-import { checkOperands, fatal, startPoint } from './util.ts'
+import { checkOperands, escaped, fatal, startPoint } from './util.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
 /** The parsed shape of a `git restore` invocation. */
@@ -113,7 +113,7 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
     if (statPath === undefined || dispatch === undefined) {
       throw new NoWorkspaceError()
     }
-    checkOperands(texts, UnknownSwitchError)
+    checkOperands(texts, UnknownSwitchError, escaped(inv.argv))
     if (texts.length === 0) throw new NoRestorePathsError()
     const flags = parseFlags(fl)
     const repo = await opened(fl, doors)
@@ -148,6 +148,16 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
       await updateIndex(repo, staged, absent)
     }
     if (flags.worktree) {
+      // Removals first, because the two sets can name the same place:
+      // restoring a directory over a file writes `slot/child` where the
+      // file `slot` still sits, and the other direction writes the file
+      // where the directory still sits. Nothing is read back from the
+      // working tree, so emptying it first is free.
+      for (const name of absent) {
+        const path = under(repo.location.worktree, name)
+        await removeFile(dispatch, path)
+        await removeEmptyParents(dispatch, path, repo.location.worktree)
+      }
       for (const name of present) {
         const entry = tree.get(name)
         if (entry === undefined) continue
@@ -159,11 +169,6 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
           blob,
           doors.ns?.links ?? null,
         )
-      }
-      for (const name of absent) {
-        const path = under(repo.location.worktree, name)
-        await removeFile(dispatch, path)
-        await removeEmptyParents(dispatch, path, repo.location.worktree)
       }
     }
   } catch (err) {

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -42,7 +42,7 @@ import {
   restoreEntry,
   under,
 } from './io.ts'
-import { matched, repoRelative } from './pathspec.ts'
+import { matched, repoRelative, under as inside } from './pathspec.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { restored } from './reset.ts'
 import { COMMIT, TREE, resolveObject, unwrapped } from './revparse.ts'
@@ -183,6 +183,14 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
     // is the whole of what the entry asks for, and the preflight has nothing
     // to say about it either.
     const replacing = present.filter((name) => tree.get(name)?.mode !== GITLINK_MODE)
+    // A gitlink's directory is not this verb's to empty either. The entry is a
+    // placeholder for a repository mirage cannot read, so git writes the
+    // directory and leaves every path under it alone: a child the source drops
+    // loses its index entry and keeps its working-tree copy, edits included.
+    // Removing it here is the one loss nothing can undo, since the content was
+    // never staged. Pinned against git 2.50.1.
+    const linked = present.filter((name) => tree.get(name)?.mode === GITLINK_MODE)
+    const dropped = absent.filter((name) => !linked.some((root) => inside(name, root)))
     if (flags.worktree) {
       await refuseReplacedMounts(statPath, repo.location.worktree, replacing, links, mounts)
     }
@@ -201,7 +209,7 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
       // file `slot` still sits, and the other direction writes the file
       // where the directory still sits. Nothing is read back from the
       // working tree, so emptying it first is free.
-      for (const name of absent) {
+      for (const name of dropped) {
         const path = under(repo.location.worktree, name)
         // A component above the entry that is not a directory is not a way
         // through to it: the unlink would resolve past it and delete a file

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -1,0 +1,155 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import git from 'isomorphic-git'
+
+import { IOResult } from '../../../../io/types.ts'
+import type { CommandFnResult } from '../../../config.ts'
+import { FlagView } from '../../../spec/types.ts'
+import type { CLIInvocation } from '../../types.ts'
+import { headEntries } from './changes.ts'
+import {
+  GitError,
+  NoRestorePathsError,
+  NoWorkspaceError,
+  UnknownPathspecError,
+  UnknownSwitchError,
+  UnresolvableSourceError,
+} from './errors.ts'
+import { readIndex, updateIndex, type StagedEntry } from './index_file.ts'
+import { removeEmptyParents, removeFile, restoreEntry, under } from './io.ts'
+import { matched, repoRelative } from './pathspec.ts'
+import { opened, repoArgs } from './repo.ts'
+import { restored } from './reset.ts'
+import { resolveCommit } from './revparse.ts'
+import { commitEntries, type TreeEntry } from './tree.ts'
+import type { IndexEntry } from './types.ts'
+import { checkOperands, fatal, startPoint } from './util.ts'
+import { compareCodePoints } from '../../../../utils/sort.ts'
+
+/** The parsed shape of a `git restore` invocation. */
+interface RestoreFlags {
+  /** `--staged`, put the index back. */
+  readonly staged: boolean
+  /**
+   * `--worktree`, put the working tree back. The default when `--staged` is
+   * absent, which is git's rule.
+   */
+  readonly worktree: boolean
+  /**
+   * `--source`, the tree to restore from. Undefined means the index for the
+   * working tree and HEAD for the index.
+   */
+  readonly source: string | undefined
+}
+
+/** Read the raw restore flag kwargs into a frozen struct. */
+function parseFlags(fl: FlagView): RestoreFlags {
+  const staged = fl.asBool('staged')
+  return { staged, worktree: fl.asBool('worktree') || !staged, source: fl.asStr('source') }
+}
+
+/** The index read as a tree: every path with its mode and blob id. */
+export function indexTree(entries: ReadonlyMap<string, IndexEntry>): Map<string, TreeEntry> {
+  const out = new Map<string, TreeEntry>()
+  for (const [path, entry] of entries)
+    out.set(path, { oid: entry.oid, mode: entry.mode.toString(8) })
+  return out
+}
+
+/**
+ * Put paths back to what a source records.
+ *
+ * Two targets and one source, git's own model. `--staged` restores the index
+ * and `--worktree` the working tree; the default is the working tree alone. The
+ * source is the index for the working tree and HEAD for the index unless
+ * `--source` names a tree, in which case a selected path the source does not
+ * hold is removed from whichever target is being restored, since that is what
+ * "make it match the source" means for it. Pinned against git 2.50.1.
+ */
+export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
+  const doors = inv.doors ?? {}
+  const texts = [...inv.texts]
+  const fl = new FlagView(inv.flags)
+  try {
+    const dispatch = doors.dispatch
+    const statPath = doors.statPath
+    if (statPath === undefined || dispatch === undefined) {
+      throw new NoWorkspaceError()
+    }
+    checkOperands(texts, UnknownSwitchError)
+    if (texts.length === 0) throw new NoRestorePathsError()
+    const flags = parseFlags(fl)
+    const repo = await opened(fl, doors)
+    const state = await readIndex(repo, dispatch)
+    const held = indexTree(state.entries)
+    let source: Map<string, TreeEntry> | null
+    if (flags.source !== undefined) {
+      let oid: string
+      try {
+        oid = await resolveCommit(repo, flags.source)
+      } catch {
+        throw new UnresolvableSourceError(flags.source)
+      }
+      source = await commitEntries(repo, oid)
+    } else if (flags.staged) {
+      source = (await headEntries(repo)) ?? new Map<string, TreeEntry>()
+    } else {
+      source = null
+    }
+    const tree = source ?? held
+    const names = new Set([...held.keys(), ...tree.keys()])
+    const start = startPoint(fl)
+    const selected = new Set<string>()
+    for (const operand of texts) {
+      const hits = matched(names, repoRelative(repo.location, start, operand))
+      if (hits.size === 0) throw new UnknownPathspecError(operand)
+      for (const path of hits) selected.add(path)
+    }
+    const present = [...selected].filter((name) => tree.has(name)).sort(compareCodePoints)
+    const absent = [...selected].filter((name) => !tree.has(name)).sort(compareCodePoints)
+    if (flags.staged) {
+      const staged = new Map<string, StagedEntry>()
+      for (const name of present) {
+        const entry = tree.get(name)
+        if (entry !== undefined)
+          staged.set(name, restored(entry.oid, Number.parseInt(entry.mode, 8)))
+      }
+      await updateIndex(repo, staged, absent)
+    }
+    if (flags.worktree) {
+      for (const name of present) {
+        const entry = tree.get(name)
+        if (entry === undefined) continue
+        const { blob } = await git.readBlob({ ...repoArgs(repo), oid: entry.oid })
+        await restoreEntry(
+          dispatch,
+          under(repo.location.worktree, name),
+          entry.mode,
+          blob,
+          doors.ns?.links ?? null,
+        )
+      }
+      for (const name of absent) {
+        const path = under(repo.location.worktree, name)
+        await removeFile(dispatch, path)
+        await removeEmptyParents(dispatch, path, repo.location.worktree)
+      }
+    }
+  } catch (err) {
+    if (err instanceof GitError) return fatal(err)
+    throw err
+  }
+  return [null, new IOResult()]
+}

--- a/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/restore.ts
@@ -220,7 +220,7 @@ export async function restore(inv: CLIInvocation): Promise<CommandFnResult> {
         if ((links?.statAt(where) ?? null) === null) {
           const info = await statPath(where)
           if (info !== null && info.type === FileType.DIRECTORY) {
-            await removeTree(dispatch, where)
+            await removeTree(dispatch, where, links)
           }
         }
         await restoreEntry(dispatch, where, entry.mode, blob, links)

--- a/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
@@ -192,6 +192,35 @@ async function typeOf(repo: Repo, oid: string, revision: string): Promise<string
 }
 
 /**
+ * What an object stands for once every tag wrapper is off.
+ *
+ * An annotated tag can point at another one, so this is a walk rather than a
+ * single hop. Anything that is no tag is already what it stands for and comes
+ * back untouched.
+ *
+ * Every reading that wants a particular kind of object goes through this: a
+ * bare id names the tag itself, so a caller asking for a tree-ish or for the
+ * tree behind `<rev>:<path>` has one to take off, and git takes it off in both
+ * places.
+ *
+ * @param repo the opened repository
+ * @param found the object to unwrap
+ * @param revision the whole revision, for error attribution
+ */
+export async function unwrapped(
+  repo: Repo,
+  found: GitObject,
+  revision: string,
+): Promise<GitObject> {
+  let { oid, type } = found
+  while (type === TAG) {
+    oid = (await git.readTag({ ...repoArgs(repo), oid })).tag.object
+    type = await typeOf(repo, oid, revision)
+  }
+  return { oid, type }
+}
+
+/**
  * Follow a `^{<type>}` peel from the object the stem named.
  *
  * A tag is unwrapped until the type asked for is reached, which for `^{}` and
@@ -212,11 +241,7 @@ async function peeled(
   want: string,
   revision: string,
 ): Promise<GitObject> {
-  let { oid, type } = found
-  while (type === TAG && want !== TAG) {
-    oid = (await git.readTag({ ...repoArgs(repo), oid })).tag.object
-    type = await typeOf(repo, oid, revision)
-  }
+  let { oid, type } = want === TAG ? found : await unwrapped(repo, found, revision)
   if (want === '') return { oid, type }
   if (want === TREE && type === COMMIT) {
     oid = (await git.readCommit({ ...repoArgs(repo), oid })).commit.tree
@@ -235,7 +260,10 @@ async function peeled(
  * @param revision the whole revision, for error attribution
  */
 async function atPath(repo: Repo, rev: string, path: string, revision: string): Promise<GitObject> {
-  const holder = await resolveObject(repo, rev)
+  // A tag is no tree and holds no path, so it comes off first: the rev half is
+  // a tree-ish, and `<tag-id>:a.txt` reads the blob through it exactly as
+  // `v1:a.txt` does.
+  const holder = await unwrapped(repo, await resolveObject(repo, rev), revision)
   try {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const found = await git.readObject({ ...repoArgs(repo), oid: holder.oid, filepath: path })
@@ -279,6 +307,37 @@ async function tagObject(repo: Repo, stem: string): Promise<GitObject | null> {
 }
 
 /**
+ * The tag object a bare id names, null when the id names no tag.
+ *
+ * A tag is the one type whose bare-id reading differs from the commit-ish one,
+ * which is why this is scoped to it rather than put in front of every
+ * resolution: every other type either is the commit that reading returns or is
+ * not commit-ish at all, and already falls through to the id.
+ *
+ * A tag *name* is deliberately not read here. git splits the two, and the split
+ * is observable: `git tag nested v1` records the tag object while
+ * `git restore --source=v1` reads the tree behind it.
+ *
+ * @param repo the opened repository
+ * @param revision the revision as the user spelled it
+ */
+async function tagAtId(repo: Repo, revision: string): Promise<GitObject | null> {
+  let oid: string
+  try {
+    oid = await expanded(repo, revision)
+  } catch {
+    return null
+  }
+  let type: string
+  try {
+    type = await typeOf(repo, oid, revision)
+  } catch {
+    return null
+  }
+  return type === TAG ? { oid, type } : null
+}
+
+/**
  * The object a revision names, whatever type it turns out to be.
  *
  * The whole grammar a caller that wants an object rather than a commit has to
@@ -298,6 +357,13 @@ export async function resolveObject(repo: Repo, revision: string): Promise<GitOb
   }
   const [stem, want] = splitPeel(revision)
   if (want === null) {
+    // A bare id names that exact object, and for an annotated tag that is the
+    // tag rather than the commit behind it: the commit-ish reading below is a
+    // peel, and git does not peel an id. `git tag nested <tag-id>` records the
+    // tag, which is the nested tag git warns about rather than quietly
+    // flattens.
+    const held = await tagAtId(repo, revision)
+    if (held !== null) return held
     try {
       return { oid: await resolveCommit(repo, revision), type: COMMIT }
     } catch {

--- a/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
@@ -18,7 +18,7 @@ import { HEAD } from './constants.ts'
 import { AmbiguousArgumentError } from './errors.ts'
 import { TAG_PREFIX } from './refs.ts'
 import { repoArgs, type Repo } from './repo.ts'
-import type { AncestryStep, GitObject } from './types.ts'
+import type { AncestryStep, GitObject, RevOp } from './types.ts'
 
 const ANCESTOR = '~'
 const PARENT = '^'
@@ -35,43 +35,27 @@ export const TAG = 'tag'
 export const OBJECT = 'object'
 
 /**
- * Split a trailing `^{<type>}` off a revision.
+ * Split a revision into its base and the operators applied to it.
  *
- * `HEAD^{tree}` is a peel, not an ancestry step, and reading it as one is silent
- * rather than loud: `^` with no digits means "first parent", so the suffix
- * resolved to HEAD's parent commit and the caller was handed a different object
- * than it asked for without a word. The braces tell the two apart, and git
- * forbids both of them in a ref name, so nothing else can end this way.
+ * git reads a revision left to right: every `~n`, `^n` and `^{<type>}` applies
+ * to whatever the one before it produced, so `HEAD^{commit}~1` is the parent of
+ * HEAD and `HEAD~1^{tree}` is that parent's tree. Reading the peel as a trailing
+ * thing instead refused every chain that did not end in one, and reading `^{` as
+ * an ancestry step is worse than refusing: `^` with no digits means "first
+ * parent", so `HEAD^{tree}` would answer with HEAD's parent without a word.
+ * Splitting on the first `~` or `^` is safe because git forbids both in a ref
+ * name, so neither can belong to the base. Pinned against git 2.50.1.
  *
- * @param revision revision as the user spelled it
- * @returns the revision without the peel, and the type word inside it, empty for
- *   `^{}` and null when there is no peel at all
- */
-function splitPeel(revision: string): [string, string | null] {
-  if (!revision.endsWith(PEEL_CLOSE)) return [revision, null]
-  const index = revision.lastIndexOf(PEEL_OPEN)
-  if (index < 0) return [revision, null]
-  return [revision.slice(0, index), revision.slice(index + PEEL_OPEN.length, -1)]
-}
-
-/**
- * Split a revision into its base and its ancestry suffixes.
- *
- * `HEAD~2^2` is a base plus two steps. Splitting on the first `~` or `^` is safe
- * because git forbids both characters in ref names, so neither can belong to the
- * base.
- *
- * Only `~` and `^` are ancestry steps, and reading anything else as one is
- * silent rather than loud: every other character counted as another
- * first-parent hop, so `HEAD^x` resolved to `HEAD^^` and the caller was handed a
- * commit it never named. git refuses the whole expression instead, and refuses
- * `main~٣` with it, since the digits it counts are ASCII.
+ * Only `~` and `^` open an operator, and reading anything else as one is silent
+ * rather than loud: every other character counted as another first-parent hop,
+ * so `HEAD^x` resolved to `HEAD^^` and the caller was handed a commit it never
+ * named. git refuses the whole expression instead, and refuses `main~٣` with it,
+ * since the digits it counts are ASCII.
  *
  * @param revision revision as the user spelled it
- * @throws AmbiguousArgumentError when the suffix holds anything but ancestry
- *   steps
+ * @throws AmbiguousArgumentError when the rest holds anything but operators
  */
-function splitRevision(revision: string): [string, AncestryStep[]] {
+function splitOperators(revision: string): [string, RevOp[]] {
   let index = revision.length
   for (let i = 0; i < revision.length; i++) {
     if (SUFFIXES.includes(revision.charAt(i))) {
@@ -81,23 +65,30 @@ function splitRevision(revision: string): [string, AncestryStep[]] {
   }
   const base = revision.slice(0, index)
   const rest = revision.slice(index)
-  const steps: AncestryStep[] = []
+  const ops: RevOp[] = []
   let position = 0
   while (position < rest.length) {
     const kind = rest.charAt(position)
     if (!SUFFIXES.includes(kind)) throw new AmbiguousArgumentError(revision)
+    if (rest.startsWith(PEEL_OPEN, position)) {
+      const close = rest.indexOf(PEEL_CLOSE, position)
+      if (close < 0) throw new AmbiguousArgumentError(revision)
+      ops.push({ want: rest.slice(position + PEEL_OPEN.length, close) })
+      position = close + 1
+      continue
+    }
     position += 1
     let digits = ''
     while (position < rest.length && /[0-9]/.test(rest.charAt(position))) {
       digits += rest.charAt(position)
       position += 1
     }
-    steps.push({
+    ops.push({
       firstParent: kind === ANCESTOR,
       count: digits === '' ? 1 : Number.parseInt(digits, 10),
     })
   }
-  return [base === '' ? HEAD : base, steps]
+  return [base === '' ? HEAD : base, ops]
 }
 
 /** Load one commit's parents by object id, or report the revision as unknown. */
@@ -155,11 +146,7 @@ async function applyStep(
  * @param revision revision as the user spelled it
  */
 export async function resolveCommit(repo: Repo, revision: string): Promise<string> {
-  const [stem, want] = splitPeel(revision)
-  if (want !== null && want !== '' && want !== COMMIT && want !== OBJECT) {
-    throw new AmbiguousArgumentError(revision)
-  }
-  const [base, steps] = splitRevision(stem)
+  const [base, ops] = splitOperators(revision)
   let oid: string
   try {
     oid = await git.resolveRef({ ...repoArgs(repo), ref: base })
@@ -186,8 +173,17 @@ export async function resolveCommit(repo: Repo, revision: string): Promise<strin
     if (type !== 'tag') throw new AmbiguousArgumentError(revision)
     oid = (await git.readTag({ ...repoArgs(repo), oid })).tag.object
   }
-  for (const step of steps) {
-    oid = await applyStep(repo, oid, step, revision)
+  for (const op of ops) {
+    if ('want' in op) {
+      // A peel this caller can use is one that lands back on a commit: `^{}`
+      // and `^{commit}` do, `^{tree}` does not, and refusing the object rather
+      // than the spelling is what lets a peel sit in the middle of a chain.
+      const found = await peeled(repo, { oid, type: COMMIT }, op.want, revision)
+      if (found.type !== COMMIT) throw new AmbiguousArgumentError(revision)
+      oid = found.oid
+      continue
+    }
+    oid = await applyStep(repo, oid, op, revision)
   }
   return oid
 }
@@ -374,8 +370,8 @@ export async function resolveObject(repo: Repo, revision: string): Promise<GitOb
     const rev = revision.slice(0, mark)
     return atPath(repo, rev === '' ? HEAD : rev, revision.slice(mark + 1), revision)
   }
-  const [stem, want] = splitPeel(revision)
-  if (want === null) {
+  const [base, ops] = splitOperators(revision)
+  if (ops.length === 0) {
     // A bare id names that exact object, and for an annotated tag that is the
     // tag rather than the commit behind it: the commit-ish reading below is a
     // peel, and git does not peel an id. `git tag nested <tag-id>` records the
@@ -393,14 +389,22 @@ export async function resolveObject(repo: Repo, revision: string): Promise<GitOb
       return { oid, type: await typeOf(repo, oid, revision) }
     }
   }
-  if (want === TAG || want === OBJECT) {
-    // The same reading `^{tag}` needs, for the same reason: the commit-ish
-    // route below peels an annotated tag before anything else sees it, and
-    // both spellings have to stop above it.
-    const found = await tagObject(repo, stem)
-    if (found !== null) return found
+  // The base is resolved without peeling an annotated tag, because `^{tag}` and
+  // `^{object}` are the two spellings that have to stop above it; every other
+  // operator unwraps the tag itself, which is git's own rule and costs nothing
+  // here.
+  const held = await tagObject(repo, base)
+  let obj = held ?? (await resolveObject(repo, base))
+  for (const op of ops) {
+    if ('want' in op) {
+      obj = await peeled(repo, obj, op.want, revision)
+      continue
+    }
+    const commit = await unwrapped(repo, obj, revision)
+    if (commit.type !== COMMIT) throw new AmbiguousArgumentError(revision)
+    obj = { oid: await applyStep(repo, commit.oid, op, revision), type: COMMIT }
   }
-  return peeled(repo, await resolveObject(repo, stem), want, revision)
+  return obj
 }
 
 /** One id, full or abbreviated, expanded through the object store. */

--- a/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
@@ -61,7 +61,15 @@ function splitPeel(revision: string): [string, string | null] {
  * because git forbids both characters in ref names, so neither can belong to the
  * base.
  *
+ * Only `~` and `^` are ancestry steps, and reading anything else as one is
+ * silent rather than loud: every other character counted as another
+ * first-parent hop, so `HEAD^x` resolved to `HEAD^^` and the caller was handed a
+ * commit it never named. git refuses the whole expression instead, and refuses
+ * `main~٣` with it, since the digits it counts are ASCII.
+ *
  * @param revision revision as the user spelled it
+ * @throws AmbiguousArgumentError when the suffix holds anything but ancestry
+ *   steps
  */
 function splitRevision(revision: string): [string, AncestryStep[]] {
   let index = revision.length
@@ -77,6 +85,7 @@ function splitRevision(revision: string): [string, AncestryStep[]] {
   let position = 0
   while (position < rest.length) {
     const kind = rest.charAt(position)
+    if (!SUFFIXES.includes(kind)) throw new AmbiguousArgumentError(revision)
     position += 1
     let digits = ''
     while (position < rest.length && /[0-9]/.test(rest.charAt(position))) {

--- a/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
@@ -30,6 +30,9 @@ const PATH_MARK = ':'
 export const COMMIT = 'commit'
 export const TREE = 'tree'
 export const TAG = 'tag'
+// Not a type any object reports: `^{object}` asks only that the name resolve to
+// something, and hands back whatever that is.
+export const OBJECT = 'object'
 
 /**
  * Split a trailing `^{<type>}` off a revision.
@@ -144,7 +147,9 @@ async function applyStep(
  */
 export async function resolveCommit(repo: Repo, revision: string): Promise<string> {
   const [stem, want] = splitPeel(revision)
-  if (want !== null && want !== '' && want !== COMMIT) throw new AmbiguousArgumentError(revision)
+  if (want !== null && want !== '' && want !== COMMIT && want !== OBJECT) {
+    throw new AmbiguousArgumentError(revision)
+  }
   const [base, steps] = splitRevision(stem)
   let oid: string
   try {
@@ -241,6 +246,11 @@ async function peeled(
   want: string,
   revision: string,
 ): Promise<GitObject> {
+  // An existence check, not a type. Every object reports a concrete type name,
+  // so comparing one against `object` refuses every expression that spells it;
+  // gitrevisions(7) has it return the named object and nothing else, which for
+  // an annotated tag is the tag rather than the commit behind it.
+  if (want === OBJECT) return found
   let { oid, type } = want === TAG ? found : await unwrapped(repo, found, revision)
   if (want === '') return { oid, type }
   if (want === TREE && type === COMMIT) {
@@ -374,7 +384,10 @@ export async function resolveObject(repo: Repo, revision: string): Promise<GitOb
       return { oid, type: await typeOf(repo, oid, revision) }
     }
   }
-  if (want === TAG) {
+  if (want === TAG || want === OBJECT) {
+    // The same reading `^{tag}` needs, for the same reason: the commit-ish
+    // route below peels an annotated tag before anything else sees it, and
+    // both spellings have to stop above it.
     const found = await tagObject(repo, stem)
     if (found !== null) return found
   }

--- a/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
@@ -26,8 +26,8 @@ const SUFFIXES = [ANCESTOR, PARENT]
 const PEEL_OPEN = '^{'
 const PEEL_CLOSE = '}'
 const PATH_MARK = ':'
-const COMMIT = 'commit'
-const TREE = 'tree'
+export const COMMIT = 'commit'
+export const TREE = 'tree'
 
 /**
  * Split a trailing `^{<type>}` off a revision.

--- a/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
@@ -16,6 +16,7 @@ import git from 'isomorphic-git'
 import { HEAD } from './constants.ts'
 
 import { AmbiguousArgumentError } from './errors.ts'
+import { TAG_PREFIX } from './refs.ts'
 import { repoArgs, type Repo } from './repo.ts'
 import type { AncestryStep, GitObject } from './types.ts'
 
@@ -28,6 +29,7 @@ const PEEL_CLOSE = '}'
 const PATH_MARK = ':'
 export const COMMIT = 'commit'
 export const TREE = 'tree'
+export const TAG = 'tag'
 
 /**
  * Split a trailing `^{<type>}` off a revision.
@@ -192,10 +194,17 @@ async function typeOf(repo: Repo, oid: string, revision: string): Promise<string
 /**
  * Follow a `^{<type>}` peel from the object the stem named.
  *
- * A tag is unwrapped first whatever the type asked for, which is what `^{}`
- * means on its own. `^{tree}` then takes a commit's tree, git's one implicit
- * step; every other spelling has to already name the type it asks for, so
- * `HEAD^{blob}` is refused rather than answered with something else.
+ * A tag is unwrapped until the type asked for is reached, which for `^{}` and
+ * for every non-tag type means unwrapping it entirely. `^{tag}` is the one
+ * spelling that stops before the first hop, so `v1^{tag}` is the tag object
+ * itself rather than a refusal saying the commit behind it is no tag.
+ * `^{tree}` then takes a commit's tree, git's one implicit step; every other
+ * spelling has to already name the type it asks for, so `HEAD^{blob}` is
+ * refused rather than answered with something else.
+ *
+ * A lightweight tag is still refused by `^{tag}`: the name resolves straight to
+ * a commit, so there is no tag object to stop at and the type check below is
+ * what says so.
  */
 async function peeled(
   repo: Repo,
@@ -204,7 +213,7 @@ async function peeled(
   revision: string,
 ): Promise<GitObject> {
   let { oid, type } = found
-  while (type === 'tag') {
+  while (type === TAG && want !== TAG) {
     oid = (await git.readTag({ ...repoArgs(repo), oid })).tag.object
     type = await typeOf(repo, oid, revision)
   }
@@ -237,6 +246,39 @@ async function atPath(repo: Repo, rev: string, path: string, revision: string): 
 }
 
 /**
+ * The tag object a name or id denotes, null when it names no tag.
+ *
+ * Read before the stem is resolved, and only for `^{tag}`: every other peel type
+ * sits at or below the commit, so unwrapping an annotated tag on the way is
+ * git's own rule and costs nothing, while `^{tag}` is the one spelling that has
+ * to stop above it. Resolving the stem the ordinary way cannot serve it, because
+ * the commit-ish reading peels the tag before anything else sees it.
+ *
+ * Both spellings a tag answers to are tried, the ref and a raw id, and anything
+ * that is not a tag object reads as no tag: a lightweight tag names a commit
+ * directly, which is why git refuses `^{tag}` on one.
+ */
+async function tagObject(repo: Repo, stem: string): Promise<GitObject | null> {
+  let oid: string
+  try {
+    oid = await git.resolveRef({ ...repoArgs(repo), ref: `${TAG_PREFIX}${stem}` })
+  } catch {
+    try {
+      oid = await git.expandOid({ ...repoArgs(repo), oid: stem })
+    } catch {
+      return null
+    }
+  }
+  let type: string
+  try {
+    type = await typeOf(repo, oid, stem)
+  } catch {
+    return null
+  }
+  return type === TAG ? { oid, type } : null
+}
+
+/**
  * The object a revision names, whatever type it turns out to be.
  *
  * The whole grammar a caller that wants an object rather than a commit has to
@@ -265,6 +307,10 @@ export async function resolveObject(repo: Repo, revision: string): Promise<GitOb
       const oid = await expanded(repo, revision)
       return { oid, type: await typeOf(repo, oid, revision) }
     }
+  }
+  if (want === TAG) {
+    const found = await tagObject(repo, stem)
+    if (found !== null) return found
   }
   return peeled(repo, await resolveObject(repo, stem), want, revision)
 }

--- a/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/revparse.ts
@@ -17,11 +17,37 @@ import { HEAD } from './constants.ts'
 
 import { AmbiguousArgumentError } from './errors.ts'
 import { repoArgs, type Repo } from './repo.ts'
-import type { AncestryStep } from './types.ts'
+import type { AncestryStep, GitObject } from './types.ts'
 
 const ANCESTOR = '~'
 const PARENT = '^'
 const SUFFIXES = [ANCESTOR, PARENT]
+// `<rev>^{<type>}` peels to a type; `<rev>:<path>` reads a tree.
+const PEEL_OPEN = '^{'
+const PEEL_CLOSE = '}'
+const PATH_MARK = ':'
+const COMMIT = 'commit'
+const TREE = 'tree'
+
+/**
+ * Split a trailing `^{<type>}` off a revision.
+ *
+ * `HEAD^{tree}` is a peel, not an ancestry step, and reading it as one is silent
+ * rather than loud: `^` with no digits means "first parent", so the suffix
+ * resolved to HEAD's parent commit and the caller was handed a different object
+ * than it asked for without a word. The braces tell the two apart, and git
+ * forbids both of them in a ref name, so nothing else can end this way.
+ *
+ * @param revision revision as the user spelled it
+ * @returns the revision without the peel, and the type word inside it, empty for
+ *   `^{}` and null when there is no peel at all
+ */
+function splitPeel(revision: string): [string, string | null] {
+  if (!revision.endsWith(PEEL_CLOSE)) return [revision, null]
+  const index = revision.lastIndexOf(PEEL_OPEN)
+  if (index < 0) return [revision, null]
+  return [revision.slice(0, index), revision.slice(index + PEEL_OPEN.length, -1)]
+}
 
 /**
  * Split a revision into its base and its ancestry suffixes.
@@ -107,11 +133,17 @@ async function applyStep(
  * tag; it knows nothing about `~` and `^`, which are applied here on top of
  * whatever its own parser returns.
  *
+ * A `^{}` or `^{commit}` peel asks for exactly what this returns and is
+ * honoured; a peel naming any other type is a revision this caller cannot use,
+ * so it is refused rather than quietly stripped.
+ *
  * @param repo repository to resolve against
  * @param revision revision as the user spelled it
  */
 export async function resolveCommit(repo: Repo, revision: string): Promise<string> {
-  const [base, steps] = splitRevision(revision)
+  const [stem, want] = splitPeel(revision)
+  if (want !== null && want !== '' && want !== COMMIT) throw new AmbiguousArgumentError(revision)
+  const [base, steps] = splitRevision(stem)
   let oid: string
   try {
     oid = await git.resolveRef({ ...repoArgs(repo), ref: base })
@@ -142,4 +174,106 @@ export async function resolveCommit(repo: Repo, revision: string): Promise<strin
     oid = await applyStep(repo, oid, step, revision)
   }
   return oid
+}
+
+/** The type isomorphic-git records for one object id. */
+async function typeOf(repo: Repo, oid: string, revision: string): Promise<string> {
+  try {
+    // Deprecated upstream for being general, but the general answer is what
+    // peeling needs: which of commit/tag/tree/blob this id names, without
+    // reading it as each in turn until one does not throw.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    return (await git.readObject({ ...repoArgs(repo), oid })).type
+  } catch {
+    throw new AmbiguousArgumentError(revision)
+  }
+}
+
+/**
+ * Follow a `^{<type>}` peel from the object the stem named.
+ *
+ * A tag is unwrapped first whatever the type asked for, which is what `^{}`
+ * means on its own. `^{tree}` then takes a commit's tree, git's one implicit
+ * step; every other spelling has to already name the type it asks for, so
+ * `HEAD^{blob}` is refused rather than answered with something else.
+ */
+async function peeled(
+  repo: Repo,
+  found: GitObject,
+  want: string,
+  revision: string,
+): Promise<GitObject> {
+  let { oid, type } = found
+  while (type === 'tag') {
+    oid = (await git.readTag({ ...repoArgs(repo), oid })).tag.object
+    type = await typeOf(repo, oid, revision)
+  }
+  if (want === '') return { oid, type }
+  if (want === TREE && type === COMMIT) {
+    oid = (await git.readCommit({ ...repoArgs(repo), oid })).commit.tree
+    type = TREE
+  }
+  if (type !== want) throw new AmbiguousArgumentError(revision)
+  return { oid, type }
+}
+
+/**
+ * The object a `<rev>:<path>` names inside a tree.
+ *
+ * @param repo the opened repository
+ * @param rev the revision before the colon, HEAD when empty
+ * @param path the path after it, repository-relative
+ * @param revision the whole revision, for error attribution
+ */
+async function atPath(repo: Repo, rev: string, path: string, revision: string): Promise<GitObject> {
+  const holder = await resolveObject(repo, rev)
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const found = await git.readObject({ ...repoArgs(repo), oid: holder.oid, filepath: path })
+    return { oid: found.oid, type: found.type }
+  } catch {
+    throw new AmbiguousArgumentError(revision)
+  }
+}
+
+/**
+ * The object a revision names, whatever type it turns out to be.
+ *
+ * The whole grammar a caller that wants an object rather than a commit has to
+ * read: `HEAD:a.txt` is the blob at a path, `HEAD^{tree}` is a commit's tree,
+ * `v1^{}` is what a tag points at, and a bare id of any type is itself. A
+ * commit-ish is tried first because that is what the operand is normally spelled
+ * with, and it is the only reading that understands ancestry.
+ *
+ * @param repo repository to resolve against
+ * @param revision revision as the user spelled it
+ */
+export async function resolveObject(repo: Repo, revision: string): Promise<GitObject> {
+  const mark = revision.indexOf(PATH_MARK)
+  if (mark >= 0) {
+    const rev = revision.slice(0, mark)
+    return atPath(repo, rev === '' ? HEAD : rev, revision.slice(mark + 1), revision)
+  }
+  const [stem, want] = splitPeel(revision)
+  if (want === null) {
+    try {
+      return { oid: await resolveCommit(repo, revision), type: COMMIT }
+    } catch {
+      // Not a commit-ish. A raw id is read as itself before the revision is
+      // called unresolved, and the type is kept, since it is what a caller
+      // records.
+      const oid = await expanded(repo, revision)
+      return { oid, type: await typeOf(repo, oid, revision) }
+    }
+  }
+  return peeled(repo, await resolveObject(repo, stem), want, revision)
+}
+
+/** One id, full or abbreviated, expanded through the object store. */
+async function expanded(repo: Repo, revision: string): Promise<string> {
+  try {
+    return await git.expandOid({ ...repoArgs(repo), oid: revision })
+  } catch {
+    throw new AmbiguousArgumentError(revision)
+  }
 }

--- a/typescript/packages/core/src/commands/cli/builtin/git/rm.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/rm.ts
@@ -24,6 +24,7 @@ import {
   NoWorkspaceError,
   PathspecError,
   RemovalRefusedError,
+  RemovePathError,
   UnknownSwitchError,
 } from './errors.ts'
 import { readIndex, updateIndex } from './index_file.ts'
@@ -34,6 +35,8 @@ import type { TreeEntry } from './tree.ts'
 import type { Dispatch, IndexEntry, RepoLocation, WorkTree } from './types.ts'
 import { checkOperands, escaped, fatal, startPoint } from './util.ts'
 import { scan, UNTRACKED_NO } from './worktree.ts'
+import type { LinkView, StatPath } from '../../../../ops/types.ts'
+import { FileType } from '../../../../types.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
 const ENC = new TextEncoder()
@@ -142,6 +145,55 @@ export async function refuseLostWork(
 }
 
 /**
+ * Delete every selected path from the working tree.
+ *
+ * A directory standing where a tracked file was is the one deletion a mount
+ * cannot make: `unlink` is not the call that empties a tree, and git reports
+ * the strerror rather than removing what it never tracked. It reports it in
+ * index order and only while nothing has been deleted yet; once one path is
+ * gone the rest of the loop tolerates a failure and the line still succeeds.
+ * That is git's own rule rather than a reading of it, and it is observable both
+ * ways: `git rm slot z.txt` is fatal with the index untouched, while
+ * `git rm a.txt slot` exits 0 with both entries unstaged and the directory
+ * still on disk. Pinned against git 2.50.1.
+ *
+ * A tracked symlink to a directory is not this case and must not be read as
+ * one: it is removed as the link it is, which is why the namespace is asked
+ * before the type.
+ *
+ * @param dispatch workspace op dispatcher
+ * @param statPath the data plane's stat, which dereferences
+ * @param worktree absolute virtual path of the working tree root
+ * @param selected the paths to delete, in index order
+ * @param lines the `rm` lines already printed, for a refusal to carry on stdout
+ *   the way git prints them anyway
+ * @param links the name plane's link facts, null when no namespace is wired
+ */
+export async function clearWorktree(
+  dispatch: Dispatch,
+  statPath: StatPath,
+  worktree: string,
+  selected: readonly string[],
+  lines: string,
+  links: LinkView | null,
+): Promise<void> {
+  let removed = false
+  for (const path of selected) {
+    const absolute = under(worktree, path)
+    if ((links?.statAt(absolute) ?? null) === null) {
+      const info = await statPath(absolute)
+      if (info !== null && info.type === FileType.DIRECTORY) {
+        if (!removed) throw new RemovePathError(path, lines)
+        continue
+      }
+    }
+    await removeFile(dispatch, absolute)
+    await removeEmptyParents(dispatch, absolute, worktree)
+    removed = true
+  }
+}
+
+/**
  * Remove paths from the index, and from the working tree too.
  *
  * `--cached` leaves the file where it is and only stops tracking it. Without
@@ -181,14 +233,22 @@ export async function rm(inv: CLIInvocation): Promise<CommandFnResult> {
       const tree = (await headEntries(repo)) ?? new Map<string, TreeEntry>()
       await refuseLostWork(repo, dispatch, tree, state.entries, found, checkable, flags.cached)
     }
-    await updateIndex(repo, new Map(), selected)
+    const lines = flags.quiet ? '' : selected.map((path) => `rm '${path}'\n`).join('')
     if (!flags.cached) {
-      for (const path of selected) {
-        const absolute = under(repo.location.worktree, path)
-        await removeFile(dispatch, absolute)
-        await removeEmptyParents(dispatch, absolute, repo.location.worktree)
-      }
+      await clearWorktree(
+        dispatch,
+        statPath,
+        repo.location.worktree,
+        selected,
+        lines,
+        doors.ns?.links ?? null,
+      )
     }
+    // Last, because the deletions above can fail: git writes the index only
+    // once the working tree is done with, so a refused deletion leaves the
+    // entry staged exactly as it stood rather than staging a removal that
+    // never happened.
+    await updateIndex(repo, new Map(), selected)
   } catch (err) {
     if (err instanceof GitError) return fatal(err)
     throw err

--- a/typescript/packages/core/src/commands/cli/builtin/git/rm.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/rm.ts
@@ -32,7 +32,7 @@ import { matched, repoRelative } from './pathspec.ts'
 import { opened, type Repo } from './repo.ts'
 import type { TreeEntry } from './tree.ts'
 import type { Dispatch, IndexEntry, RepoLocation, WorkTree } from './types.ts'
-import { checkOperands, fatal, startPoint } from './util.ts'
+import { checkOperands, escaped, fatal, startPoint } from './util.ts'
 import { scan, UNTRACKED_NO } from './worktree.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
@@ -161,7 +161,7 @@ export async function rm(inv: CLIInvocation): Promise<CommandFnResult> {
     if (statPath === undefined || dispatch === undefined) {
       throw new NoWorkspaceError()
     }
-    checkOperands(texts, UnknownSwitchError)
+    checkOperands(texts, UnknownSwitchError, escaped(inv.argv))
     flags = parseFlags(fl)
     if (texts.length === 0) throw new NoPathspecRemoveError()
     const repo = await opened(fl, doors)

--- a/typescript/packages/core/src/commands/cli/builtin/git/rm.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/rm.ts
@@ -16,7 +16,7 @@ import { IOResult } from '../../../../io/types.ts'
 import type { CommandFnResult } from '../../../config.ts'
 import { FlagView } from '../../../spec/types.ts'
 import type { CLIInvocation } from '../../types.ts'
-import { headEntries, MODIFIED, workChanges } from './changes.ts'
+import { DELETED, headEntries, MODIFIED, workChanges } from './changes.ts'
 import {
   GitError,
   NoPathspecRemoveError,
@@ -35,7 +35,7 @@ import type { TreeEntry } from './tree.ts'
 import type { Dispatch, IndexEntry, RepoLocation, WorkTree } from './types.ts'
 import { checkOperands, escaped, fatal, startPoint } from './util.ts'
 import { scan, UNTRACKED_NO } from './worktree.ts'
-import type { LinkView, StatPath } from '../../../../ops/types.ts'
+import type { LinkView, MountView, StatPath } from '../../../../ops/types.ts'
 import { FileType } from '../../../../types.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
@@ -101,6 +101,41 @@ export function select(
 }
 
 /**
+ * Which absent paths a link above them is only hiding.
+ *
+ * git lstats a tracked path to decide whether it still has local work to lose,
+ * and that lstat resolves every component above the file, so a symlink standing
+ * where a directory was does not hide the file: it points the check at whatever
+ * lies at the other end, which is some other file entirely and therefore a
+ * local change. The walk answers the opposite way on purpose, because git's own
+ * diff refuses to follow a leading link and reports the path deleted, which is
+ * why `git status` says `D` here and `git rm` still refuses. Nothing is
+ * compared: two files agreeing byte for byte are still two files, and git
+ * refuses that case too. Pinned against git 2.50.1.
+ *
+ * @param links the name plane's link facts, null when no namespace is wired
+ * @param worktree absolute virtual path of the working tree root
+ * @param paths the selected paths that hold an index entry
+ * @param missing what the walk said about each path
+ */
+export async function shadowed(
+  links: LinkView | null,
+  worktree: string,
+  paths: readonly string[],
+  missing: ReadonlyMap<string, string>,
+): Promise<Set<string>> {
+  const found = new Set<string>()
+  if (links === null) return found
+  for (const path of paths) {
+    if (missing.get(path) !== DELETED) continue
+    const absolute = under(worktree, path)
+    if (links.resolve(absolute) === absolute) continue
+    if (await links.exists(absolute)) found.add(path)
+  }
+  return found
+}
+
+/**
  * Refuse a removal that would throw away uncommitted work.
  *
  * git's own three-way test per path: whether the index differs from HEAD, and
@@ -118,6 +153,7 @@ export async function refuseLostWork(
   found: WorkTree,
   paths: readonly string[],
   cached: boolean,
+  links: LinkView | null,
 ): Promise<void> {
   const chosen = new Map<string, IndexEntry>()
   for (const path of paths) {
@@ -125,6 +161,7 @@ export async function refuseLostWork(
     if (entry !== undefined) chosen.set(path, entry)
   }
   const unstaged = await workChanges(repo, dispatch, repo.location.worktree, chosen, found)
+  const hidden = await shadowed(links, repo.location.worktree, paths, unstaged)
   const both: string[] = []
   const staged: string[] = []
   const local: string[] = []
@@ -132,7 +169,7 @@ export async function refuseLostWork(
     const recorded = tree.get(path)
     const stagedChanges =
       recorded?.oid !== entry.oid || Number.parseInt(recorded.mode, 8) !== entry.mode
-    const localChanges = unstaged.get(path) === MODIFIED
+    const localChanges = unstaged.get(path) === MODIFIED || hidden.has(path)
     if (localChanges && stagedChanges) both.push(path)
     else if (!cached) {
       if (stagedChanges) staged.push(path)
@@ -168,6 +205,7 @@ export async function refuseLostWork(
  * @param lines the `rm` lines already printed, for a refusal to carry on stdout
  *   the way git prints them anyway
  * @param links the name plane's link facts, null when no namespace is wired
+ * @param mounts the name plane's mount boundaries, null when none is wired
  */
 export async function clearWorktree(
   dispatch: Dispatch,
@@ -176,6 +214,7 @@ export async function clearWorktree(
   selected: readonly string[],
   lines: string,
   links: LinkView | null,
+  mounts: MountView | null,
 ): Promise<void> {
   let removed = false
   for (const path of selected) {
@@ -188,7 +227,7 @@ export async function clearWorktree(
       }
     }
     await removeFile(dispatch, absolute)
-    await removeEmptyParents(dispatch, absolute, worktree)
+    await removeEmptyParents(dispatch, absolute, worktree, mounts)
     removed = true
   }
 }
@@ -231,7 +270,16 @@ export async function rm(inv: CLIInvocation): Promise<CommandFnResult> {
         doors.ns?.links ?? null,
       )
       const tree = (await headEntries(repo)) ?? new Map<string, TreeEntry>()
-      await refuseLostWork(repo, dispatch, tree, state.entries, found, checkable, flags.cached)
+      await refuseLostWork(
+        repo,
+        dispatch,
+        tree,
+        state.entries,
+        found,
+        checkable,
+        flags.cached,
+        doors.ns?.links ?? null,
+      )
     }
     const lines = flags.quiet ? '' : selected.map((path) => `rm '${path}'\n`).join('')
     if (!flags.cached) {
@@ -242,6 +290,7 @@ export async function rm(inv: CLIInvocation): Promise<CommandFnResult> {
         selected,
         lines,
         doors.ns?.links ?? null,
+        doors.ns?.mounts ?? null,
       )
     }
     // Last, because the deletions above can fail: git writes the index only

--- a/typescript/packages/core/src/commands/cli/builtin/git/rm.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/rm.ts
@@ -1,0 +1,198 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { IOResult } from '../../../../io/types.ts'
+import type { CommandFnResult } from '../../../config.ts'
+import { FlagView } from '../../../spec/types.ts'
+import type { CLIInvocation } from '../../types.ts'
+import { headEntries, MODIFIED, workChanges } from './changes.ts'
+import {
+  GitError,
+  NoPathspecRemoveError,
+  NotRecursiveError,
+  NoWorkspaceError,
+  PathspecError,
+  RemovalRefusedError,
+  UnknownSwitchError,
+} from './errors.ts'
+import { readIndex, updateIndex } from './index_file.ts'
+import { removeEmptyParents, removeFile, under } from './io.ts'
+import { matched, repoRelative } from './pathspec.ts'
+import { opened, type Repo } from './repo.ts'
+import type { TreeEntry } from './tree.ts'
+import type { Dispatch, IndexEntry, RepoLocation, WorkTree } from './types.ts'
+import { checkOperands, fatal, startPoint } from './util.ts'
+import { scan, UNTRACKED_NO } from './worktree.ts'
+import { compareCodePoints } from '../../../../utils/sort.ts'
+
+const ENC = new TextEncoder()
+
+/** The parsed shape of a `git rm` invocation. */
+export interface RmFlags {
+  /** `-r`, allow a directory operand. */
+  readonly recursive: boolean
+  /** `--cached`, unstage only and keep the file. */
+  readonly cached: boolean
+  /** `-f`, remove even over uncommitted changes. */
+  readonly force: boolean
+  /** `-q`, print no `rm` line per path. */
+  readonly quiet: boolean
+  /** `--ignore-unmatch`, an operand naming nothing is not an error. */
+  readonly ignoreUnmatch: boolean
+}
+
+/** Read the raw rm flag kwargs into a frozen struct. */
+function parseFlags(fl: FlagView): RmFlags {
+  return {
+    recursive: fl.asBool('r'),
+    cached: fl.asBool('cached'),
+    force: fl.asBool('force'),
+    quiet: fl.asBool('quiet'),
+    ignoreUnmatch: fl.asBool('ignore_unmatch'),
+  }
+}
+
+/**
+ * Which tracked paths the operands remove, in index order.
+ *
+ * Every operand is checked before anything is removed, which is git's order
+ * too: a line with one bad operand removes nothing. A directory is refused
+ * without `-r` rather than expanded, and an operand that names nothing tracked
+ * is a fatal unless `--ignore-unmatch` says otherwise. An untracked file is
+ * "nothing tracked": git has nothing to remove it from.
+ */
+export function select(
+  location: RepoLocation,
+  start: string,
+  operands: readonly string[],
+  tracked: ReadonlySet<string>,
+  flags: RmFlags,
+): string[] {
+  const selected = new Set<string>()
+  for (const operand of operands) {
+    const target = repoRelative(location, start, operand)
+    if (tracked.has(target)) {
+      selected.add(target)
+      continue
+    }
+    const hits = matched(tracked, target)
+    if (hits.size === 0) {
+      if (flags.ignoreUnmatch) continue
+      throw new PathspecError(operand)
+    }
+    if (!flags.recursive) throw new NotRecursiveError(operand)
+    for (const path of hits) selected.add(path)
+  }
+  return [...selected].sort(compareCodePoints)
+}
+
+/**
+ * Refuse a removal that would throw away uncommitted work.
+ *
+ * git's own three-way test per path: whether the index differs from HEAD, and
+ * whether the working tree differs from the index. A path that differs both
+ * ways is refused outright; one that differs one way is refused unless
+ * `--cached` keeps the file. A file already gone from the working tree has no
+ * local change to lose, which is what makes `git rm <deleted>` the way to stage
+ * a deletion. Pinned against git 2.50.1.
+ */
+export async function refuseLostWork(
+  repo: Repo,
+  dispatch: Dispatch,
+  tree: ReadonlyMap<string, TreeEntry>,
+  entries: ReadonlyMap<string, IndexEntry>,
+  found: WorkTree,
+  paths: readonly string[],
+  cached: boolean,
+): Promise<void> {
+  const chosen = new Map<string, IndexEntry>()
+  for (const path of paths) {
+    const entry = entries.get(path)
+    if (entry !== undefined) chosen.set(path, entry)
+  }
+  const unstaged = await workChanges(repo, dispatch, repo.location.worktree, chosen, found)
+  const both: string[] = []
+  const staged: string[] = []
+  const local: string[] = []
+  for (const [path, entry] of chosen) {
+    const recorded = tree.get(path)
+    const stagedChanges =
+      recorded?.oid !== entry.oid || Number.parseInt(recorded.mode, 8) !== entry.mode
+    const localChanges = unstaged.get(path) === MODIFIED
+    if (localChanges && stagedChanges) both.push(path)
+    else if (!cached) {
+      if (stagedChanges) staged.push(path)
+      if (localChanges) local.push(path)
+    }
+  }
+  if (both.length > 0 || staged.length > 0 || local.length > 0) {
+    throw new RemovalRefusedError(both, staged, local)
+  }
+}
+
+/**
+ * Remove paths from the index, and from the working tree too.
+ *
+ * `--cached` leaves the file where it is and only stops tracking it. Without
+ * `-f` a path carrying uncommitted work is refused rather than deleted, which is
+ * the one check that makes the verb safe to hand an agent: there is no reflog
+ * here to recover a file from.
+ */
+export async function rm(inv: CLIInvocation): Promise<CommandFnResult> {
+  const doors = inv.doors ?? {}
+  const texts = [...inv.texts]
+  const fl = new FlagView(inv.flags)
+  let flags: RmFlags
+  let selected: string[]
+  try {
+    const dispatch = doors.dispatch
+    const statPath = doors.statPath
+    if (statPath === undefined || dispatch === undefined) {
+      throw new NoWorkspaceError()
+    }
+    checkOperands(texts, UnknownSwitchError)
+    flags = parseFlags(fl)
+    if (texts.length === 0) throw new NoPathspecRemoveError()
+    const repo = await opened(fl, doors)
+    const state = await readIndex(repo, dispatch)
+    const tracked = new Set([...state.entries.keys(), ...state.conflicts.keys()])
+    selected = select(repo.location, startPoint(fl), texts, tracked, flags)
+    if (!flags.force) {
+      const checkable = selected.filter((path) => state.entries.has(path))
+      const found = await scan(
+        dispatch,
+        statPath,
+        repo.location,
+        tracked,
+        UNTRACKED_NO,
+        doors.ns?.links ?? null,
+      )
+      const tree = (await headEntries(repo)) ?? new Map<string, TreeEntry>()
+      await refuseLostWork(repo, dispatch, tree, state.entries, found, checkable, flags.cached)
+    }
+    await updateIndex(repo, new Map(), selected)
+    if (!flags.cached) {
+      for (const path of selected) {
+        const absolute = under(repo.location.worktree, path)
+        await removeFile(dispatch, absolute)
+        await removeEmptyParents(dispatch, absolute, repo.location.worktree)
+      }
+    }
+  } catch (err) {
+    if (err instanceof GitError) return fatal(err)
+    throw err
+  }
+  if (flags.quiet) return [null, new IOResult()]
+  return [ENC.encode(selected.map((path) => `rm '${path}'\n`).join('')), new IOResult()]
+}

--- a/typescript/packages/core/src/commands/cli/builtin/git/show.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/show.ts
@@ -34,7 +34,7 @@ import { commitFacts, opened, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
 import { diffstat, statTable } from './summary.ts'
 import { treeEntries, type TreeEntry } from './tree.ts'
-import { checkOperands, fatal, revisionArg } from './util.ts'
+import { checkOperands, escaped, fatal, revisionArg } from './util.ts'
 import { encodeText } from '../../../../shell/bytes.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
@@ -135,7 +135,7 @@ export async function show(inv: CLIInvocation): Promise<CommandFnResult> {
   const texts = [...inv.texts]
   const fl = new FlagView(inv.flags)
   try {
-    checkOperands(texts)
+    checkOperands(texts, undefined, escaped(inv.argv))
     const parsed = parseShowFlags(fl)
     const repo = await opened(fl, doors)
     const oid = await resolveCommit(repo, revisionArg(texts))

--- a/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
@@ -25,6 +25,7 @@ import {
   BranchExpectedError,
   DetachWithCreateError,
   GitError,
+  InvalidBranchNameError,
   InvalidReferenceError,
   MissingBranchArgumentError,
   NoWorkspaceError,
@@ -32,7 +33,7 @@ import {
   UnknownSwitchError,
 } from './errors.ts'
 import { short } from './format.ts'
-import { BRANCH_PREFIX, loadRefs, readHead, TAG_PREFIX } from './refs.ts'
+import { BRANCH_PREFIX, loadRefs, readHead, TAG_PREFIX, validRefName } from './refs.ts'
 import { opened, repoArgs } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
 import { checkOperands, fatal } from './util.ts'
@@ -112,6 +113,11 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
       } catch {
         throw new InvalidReferenceError(start)
       }
+      // After the start point and before anything is written, which is git's
+      // own order. A ref is a path below .git, so an unchecked name reaches
+      // writeRef as one: -c ../../config would land on the repository's own
+      // configuration rather than on a branch.
+      if (!validRefName(target)) throw new InvalidBranchNameError(target)
       attached = true
     } else {
       target = first ?? ''

--- a/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
@@ -97,7 +97,11 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
     if (creating && flags.detach) throw new DetachWithCreateError()
     if (texts.length > 1) throw new OneReferenceError()
     const first = texts[0]
-    if (!creating && first === undefined) throw new MissingBranchArgumentError()
+    // A detach takes HEAD when nothing is named, which is git's own default;
+    // only an attaching switch needs a branch to name.
+    if (!creating && first === undefined && !flags.detach) {
+      throw new MissingBranchArgumentError()
+    }
     const repo = await opened(fl, doors)
     const head = await readHead(dispatch, repo.location.gitdir)
     const known = await loadRefs(dispatch, repo.location.gitdir, repo.location.commondir)
@@ -120,7 +124,7 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
       if (!validRefName(target)) throw new InvalidBranchNameError(target)
       attached = true
     } else {
-      target = first ?? ''
+      target = first ?? HEAD
       if (!flags.detach && target === head.branch) {
         return [null, new IOResult({ stderr: ENC.encode(`Already on '${target}'\n`) })]
       }

--- a/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
@@ -33,7 +33,7 @@ import {
   UnknownSwitchError,
 } from './errors.ts'
 import { short } from './format.ts'
-import { BRANCH_PREFIX, loadRefs, readHead, TAG_PREFIX, validRefName } from './refs.ts'
+import { BRANCH_PREFIX, loadRefs, readHead, setHead, TAG_PREFIX, validRefName } from './refs.ts'
 import { opened, repoArgs } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
 import { checkOperands, escaped, fatal } from './util.ts'
@@ -114,10 +114,21 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
       if (known.has(`${BRANCH_PREFIX}${target}`)) throw new BranchExistsError(target)
       startPoint = first
       const start = first ?? HEAD
-      try {
-        oid = await resolveCommit(repo, start)
-      } catch {
-        throw new InvalidReferenceError(start)
+      // Before the first commit there is nothing for HEAD to resolve to, and
+      // git makes the branch anyway: the line only repoints symbolic HEAD,
+      // writing neither the ref nor a reflog line, because a branch with no
+      // commit is a name and nothing else. A start point is a different line
+      // and stays unresolvable (`fatal: invalid reference: main`), so this
+      // reads the shape of the line rather than probing HEAD. Pinned against
+      // git 2.50.1.
+      const unborn = first === undefined && head.ref !== null && !known.has(head.ref)
+      oid = ''
+      if (!unborn) {
+        try {
+          oid = await resolveCommit(repo, start)
+        } catch {
+          throw new InvalidReferenceError(start)
+        }
       }
       // After the start point and before anything is written, which is git's
       // own order. A ref is a path below .git, so an unchecked name reaches
@@ -125,6 +136,13 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
       // configuration rather than on a branch.
       if (!validRefName(target)) throw new InvalidBranchNameError(target)
       attached = true
+      if (unborn) {
+        await setHead(dispatch, repo.location.gitdir, `${BRANCH_PREFIX}${target}`)
+        return [
+          ENC.encode(''),
+          new IOResult({ stderr: ENC.encode(`Switched to a new branch '${target}'\n`) }),
+        ]
+      }
     } else {
       target = first ?? HEAD
       if (!flags.detach && target === head.branch) {
@@ -140,7 +158,7 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
         throw new BranchExpectedError(expectedKind(known, target), target)
       }
     }
-    const dirty = await moveHead(
+    const moved = await moveHead(
       dispatch,
       statPath,
       doors.ns?.links ?? null,
@@ -153,9 +171,9 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
       creating,
       creating && startPoint === undefined,
     )
-    carried = [...dirty]
-      .sort(compareCodePoints)
-      .map((path) => `M\t${path}\n`)
+    carried = [...moved]
+      .sort(([a], [b]) => compareCodePoints(a, b))
+      .map(([path, letter]) => `${letter}\t${path}\n`)
       .join('')
     note = await previousPosition(repo, head)
     if (attached) {

--- a/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
@@ -181,6 +181,7 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
       dispatch,
       statPath,
       doors.ns?.links ?? null,
+      doors.ns?.mounts ?? null,
       repo,
       known,
       head,

--- a/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
@@ -34,6 +34,7 @@ import {
   UnknownSwitchError,
 } from './errors.ts'
 import { short } from './format.ts'
+import { readIndex, refuseUnresolved } from './index_file.ts'
 import {
   BRANCH_PREFIX,
   blockingRef,
@@ -165,6 +166,10 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
       // is what leaves `switch -c` as the only line an unborn HEAD accepts.
       // Pinned against git 2.50.1.
       if (!flags.detach && target === head.branch && known.has(`${BRANCH_PREFIX}${target}`)) {
+        // Moving nothing is not the same as having nothing to check: git dies
+        // on an unresolved index here too, so the shortcut reads it before it
+        // answers. Every ref check above comes first, which is git's own order.
+        refuseUnresolved(await readIndex(repo, dispatch))
         return [null, new IOResult({ stderr: ENC.encode(`Already on '${target}'\n`) })]
       }
       try {

--- a/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
@@ -1,0 +1,161 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import git from 'isomorphic-git'
+
+import { IOResult } from '../../../../io/types.ts'
+import type { CommandFnResult } from '../../../config.ts'
+import { FlagView } from '../../../spec/types.ts'
+import type { CLIInvocation } from '../../types.ts'
+import { moveHead, previousPosition } from './checkout.ts'
+import { HEAD } from './constants.ts'
+import {
+  BranchExistsError,
+  BranchExpectedError,
+  DetachWithCreateError,
+  GitError,
+  InvalidReferenceError,
+  MissingBranchArgumentError,
+  NoWorkspaceError,
+  OneReferenceError,
+  UnknownSwitchError,
+} from './errors.ts'
+import { short } from './format.ts'
+import { BRANCH_PREFIX, loadRefs, readHead, TAG_PREFIX } from './refs.ts'
+import { opened, repoArgs } from './repo.ts'
+import { resolveCommit } from './revparse.ts'
+import { checkOperands, fatal } from './util.ts'
+import { compareCodePoints } from '../../../../utils/sort.ts'
+
+const ENC = new TextEncoder()
+const REMOTES_PREFIX = 'refs/remotes/'
+const COMMIT = 'commit'
+const TAG = 'tag'
+const REMOTE_BRANCH = 'remote branch'
+
+/** The parsed shape of a `git switch` invocation. */
+interface SwitchFlags {
+  /** `-c`, the branch to create and switch to. */
+  readonly create: string | undefined
+  /** `--detach`, leave HEAD on the commit itself. */
+  readonly detach: boolean
+}
+
+/** Read the raw switch flag kwargs into a frozen struct. */
+function parseFlags(fl: FlagView): SwitchFlags {
+  return { create: fl.asStr('create'), detach: fl.asBool('detach') }
+}
+
+/**
+ * What a non-branch operand named, for the refusal that says so.
+ *
+ * git tells a tag and a remote-tracking branch apart from a bare commit in the
+ * same sentence, so the refusal can say which one the caller reached for.
+ */
+export function expectedKind(known: ReadonlyMap<string, string>, name: string): string {
+  if (known.has(`${TAG_PREFIX}${name}`)) return TAG
+  if (known.has(`${REMOTES_PREFIX}${name}`)) return REMOTE_BRANCH
+  return COMMIT
+}
+
+/**
+ * Switch to a branch, creating it under `-c`.
+ *
+ * The same move `checkout` makes, with a narrower grammar: only a branch is
+ * accepted, so a commit, tag or remote-tracking name is refused unless
+ * `--detach` says that a detached HEAD is what was meant. That is the whole
+ * reason git split the verb off, and it holds here for the same reason: a
+ * detached HEAD is the state an agent loses commits in.
+ */
+export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult> {
+  const doors = inv.doors ?? {}
+  const texts = [...inv.texts]
+  const fl = new FlagView(inv.flags)
+  let carried: string
+  let note: string
+  try {
+    const dispatch = doors.dispatch
+    const statPath = doors.statPath
+    if (statPath === undefined || dispatch === undefined) {
+      throw new NoWorkspaceError()
+    }
+    checkOperands(texts, UnknownSwitchError)
+    const flags = parseFlags(fl)
+    const creating = flags.create !== undefined
+    if (creating && flags.detach) throw new DetachWithCreateError()
+    if (texts.length > 1) throw new OneReferenceError()
+    const first = texts[0]
+    if (!creating && first === undefined) throw new MissingBranchArgumentError()
+    const repo = await opened(fl, doors)
+    const head = await readHead(dispatch, repo.location.gitdir)
+    const known = await loadRefs(dispatch, repo.location.gitdir, repo.location.commondir)
+    let target: string
+    let oid: string
+    let attached: boolean
+    if (flags.create !== undefined) {
+      target = flags.create
+      if (known.has(`${BRANCH_PREFIX}${target}`)) throw new BranchExistsError(target)
+      const start = first ?? HEAD
+      try {
+        oid = await resolveCommit(repo, start)
+      } catch {
+        throw new InvalidReferenceError(start)
+      }
+      attached = true
+    } else {
+      target = first ?? ''
+      if (!flags.detach && target === head.branch) {
+        return [null, new IOResult({ stderr: ENC.encode(`Already on '${target}'\n`) })]
+      }
+      try {
+        oid = await resolveCommit(repo, target)
+      } catch {
+        throw new InvalidReferenceError(target)
+      }
+      attached = !flags.detach && known.has(`${BRANCH_PREFIX}${target}`)
+      if (!flags.detach && !attached) {
+        throw new BranchExpectedError(expectedKind(known, target), target)
+      }
+    }
+    const dirty = await moveHead(
+      dispatch,
+      statPath,
+      doors.ns?.links ?? null,
+      repo,
+      known,
+      head,
+      oid,
+      target,
+      attached ? `${BRANCH_PREFIX}${target}` : null,
+      creating,
+    )
+    carried = [...dirty]
+      .sort(compareCodePoints)
+      .map((path) => `M\t${path}\n`)
+      .join('')
+    note = await previousPosition(repo, head)
+    if (attached) {
+      const verb = creating ? 'Switched to a new branch' : 'Switched to branch'
+      note += `${verb} '${target}'\n`
+    } else {
+      const { commit } = await git.readCommit({ ...repoArgs(repo), oid })
+      const subject = commit.message.split('\n')[0] ?? ''
+      note += `HEAD is now at ${short(oid, repo.abbrev)} ${subject}\n`
+    }
+  } catch (err) {
+    if (err instanceof GitError) return fatal(err)
+    throw err
+  }
+  return [ENC.encode(carried), new IOResult({ stderr: ENC.encode(note) })]
+}

--- a/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
@@ -196,11 +196,14 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
       creating,
       creating && startPoint === undefined,
     )
-    carried = [...moved]
+    carried = [...moved.carried]
       .sort(([a], [b]) => compareCodePoints(a, b))
       .map(([path, letter]) => `${letter}\t${path}\n`)
       .join('')
-    note = await previousPosition(repo, head)
+    // git writes the warning above everything it says about the move, because
+    // the directory it could not remove is a fact about the working tree
+    // rather than about where HEAD went.
+    note = moved.warnings + (await previousPosition(repo, head))
     if (attached) {
       const verb = creating ? 'Switched to a new branch' : 'Switched to branch'
       note += `${verb} '${target}'\n`

--- a/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
@@ -36,7 +36,7 @@ import { short } from './format.ts'
 import { BRANCH_PREFIX, loadRefs, readHead, TAG_PREFIX, validRefName } from './refs.ts'
 import { opened, repoArgs } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
-import { checkOperands, fatal } from './util.ts'
+import { checkOperands, escaped, fatal } from './util.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
 const ENC = new TextEncoder()
@@ -91,7 +91,7 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
     if (statPath === undefined || dispatch === undefined) {
       throw new NoWorkspaceError()
     }
-    checkOperands(texts, UnknownSwitchError)
+    checkOperands(texts, UnknownSwitchError, escaped(inv.argv))
     const flags = parseFlags(fl)
     const creating = flags.create !== undefined
     if (creating && flags.detach) throw new DetachWithCreateError()

--- a/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
@@ -145,7 +145,13 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
       }
     } else {
       target = first ?? HEAD
-      if (!flags.detach && target === head.branch) {
+      // The ref has to exist, not just be the name HEAD carries. A fresh
+      // repository's HEAD names a branch that has never been written, and
+      // reading the name alone answered `Already on 'main'` at exit 0 for a
+      // branch with no commit to be on. git resolves it first and dies, which
+      // is what leaves `switch -c` as the only line an unborn HEAD accepts.
+      // Pinned against git 2.50.1.
+      if (!flags.detach && target === head.branch && known.has(`${BRANCH_PREFIX}${target}`)) {
         return [null, new IOResult({ stderr: ENC.encode(`Already on '${target}'\n`) })]
       }
       try {

--- a/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
@@ -108,9 +108,11 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
     let target: string
     let oid: string
     let attached: boolean
+    let startPoint: string | undefined
     if (flags.create !== undefined) {
       target = flags.create
       if (known.has(`${BRANCH_PREFIX}${target}`)) throw new BranchExistsError(target)
+      startPoint = first
       const start = first ?? HEAD
       try {
         oid = await resolveCommit(repo, start)
@@ -149,6 +151,7 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
       target,
       attached ? `${BRANCH_PREFIX}${target}` : null,
       creating,
+      creating && startPoint === undefined,
     )
     carried = [...dirty]
       .sort(compareCodePoints)

--- a/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/switch.ts
@@ -30,10 +30,19 @@ import {
   MissingBranchArgumentError,
   NoWorkspaceError,
   OneReferenceError,
+  RefLockError,
   UnknownSwitchError,
 } from './errors.ts'
 import { short } from './format.ts'
-import { BRANCH_PREFIX, loadRefs, readHead, setHead, TAG_PREFIX, validRefName } from './refs.ts'
+import {
+  BRANCH_PREFIX,
+  blockingRef,
+  loadRefs,
+  readHead,
+  setHead,
+  TAG_PREFIX,
+  validRefName,
+} from './refs.ts'
 import { opened, repoArgs } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
 import { checkOperands, escaped, fatal } from './util.ts'
@@ -135,6 +144,10 @@ export async function switchBranch(inv: CLIInvocation): Promise<CommandFnResult>
       // writeRef as one: -c ../../config would land on the repository's own
       // configuration rather than on a branch.
       if (!validRefName(target)) throw new InvalidBranchNameError(target)
+      // And before the working tree moves: git takes the ref lock first, so a
+      // name whose path another ref holds refuses with nothing checked out.
+      const held = blockingRef(new Set(known.keys()), `${BRANCH_PREFIX}${target}`)
+      if (held !== null) throw new RefLockError(`${BRANCH_PREFIX}${target}`, held)
       attached = true
       if (unborn) {
         await setHead(dispatch, repo.location.gitdir, `${BRANCH_PREFIX}${target}`)

--- a/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
@@ -148,13 +148,14 @@ export function renderListing(
  *
  * A tag made from another tag points at the tag object itself rather than at
  * what it peels to, which is git's own rule; anything else resolves as a
- * commit, ancestry suffixes included.
+ * commit first, ancestry suffixes included, and then as a bare object, so a
+ * blob or a tree id is a legal target.
  */
 async function resolveTarget(
   repo: Repo,
   known: ReadonlyMap<string, string>,
   revision: string,
-): Promise<{ oid: string; type: 'commit' | 'tag' }> {
+): Promise<{ oid: string; type: string }> {
   const held = known.get(`${TAG_PREFIX}${revision}`)
   if (held !== undefined) {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -163,6 +164,16 @@ async function resolveTarget(
   }
   try {
     return { oid: await resolveCommit(repo, revision), type: 'commit' }
+  } catch {
+    // Not a commit-ish. git tags any object and its usage line says so, so the
+    // id is read as itself before the revision is called unresolved; the type
+    // is kept, since it is what the tag records.
+  }
+  try {
+    const oid = await git.expandOid({ ...repoArgs(repo), oid: revision })
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const { type } = await git.readObject({ ...repoArgs(repo), oid })
+    return { oid, type }
   } catch {
     throw new UnresolvedRefError(revision)
   }
@@ -253,7 +264,9 @@ export async function tag(inv: CLIInvocation): Promise<CommandFnResult> {
     if (flags.listing || flags.lines !== undefined || texts.length === 0) {
       const names = selectedNames(tagNames(known), texts)
       let messages: Map<string, string[]> | null = null
-      if (flags.lines !== undefined) {
+      // -n0 (and any other count that prints no line) is a plain listing in
+      // git, so nothing is read and nothing is padded.
+      if (flags.lines !== undefined && flags.lines > 0) {
         messages = new Map()
         for (const each of names) {
           messages.set(each, await messageLines(repo, known.get(`${TAG_PREFIX}${each}`) ?? ''))

--- a/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
@@ -24,8 +24,10 @@ import {
   GitError,
   IncompatibleOptionsError,
   InvalidTagNameError,
+  ListModeOnlyError,
   MissingTagMessageError,
   NoWorkspaceError,
+  RefUpdateConflictError,
   TagExistsError,
   TagNotFoundError,
   TagUsageError,
@@ -235,12 +237,17 @@ export async function tag(inv: CLIInvocation): Promise<CommandFnResult> {
     ) {
       throw new TagUsageError()
     }
+    // After the two usage refusals above, which git reaches first: `-l -d -n1`
+    // is the incompatible pair and `-d -f -n1` the usage, both exiting 129,
+    // where `-d -n1` alone dies here.
+    if (flags.remove && flags.lines !== undefined) throw new ListModeOnlyError()
     const repo = await opened(fl, doors)
     abbrev = repo.abbrev
     const known = await loadRefs(dispatch, repo.location.gitdir, repo.location.commondir)
     if (flags.remove) {
       const out: string[] = []
       const err: string[] = []
+      const doomed: { name: string; ref: string; sha: string }[] = []
       for (const each of texts) {
         const ref = `${TAG_PREFIX}${each}`
         const sha = known.get(ref)
@@ -248,6 +255,25 @@ export async function tag(inv: CLIInvocation): Promise<CommandFnResult> {
           err.push(`error: ${new TagNotFoundError(each).message}\n`)
           continue
         }
+        doomed.push({ name: each, ref, sha })
+      }
+      // Every deletion on the line is one ref transaction, and a name given
+      // twice makes two updates for one ref, which the transaction refuses
+      // before applying any of them: the whole line deletes nothing. A name
+      // that is not there never reaches the transaction, so `-d nosuch nosuch`
+      // is two ordinary reports rather than this refusal.
+      const seen = new Map<string, number>()
+      for (const { ref } of doomed) seen.set(ref, (seen.get(ref) ?? 0) + 1)
+      const repeated = [...seen.entries()]
+        .filter(([, count]) => count > 1)
+        .map(([ref]) => ref)
+        .sort(compareCodePoints)
+      const blamed = repeated[0]
+      if (blamed !== undefined) {
+        err.push(`error: ${new RefUpdateConflictError(blamed).message}\n`)
+        return [null, new IOResult({ exitCode: 1, stderr: ENC.encode(err.join('')) })]
+      }
+      for (const { name: each, ref, sha } of doomed) {
         await deleteRef(dispatch, repo.location.commondir, ref)
         out.push(`Deleted tag '${each}' (was ${short(sha, repo.abbrev)})\n`)
       }

--- a/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
@@ -36,7 +36,7 @@ import {
 import { short } from './format.ts'
 import { deleteRef, loadRefs, TAG_PREFIX, validRefName, writeRef } from './refs.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
-import { resolveCommit } from './revparse.ts'
+import { resolveObject } from './revparse.ts'
 import { checkOperands, escaped, fatal } from './util.ts'
 import { fnmatch } from '../../../../utils/fnmatch.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
@@ -147,9 +147,10 @@ export function renderListing(
  * The object a new tag points at, and what kind it is.
  *
  * A tag made from another tag points at the tag object itself rather than at
- * what it peels to, which is git's own rule; anything else resolves as a
- * commit first, ancestry suffixes included, and then as a bare object, so a
- * blob or a tree id is a legal target.
+ * what it peels to, which is git's own rule. Anything else is resolved as an
+ * object expression, because git tags any object and its usage line says so:
+ * `HEAD^{tree}` and `HEAD:a.txt` are as good a target as a branch, and the type
+ * resolution lands on is what the tag records.
  */
 async function resolveTarget(
   repo: Repo,
@@ -163,17 +164,7 @@ async function resolveTarget(
     return { oid: held, type: type === 'tag' ? 'tag' : 'commit' }
   }
   try {
-    return { oid: await resolveCommit(repo, revision), type: 'commit' }
-  } catch {
-    // Not a commit-ish. git tags any object and its usage line says so, so the
-    // id is read as itself before the revision is called unresolved; the type
-    // is kept, since it is what the tag records.
-  }
-  try {
-    const oid = await git.expandOid({ ...repoArgs(repo), oid: revision })
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const { type } = await git.readObject({ ...repoArgs(repo), oid })
-    return { oid, type }
+    return await resolveObject(repo, revision)
   } catch {
     throw new UnresolvedRefError(revision)
   }

--- a/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
@@ -28,6 +28,7 @@ import {
   NoWorkspaceError,
   TagExistsError,
   TagNotFoundError,
+  TagUsageError,
   TooManyArgumentsError,
   UnknownSwitchError,
   UnresolvedRefError,
@@ -218,6 +219,16 @@ export async function tag(inv: CLIInvocation): Promise<CommandFnResult> {
     checkOperands(texts, UnknownSwitchError)
     const flags = parseFlags(fl)
     if (flags.listing && flags.remove) throw new IncompatibleOptionsError('-l', '-d')
+    // -a, -m and -f create a tag, so a line that lists or deletes instead has
+    // nothing for them to do: git prints its usage and exits 129, where the
+    // same line without them lists or deletes and exits 0. No operand at all is
+    // a listing, which is why it counts here too.
+    if (
+      (flags.annotate || flags.force) &&
+      (flags.listing || flags.remove || flags.lines !== undefined || texts.length === 0)
+    ) {
+      throw new TagUsageError()
+    }
     const repo = await opened(fl, doors)
     abbrev = repo.abbrev
     const known = await loadRefs(dispatch, repo.location.gitdir, repo.location.commondir)

--- a/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
@@ -1,0 +1,279 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import git from 'isomorphic-git'
+
+import { IOResult } from '../../../../io/types.ts'
+import type { CommandFnResult } from '../../../config.ts'
+import { FlagView } from '../../../spec/types.ts'
+import type { CLIInvocation } from '../../types.ts'
+import { identity } from './commit.ts'
+import { HEAD } from './constants.ts'
+import {
+  GitError,
+  IncompatibleOptionsError,
+  InvalidTagNameError,
+  MissingTagMessageError,
+  NoWorkspaceError,
+  TagExistsError,
+  TagNotFoundError,
+  TooManyArgumentsError,
+  UnknownSwitchError,
+  UnresolvedRefError,
+} from './errors.ts'
+import { short } from './format.ts'
+import { deleteRef, loadRefs, TAG_PREFIX, validRefName, writeRef } from './refs.ts'
+import { opened, repoArgs, type Repo } from './repo.ts'
+import { resolveCommit } from './revparse.ts'
+import { checkOperands, fatal } from './util.ts'
+import { fnmatch } from '../../../../utils/fnmatch.ts'
+import { compareCodePoints } from '../../../../utils/sort.ts'
+
+const ENC = new TextEncoder()
+const DEC = new TextDecoder()
+// git pads a tag name to this width before the message under -n.
+const NAME_WIDTH = 15
+const CONTINUATION = '    '
+
+/** The parsed shape of a `git tag` invocation. */
+interface TagFlags {
+  /** `-l`, list tags, the operands being patterns. */
+  readonly listing: boolean
+  /** `-d`, delete the named tags. */
+  readonly remove: boolean
+  /** `-a`, write a tag object; implied by `-m`. */
+  readonly annotate: boolean
+  /** `-m`, the tag message. */
+  readonly message: string | undefined
+  /** `-f`, replace a tag that exists. */
+  readonly force: boolean
+  /**
+   * `-n[<num>]`, how many message lines to print per tag when listing;
+   * undefined when not listing that way.
+   */
+  readonly lines: number | undefined
+}
+
+/**
+ * Read the raw tag flag kwargs into a frozen struct.
+ *
+ * `-n` carries its count attached or not at all, and a bare one means one line,
+ * which is why the value is read as an integer first and only then as a
+ * boolean. `-m` may repeat, each occurrence a paragraph of its own.
+ */
+function parseFlags(fl: FlagView): TagFlags {
+  let lines = fl.asInt('n')
+  if (lines === undefined && fl.asBool('n')) lines = 1
+  // Several -m are several paragraphs, joined the way git joins them.
+  const paragraphs = fl.asList('message')
+  const message = paragraphs.length > 0 ? paragraphs.join('\n\n') : undefined
+  return {
+    listing: fl.asBool('list'),
+    remove: fl.asBool('delete'),
+    annotate: fl.asBool('annotate') || message !== undefined,
+    message,
+    force: fl.asBool('force'),
+    lines,
+  }
+}
+
+/** Every tag name the repository publishes, in git's listing order. */
+export function tagNames(known: ReadonlyMap<string, string>): string[] {
+  return [...known.keys()]
+    .filter((ref) => ref.startsWith(TAG_PREFIX))
+    .map((ref) => ref.slice(TAG_PREFIX.length))
+    .sort(compareCodePoints)
+}
+
+/** The names a `-l` pattern list keeps: any pattern, or all. */
+export function selectedNames(names: readonly string[], patterns: readonly string[]): string[] {
+  if (patterns.length === 0) return [...names]
+  return names.filter((name) => patterns.some((pattern) => fnmatch(name, pattern)))
+}
+
+/**
+ * The message `-n` prints for a tag: its own, or its commit's.
+ *
+ * An annotated tag carries a message; a lightweight one is a bare pointer, so
+ * git shows the message of what it points at. Read off the raw object rather
+ * than through isomorphic-git's tag parser, which normalizes away the blank
+ * line an empty message leaves and then reads the headers as the message.
+ */
+async function messageLines(repo: Repo, oid: string): Promise<string[]> {
+  // Deprecated upstream for being general, but the general answer is what
+  // reading a tag and a commit the same way needs.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  const { type, object } = await git.readObject({ ...repoArgs(repo), oid, format: 'content' })
+  if (type !== 'tag' && type !== 'commit') return []
+  const text = DEC.decode(object as Uint8Array)
+  const cut = text.indexOf('\n\n')
+  const lines = (cut === -1 ? '' : text.slice(cut + 2)).split('\n')
+  if (lines[lines.length - 1] === '') lines.pop()
+  return lines
+}
+
+/** One line per tag, with up to `count` message lines under -n. */
+export function renderListing(
+  names: readonly string[],
+  messages: ReadonlyMap<string, readonly string[]> | null,
+  count: number,
+): string {
+  const lines: string[] = []
+  for (const name of names) {
+    if (messages === null) {
+      lines.push(name)
+      continue
+    }
+    const body = (messages.get(name) ?? []).slice(0, count)
+    lines.push(`${name.padEnd(NAME_WIDTH)} ${body[0] ?? ''}`)
+    for (const line of body.slice(1)) lines.push(`${CONTINUATION}${line}`)
+  }
+  return lines.map((line) => `${line}\n`).join('')
+}
+
+/**
+ * The object a new tag points at, and what kind it is.
+ *
+ * A tag made from another tag points at the tag object itself rather than at
+ * what it peels to, which is git's own rule; anything else resolves as a
+ * commit, ancestry suffixes included.
+ */
+async function resolveTarget(
+  repo: Repo,
+  known: ReadonlyMap<string, string>,
+  revision: string,
+): Promise<{ oid: string; type: 'commit' | 'tag' }> {
+  const held = known.get(`${TAG_PREFIX}${revision}`)
+  if (held !== undefined) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const { type } = await git.readObject({ ...repoArgs(repo), oid: held })
+    return { oid: held, type: type === 'tag' ? 'tag' : 'commit' }
+  }
+  try {
+    return { oid: await resolveCommit(repo, revision), type: 'commit' }
+  } catch {
+    throw new UnresolvedRefError(revision)
+  }
+}
+
+/**
+ * Write an annotated tag object and return its id.
+ *
+ * Rendered by hand rather than through isomorphic-git's tag writer, which
+ * appends a newline of its own after the message: git stores `-m x` as `x\n`
+ * and an empty message as nothing at all, and the bytes decide the id.
+ */
+export async function buildTag(
+  repo: Repo,
+  name: string,
+  target: { oid: string; type: string },
+  message: string,
+  tagger: string,
+  when: number,
+): Promise<string> {
+  const body = message === '' ? '' : `${message}\n`
+  const raw =
+    `object ${target.oid}\ntype ${target.type}\ntag ${name}\n` +
+    `tagger ${tagger} ${String(when)} +0000\n\n${body}`
+  // Deprecated upstream in favour of writeTag, which is the writer whose extra
+  // newline this exists to avoid.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  return git.writeObject({
+    ...repoArgs(repo),
+    type: 'tag',
+    object: ENC.encode(raw),
+    format: 'content',
+  })
+}
+
+/**
+ * List, create or delete tags.
+ *
+ * No operand lists them, a name creates one, `-d` deletes. A bare name is a
+ * lightweight tag, a pointer and nothing more; `-a` or `-m` writes a tag object
+ * carrying a message and a tagger, and `-a` without `-m` is refused for the
+ * reason `commit` refuses a missing message: there is no editor to open.
+ */
+export async function tag(inv: CLIInvocation): Promise<CommandFnResult> {
+  const doors = inv.doors ?? {}
+  const texts = [...inv.texts]
+  const fl = new FlagView(inv.flags)
+  let name: string
+  let was: string | undefined
+  let abbrev: number
+  try {
+    const dispatch = doors.dispatch
+    if (dispatch === undefined) throw new NoWorkspaceError()
+    checkOperands(texts, UnknownSwitchError)
+    const flags = parseFlags(fl)
+    if (flags.listing && flags.remove) throw new IncompatibleOptionsError('-l', '-d')
+    const repo = await opened(fl, doors)
+    abbrev = repo.abbrev
+    const known = await loadRefs(dispatch, repo.location.gitdir, repo.location.commondir)
+    if (flags.remove) {
+      const out: string[] = []
+      const err: string[] = []
+      for (const each of texts) {
+        const ref = `${TAG_PREFIX}${each}`
+        const sha = known.get(ref)
+        if (sha === undefined) {
+          err.push(`error: ${new TagNotFoundError(each).message}\n`)
+          continue
+        }
+        await deleteRef(dispatch, repo.location.commondir, ref)
+        out.push(`Deleted tag '${each}' (was ${short(sha, repo.abbrev)})\n`)
+      }
+      return [
+        ENC.encode(out.join('')),
+        new IOResult({ exitCode: err.length > 0 ? 1 : 0, stderr: ENC.encode(err.join('')) }),
+      ]
+    }
+    if (flags.listing || flags.lines !== undefined || texts.length === 0) {
+      const names = selectedNames(tagNames(known), texts)
+      let messages: Map<string, string[]> | null = null
+      if (flags.lines !== undefined) {
+        messages = new Map()
+        for (const each of names) {
+          messages.set(each, await messageLines(repo, known.get(`${TAG_PREFIX}${each}`) ?? ''))
+        }
+      }
+      return [ENC.encode(renderListing(names, messages, flags.lines ?? 0)), new IOResult()]
+    }
+    if (texts.length > 2) throw new TooManyArgumentsError()
+    name = texts[0] ?? ''
+    if (!validRefName(name)) throw new InvalidTagNameError(name)
+    const ref = `${TAG_PREFIX}${name}`
+    was = known.get(ref)
+    if (was !== undefined && !flags.force) throw new TagExistsError(name)
+    if (flags.annotate && flags.message === undefined) throw new MissingTagMessageError()
+    const target = await resolveTarget(repo, known, texts[1] ?? HEAD)
+    let pointed = target.oid
+    if (flags.annotate) {
+      pointed = await buildTag(
+        repo,
+        name,
+        target,
+        flags.message ?? '',
+        identity(fl, doors.sessionView).line,
+        Math.floor(Date.now() / 1000),
+      )
+    }
+    await writeRef(dispatch, repo.location.commondir, ref, pointed)
+  } catch (err) {
+    if (err instanceof GitError) return fatal(err)
+    throw err
+  }
+  if (was === undefined) return [null, new IOResult()]
+  return [ENC.encode(`Updated tag '${name}' (was ${short(was, abbrev)})\n`), new IOResult()]
+}

--- a/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
@@ -27,6 +27,7 @@ import {
   ListModeOnlyError,
   MissingTagMessageError,
   NoWorkspaceError,
+  RefLockError,
   RefUpdateConflictError,
   TagExistsError,
   TagNotFoundError,
@@ -36,7 +37,7 @@ import {
   UnresolvedRefError,
 } from './errors.ts'
 import { short } from './format.ts'
-import { deleteRef, loadRefs, TAG_PREFIX, validRefName, writeRef } from './refs.ts'
+import { blockingRef, deleteRef, loadRefs, TAG_PREFIX, validRefName, writeRef } from './refs.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { resolveObject } from './revparse.ts'
 import { checkOperands, escaped, fatal } from './util.ts'
@@ -314,6 +315,11 @@ export async function tag(inv: CLIInvocation): Promise<CommandFnResult> {
         Math.floor(Date.now() / 1000),
       )
     }
+    // After the object is built, which is git's order: an annotated tag whose
+    // ref cannot be locked has already been written to the database and is
+    // left there unreferenced.
+    const held = blockingRef(new Set(known.keys()), ref)
+    if (held !== null) throw new RefLockError(ref, held)
     await writeRef(dispatch, repo.location.commondir, ref, pointed)
   } catch (err) {
     if (err instanceof GitError) return fatal(err)

--- a/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
@@ -37,7 +37,7 @@ import { short } from './format.ts'
 import { deleteRef, loadRefs, TAG_PREFIX, validRefName, writeRef } from './refs.ts'
 import { opened, repoArgs, type Repo } from './repo.ts'
 import { resolveCommit } from './revparse.ts'
-import { checkOperands, fatal } from './util.ts'
+import { checkOperands, escaped, fatal } from './util.ts'
 import { fnmatch } from '../../../../utils/fnmatch.ts'
 import { compareCodePoints } from '../../../../utils/sort.ts'
 
@@ -227,7 +227,7 @@ export async function tag(inv: CLIInvocation): Promise<CommandFnResult> {
   try {
     const dispatch = doors.dispatch
     if (dispatch === undefined) throw new NoWorkspaceError()
-    checkOperands(texts, UnknownSwitchError)
+    checkOperands(texts, UnknownSwitchError, escaped(inv.argv))
     const flags = parseFlags(fl)
     if (flags.listing && flags.remove) throw new IncompatibleOptionsError('-l', '-d')
     // -a, -m and -f create a tag, so a line that lists or deletes instead has

--- a/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
@@ -25,6 +25,7 @@ import {
   IncompatibleOptionsError,
   InvalidTagNameError,
   ListModeOnlyError,
+  TagLinesError,
   MissingTagMessageError,
   NoWorkspaceError,
   RefLockError,
@@ -64,7 +65,7 @@ interface TagFlags {
   readonly force: boolean
   /**
    * `-n[<num>]`, how many message lines to print per tag when listing;
-   * undefined when not listing that way.
+   * undefined when `-n` was not given, which `-n-1` also means.
    */
   readonly lines: number | undefined
 }
@@ -79,6 +80,10 @@ interface TagFlags {
 function parseFlags(fl: FlagView): TagFlags {
   let lines = fl.asInt('n')
   if (lines === undefined && fl.asBool('n')) lines = 1
+  // -1 is where git's own parser starts the count, so it reads as "-n was
+  // never given" rather than as a count of -1: `-n-1` deletes and creates
+  // where any real `-n` refuses both.
+  if (lines === -1) lines = undefined
   // Several -m are several paragraphs, joined the way git joins them.
   const paragraphs = fl.asList('message')
   const message = paragraphs.length > 0 ? paragraphs.join('\n\n') : undefined
@@ -242,6 +247,10 @@ export async function tag(inv: CLIInvocation): Promise<CommandFnResult> {
     // is the incompatible pair and `-d -f -n1` the usage, both exiting 129,
     // where `-d -n1` alone dies here.
     if (flags.remove && flags.lines !== undefined) throw new ListModeOnlyError()
+    // git reads the count while parsing the format it lists with, which is
+    // after both usage refusals above and before any ref is read: a repository
+    // holding no tags refuses this one too.
+    if (flags.lines !== undefined && flags.lines < 0) throw new TagLinesError(flags.lines)
     const repo = await opened(fl, doors)
     abbrev = repo.abbrev
     const known = await loadRefs(dispatch, repo.location.gitdir, repo.location.commondir)

--- a/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/tag.ts
@@ -159,9 +159,13 @@ async function resolveTarget(
 ): Promise<{ oid: string; type: string }> {
   const held = known.get(`${TAG_PREFIX}${revision}`)
   if (held !== undefined) {
+    // The type is recorded as read. A lightweight tag is a ref like any
+    // other and points at whatever it was made from, so `tag blobtag
+    // HEAD:a.txt` then `tag -a release -m x blobtag` records `type blob`;
+    // calling it a commit wrote a tag object git show and git fsck reject.
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { type } = await git.readObject({ ...repoArgs(repo), oid: held })
-    return { oid: held, type: type === 'tag' ? 'tag' : 'commit' }
+    return { oid: held, type }
   }
   try {
     return await resolveObject(repo, revision)

--- a/typescript/packages/core/src/commands/cli/builtin/git/types.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/types.ts
@@ -61,6 +61,21 @@ export interface HeadRef {
 }
 
 /**
+ * What moving HEAD carried across, and what it could not do.
+ *
+ * Two things rather than one because git writes both: the paths whose
+ * uncommitted change survived the move go to stdout with their status letters,
+ * and a submodule directory the move could not remove is a warning on stderr
+ * above the line saying the branch changed.
+ */
+export interface HeadMove {
+  /** Each path whose uncommitted change was carried across, by status letter. */
+  readonly carried: ReadonlyMap<string, string>
+  /** The warning lines to write before the note, empty when there are none. */
+  readonly warnings: string
+}
+
+/**
  * One object id with the type git records for it.
  *
  * The pair travels together because a revision that names a tree or a blob is
@@ -82,6 +97,15 @@ export interface AncestryStep {
   /** The number after the suffix, 1 when it was bare. */
   readonly count: number
 }
+
+/** One `^{<type>}` suffix of a revision. */
+export interface PeelStep {
+  /** The type word inside the braces, empty for `^{}`. */
+  readonly want: string
+}
+
+/** One operator of a revision, in the order git applies them. */
+export type RevOp = AncestryStep | PeelStep
 
 /**
  * One entry of `.git/index`.

--- a/typescript/packages/core/src/commands/cli/builtin/git/types.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/types.ts
@@ -60,6 +60,18 @@ export interface HeadRef {
   readonly commit: string | null
 }
 
+/**
+ * One object id with the type git records for it.
+ *
+ * The pair travels together because a revision that names a tree or a blob is
+ * as legal as one that names a commit wherever an object is wanted, and the
+ * type is what a tag records about its target.
+ */
+export interface GitObject {
+  readonly oid: string
+  readonly type: string
+}
+
 /** One `~` or `^` suffix of a revision. */
 export interface AncestryStep {
   /**

--- a/typescript/packages/core/src/commands/cli/builtin/git/util.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/util.ts
@@ -20,6 +20,8 @@ import type { GitError } from './errors.ts'
 import { UnrecognizedArgumentError } from './errors.ts'
 
 const ROOT = '/'
+// The end-of-options marker, which the parser consumes.
+const MARKER = '--'
 
 const ENC = new TextEncoder()
 
@@ -53,6 +55,27 @@ export function revisionArg(texts: readonly string[], fallback: string = HEAD): 
 }
 
 /**
+ * The words a `--` on the line marked as operands, not options.
+ *
+ * `--` is exactly how a caller names a file whose name begins with a dash, and
+ * git says so in every synopsis that ends `[--] [<pathspec>...]`: `git rm
+ * -draft` is a refused switch and `git rm -- -draft` removes the file. The
+ * parser consumes the marker, so the words themselves are what carries the fact
+ * forward, read back off the verbatim argv the record already holds.
+ *
+ * A set is enough. A dash word before the marker was read as an option and
+ * never reached the operands, so a word that is here and also spelled earlier on
+ * the line is still the escaped one.
+ *
+ * @param argv the line's verbatim tokens after the head word, subcommand words
+ *   included
+ */
+export function escaped(argv: readonly string[]): Set<string> {
+  const at = argv.indexOf(MARKER)
+  return at === -1 ? new Set() : new Set(argv.slice(at + 1))
+}
+
+/**
  * Refuse an operand that is really an option this build lacks.
  *
  * A verb taking a revision accepts free text, so every flag mirage does not
@@ -61,26 +84,30 @@ export function revisionArg(texts: readonly string[], fallback: string = HEAD): 
  * when what happened is that mirage has no such flag. Refused here, before any
  * object is read, so the message names the real problem.
  *
- * A pathspec is not checked for and cannot be: the shared parser consumes `--`
- * as its end-of-options marker, so `log -- a.txt` and `log a.txt` reach a leaf
- * identically. Both resolve the operand as a revision and fail with git's own
- * "unknown revision or path" wording, which is exactly right for an untracked
- * path and a deliberate divergence for a tracked one, where git would narrow the
- * walk instead. Erring is the safe half of that trade: limiting by nothing would
- * print every commit and look like an answer.
+ * Unless the caller said otherwise. A word after `--` is an operand by the
+ * caller's own instruction whatever it starts with, so it is never read as an
+ * option here; see `escaped`, which is where the marker survives the parser.
+ *
+ * Which side of the marker an operand fell on says nothing about what it
+ * *means*: a verb taking a revision reads an escaped word as one and fails with
+ * git's own "unknown revision or path" wording, where git would narrow the walk
+ * by it instead. That divergence is unchanged and deliberate, because limiting
+ * by nothing would print every commit and look like an answer.
  *
  * Which refusal to raise is the caller's, because git words this differently per
  * verb and means each one: see UnknownSwitchError for the three.
  *
  * @param texts positional text operands, as typed
  * @param error the refusal this verb words it with
+ * @param marked operands a `--` on the line escaped
  */
 export function checkOperands(
   texts: readonly string[],
   error: new (argument: string) => GitError = UnrecognizedArgumentError,
+  marked: ReadonlySet<string> = new Set(),
 ): void {
   for (const text of texts) {
-    if (text.startsWith('-')) throw new error(text)
+    if (text.startsWith('-') && !marked.has(text)) throw new error(text)
   }
 }
 

--- a/typescript/packages/core/src/commands/cli/builtin/git/util.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/git/util.ts
@@ -120,11 +120,18 @@ export function checkOperands(
  * instead, which is git's own split, and a refusal that is really a report
  * ("nothing to commit") carries no prefix and goes to stdout.
  *
+ *
+ * An error carrying a `report` puts that on stdout beside the stderr line,
+ * because git writes some refusals to both streams at once: `<path>: needs
+ * merge` is the diagnosis and "you need to resolve your current index first" is
+ * the refusal.
+ *
  * @param exc the error to render
  */
 export function fatal(exc: GitError): CommandFnResult {
   const body = exc.prefix === null ? `${exc.message}\n` : `${exc.prefix}: ${exc.message}\n`
   const data = ENC.encode(body)
   if (exc.stream === 'stdout') return [data, new IOResult({ exitCode: exc.code })]
-  return [null, new IOResult({ exitCode: exc.code, stderr: data })]
+  const told = exc.report === '' ? null : ENC.encode(exc.report)
+  return [told, new IOResult({ exitCode: exc.code, stderr: data })]
 }

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.test.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.test.ts
@@ -197,18 +197,41 @@ describe('the node table answers every verb that names a link', () => {
     }
   })
 
-  it('replaces the nodes below a rename destination', async () => {
-    // rename(2) replaces what it lands on, subtree included, so a link left
-    // below the destination would shadow the content that arrived.
+  it('refuses a rename destination holding a link', async () => {
+    // A link is a directory entry no backend can see, so a destination the
+    // backend reads as empty is not: POSIX rename(2) answers ENOTEMPTY for it
+    // (probed on debian:stable-slim, where a directory holding one broken
+    // symlink refuses the rename). Letting the backend decide replaced the
+    // directory and deleted the link with it, which loses namespace state
+    // where the kernel refuses.
     const ws = await linkWorkspace()
     try {
       await ws.execute('echo hi > /ram/d/a.txt')
       await ws.execute('ln -s a.txt /ram/d/inner')
       await ws.execute('mkdir /ram/e')
       await ws.execute('ln -s gone /ram/e/stale')
+      await expect(
+        ws.dispatch('rename', '/ram/d', [PathSpec.fromStrPath('/ram/e')]),
+      ).rejects.toMatchObject({ code: 'ENOTEMPTY' })
+      // Nothing moved: both ends are as they were.
+      expect(DEC.decode((await ws.execute('readlink /ram/e/stale')).stdout)).toBe('gone\n')
+      expect(DEC.decode((await ws.execute('readlink /ram/d/inner')).stdout)).toBe('a.txt\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('replaces an empty rename destination', async () => {
+    // The other half of rename(2): a destination with nothing in it is
+    // replaced, and the subtree re-anchors onto the new name.
+    const ws = await linkWorkspace()
+    try {
+      await ws.execute('echo hi > /ram/d/a.txt')
+      await ws.execute('ln -s a.txt /ram/d/inner')
+      await ws.execute('mkdir /ram/e')
       await ws.dispatch('rename', '/ram/d', [PathSpec.fromStrPath('/ram/e')])
-      expect((await ws.execute('readlink /ram/e/stale')).exitCode).toBe(1)
       expect(DEC.decode((await ws.execute('readlink /ram/e/inner')).stdout)).toBe('a.txt\n')
+      expect((await ws.execute('readlink /ram/d/inner')).exitCode).toBe(1)
     } finally {
       await ws.close()
     }

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.test.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.test.ts
@@ -180,6 +180,40 @@ describe('the node table answers every verb that names a link', () => {
     }
   })
 
+  it('carries the nodes below a renamed directory', async () => {
+    // A rename re-anchors a whole subtree, and the part of it no backend can
+    // see has to move with it: the link below the source used to stay at a
+    // name the rename had emptied, so the moved directory was missing it and
+    // the old name still answered readlink.
+    const ws = await linkWorkspace()
+    try {
+      await ws.execute('echo hi > /ram/d/a.txt')
+      await ws.execute('ln -s a.txt /ram/d/inner')
+      await ws.dispatch('rename', '/ram/d', [PathSpec.fromStrPath('/ram/e')])
+      expect(DEC.decode((await ws.execute('readlink /ram/e/inner')).stdout)).toBe('a.txt\n')
+      expect((await ws.execute('readlink /ram/d/inner')).exitCode).toBe(1)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('replaces the nodes below a rename destination', async () => {
+    // rename(2) replaces what it lands on, subtree included, so a link left
+    // below the destination would shadow the content that arrived.
+    const ws = await linkWorkspace()
+    try {
+      await ws.execute('echo hi > /ram/d/a.txt')
+      await ws.execute('ln -s a.txt /ram/d/inner')
+      await ws.execute('mkdir /ram/e')
+      await ws.execute('ln -s gone /ram/e/stale')
+      await ws.dispatch('rename', '/ram/d', [PathSpec.fromStrPath('/ram/e')])
+      expect((await ws.execute('readlink /ram/e/stale')).exitCode).toBe(1)
+      expect(DEC.decode((await ws.execute('readlink /ram/e/inner')).stdout)).toBe('a.txt\n')
+    } finally {
+      await ws.close()
+    }
+  })
+
   it('answers a no-follow stat with the link row', async () => {
     // lstat asks for the row only the node table holds; a following stat
     // arrives resolved to the target and must not see a link at all.

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.test.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.test.ts
@@ -420,3 +420,44 @@ describe('the turf mode gates the node table', () => {
     }
   })
 })
+
+describe('a rename moves what the node table holds', () => {
+  it('carries the node at the source itself', async () => {
+    // The subtree below the source was re-anchored and the source's own
+    // node was not, so an overlay recorded there stayed at the emptied
+    // name: it never reached the landing, and whatever was created at
+    // the old name next inherited it.
+    const parser = await getTestParser()
+    const ws = new Workspace(
+      { '/a': new RAMResource() },
+      { mode: MountMode.WRITE, shellParserFactory: () => Promise.resolve(parser) },
+    )
+    try {
+      await ws.execute('printf one > /a/f.txt')
+      await ws.namespace.setAttrs('/a/f.txt', { mode: 0o400 })
+      await ws.dispatch('rename', '/a/f.txt', [PathSpec.fromStrPath('/a/g.txt')])
+      expect(ws.namespace.metaFor('/a/f.txt')).toBeNull()
+      expect(ws.namespace.metaFor('/a/g.txt')?.mode).toBe(0o400)
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('replaces the node at the landing', async () => {
+    // rename(2) replaces the destination, so the overlay it carried
+    // goes with it rather than staying to shadow what just landed.
+    const parser = await getTestParser()
+    const ws = new Workspace(
+      { '/a': new RAMResource() },
+      { mode: MountMode.WRITE, shellParserFactory: () => Promise.resolve(parser) },
+    )
+    try {
+      await ws.execute('printf one > /a/f.txt && printf two > /a/g.txt')
+      await ws.namespace.setAttrs('/a/g.txt', { mode: 0o400 })
+      await ws.dispatch('rename', '/a/f.txt', [PathSpec.fromStrPath('/a/g.txt')])
+      expect(ws.namespace.metaFor('/a/g.txt')).toBeNull()
+    } finally {
+      await ws.close()
+    }
+  })
+})

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -26,6 +26,7 @@ import {
   eexist,
   einval,
   enoent,
+  enotempty,
   isMissError,
   isMissingOp,
   type FsError,
@@ -242,6 +243,19 @@ export class Dispatcher {
           throw eacces(path.virtual)
         }
       }
+    }
+    if (
+      opName === 'rename' &&
+      dstArg instanceof PathSpec &&
+      this.namespace.linkStatsBelow(dstArg.virtual).length > 0
+    ) {
+      // rename(2) replaces a destination directory only when it is empty, and
+      // the node table is half of what empty means here: a link is invisible to
+      // every backend, so a destination the backend reads as empty can still
+      // hold one. Left to the backend the rename succeeded and the purge below
+      // then deleted the link with it, losing namespace state silently where
+      // POSIX promises ENOTEMPTY.
+      throw enotempty(dstArg.virtual)
     }
     if (this.tableAnswers(opName, path.virtual, kwargs)) {
       return [

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -471,7 +471,7 @@ export class Dispatcher {
       const observed = STAMP_WRITE_OPS.has(opName) ? Date.now() / 1000 : null
       await this.invalidateAfterWriteByPath(p.virtual, observed)
       if (renameDst !== null) {
-        await this.invalidateAfterWriteByPath(renameDst.virtual)
+        await this.invalidateAfterRenameByPath(p.virtual, renameDst.virtual)
         // rename(2) replaces the destination, so a node the table holds
         // at that name does not survive the move. A link left there
         // shadowed the file that had just landed: the listing showed the
@@ -1017,6 +1017,26 @@ export class Dispatcher {
     await this.cache.clear()
   }
 
+  /**
+   * The cache manager that owns a mount's listings and bodies.
+   *
+   * One manager for both halves, as Python's invalidate_after_write does: it
+   * is what knows the file cache is keyed mount-absolute while the index may
+   * not be, and evicting the index inline here spelled the key the other way
+   * and missed.
+   */
+  private managerFor(mount: MountEntry): CacheManager {
+    return (
+      mount.cacheManager ??
+      new CacheManager(
+        this.cache,
+        mount.resource.index ?? null,
+        mount.prefix,
+        cachesReads(mount.resource),
+      )
+    )
+  }
+
   async invalidateAfterWriteByPath(rawPath: string, observed: number | null = null): Promise<void> {
     // Directory writes (mkdir/rmdir via tree copies) arrive with a
     // trailing slash; normalize so the parent computation below does not
@@ -1026,20 +1046,29 @@ export class Dispatcher {
     const mount = this.namespace.tryMountFor(path)
     if (mount === null) return
     await this.namespace.clearTimes(path, observed)
-    // One manager for both halves, as Python's invalidate_after_write
-    // does: it is what knows the file cache is keyed mount-absolute while
-    // the index may not be, and evicting the index inline here spelled
-    // the key the other way and missed.
-    const manager =
-      mount.cacheManager ??
-      new CacheManager(
-        this.cache,
-        mount.resource.index ?? null,
-        mount.prefix,
-        cachesReads(mount.resource),
-      )
+    const manager = this.managerFor(mount)
     await manager.invalidateAfterWrite(path)
     await manager.invalidateAncestors(path)
+  }
+
+  /**
+   * Drop everything cached below both ends of a rename.
+   *
+   * A rename re-anchors the whole subtree under its source, so the listings
+   * and bodies cached one level down under either name are stale, not just the
+   * two paths and their parents. Evicting only those left a moved directory's
+   * old name answering `stat` and `ls` from its cached children, so the next
+   * rename onto that name saw a directory that was no longer there.
+   */
+  async invalidateAfterRenameByPath(source: string, dst: string): Promise<void> {
+    const from = rstripSlash(source) || '/'
+    const to = rstripSlash(dst) || '/'
+    const mount = this.namespace.tryMountFor(from)
+    if (mount === null) return
+    const manager = this.managerFor(mount)
+    await manager.invalidateSubtree(from)
+    await manager.invalidateSubtree(to)
+    await manager.invalidateAncestors(to)
   }
 
   // The file cache only holds paths for read-caching mounts, mirroring

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -478,6 +478,13 @@ export class Dispatcher {
         // new file, every read followed the old link, and the moved
         // content was reachable under no name at all.
         await this.namespace.unlink(renameDst.virtual)
+        // The subtree moves with it, and only the node table can move the
+        // part of it no backend holds: a link or an attr overlay below the
+        // source is addressed by absolute path, so it would otherwise stay
+        // behind at a name the rename has emptied. The destination's own
+        // subtree is replaced first, as rename(2) replaces what it lands on.
+        await this.namespace.purgeUnder(renameDst.virtual)
+        await this.namespace.renameUnder(p.virtual, renameDst.virtual)
       }
     }
     if (opName === 'stat' && result instanceof FileStat) {

--- a/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
+++ b/typescript/packages/core/src/workspace/dispatcher/dispatcher.ts
@@ -498,6 +498,13 @@ export class Dispatcher {
         // behind at a name the rename has emptied. The destination's own
         // subtree is replaced first, as rename(2) replaces what it lands on.
         await this.namespace.purgeUnder(renameDst.virtual)
+        // The node at the source itself is not part of the subtree below it,
+        // so re-anchoring that subtree leaves it behind: the mode or ownership
+        // a chmod recorded stayed at the emptied name, never reached the
+        // landing, and was inherited by whatever was created at the old name
+        // next. Shell mv compensates for this in its own prepare step; a verb
+        // reaching the dispatcher directly, as git mv does, had nothing to.
+        await this.namespace.rename(p.virtual, renameDst.virtual)
         await this.namespace.renameUnder(p.virtual, renameDst.virtual)
       }
     }

--- a/typescript/packages/core/src/workspace/executor/builtins/links/links.test.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/links/links.test.ts
@@ -16,9 +16,12 @@ import { describe, expect, it } from 'vitest'
 import type { Policy } from '../../../../policy/base.ts'
 import type { Action, OpsContext } from '../../../../policy/types.ts'
 import { RAMResource } from '../../../../resource/ram/ram.ts'
-import { MountMode } from '../../../../types.ts'
+import { MountMode, PathSpec } from '../../../../types.ts'
 import { getTestParser } from '../../../fixtures/workspace_fixture.ts'
 import { Workspace } from '../../../workspace/workspace.ts'
+import { prepareMv } from './links.ts'
+import { IOResult } from '../../../../io/types.ts'
+import type { DispatchFn } from '../../../../runtime/types.ts'
 
 const DEC = new TextDecoder()
 
@@ -38,6 +41,13 @@ class SealReads implements Policy {
     }
     return null
   }
+}
+
+function dispatchOf(ws: Workspace): DispatchFn {
+  return async (op, path, args = [], kwargs = {}) => [
+    await ws.dispatch(op, path.virtual, args, kwargs),
+    new IOResult(),
+  ]
 }
 
 async function makeWs(policies: Policy[] = []): Promise<Workspace> {
@@ -277,6 +287,78 @@ describe('rm and unlink reach a link through the op door', () => {
       }
       expect(ws.namespace.isLink('/data/l1')).toBe(true)
       expect(ws.namespace.isLink('/data/l2')).toBe(true)
+    } finally {
+      await ws.close()
+    }
+  })
+})
+
+describe('mv re-anchors what the node table holds', () => {
+  it('hands back the pair whatever the table holds at the source', async () => {
+    // Gated on the source carrying overlay attrs, the pair was withheld
+    // for a directory whose own node is empty, and every link below it
+    // stayed at the emptied name: readable nowhere, since no backend
+    // holds an entry for a link at all.
+    const ws = await makeWs()
+    try {
+      await ws.execute('mkdir -p /data/d; printf t > /data/t')
+      await ws.execute('ln -s /data/t /data/d/link')
+      const prepared = await prepareMv(
+        ws.namespace,
+        dispatchOf(ws),
+        [PathSpec.fromStrPath('/data/d'), PathSpec.fromStrPath('/data/moved')],
+        ['/data/d', '/data/moved'],
+        '/',
+      )
+      expect(prepared.early).toBeNull()
+      expect(prepared.postUnlink).toBe('/data/moved')
+      expect(prepared.postRename).toEqual(['/data/d', '/data/moved'])
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('reads the destination off the parsed line', async () => {
+    // -T names the destination outright, so no basename is appended to
+    // it, and -t makes every positional a source, which is the shape a
+    // two-operand pair cannot describe at all.
+    const ws = await makeWs()
+    try {
+      await ws.execute('mkdir -p /data/dst; printf a > /data/a')
+      const pair = [PathSpec.fromStrPath('/data/a'), PathSpec.fromStrPath('/data/dst')]
+      const dispatch = dispatchOf(ws)
+      const into = await prepareMv(ws.namespace, dispatch, pair, ['/data/a', '/data/dst'], '/')
+      expect(into.postRename).toEqual(['/data/a', '/data/dst/a'])
+      const onto = await prepareMv(
+        ws.namespace,
+        dispatch,
+        pair,
+        ['-T', '/data/a', '/data/dst'],
+        '/',
+      )
+      expect(onto.postRename).toEqual(['/data/a', '/data/dst'])
+      const many = await prepareMv(
+        ws.namespace,
+        dispatch,
+        pair,
+        ['-t', '/data/dst', '/data/a'],
+        '/',
+      )
+      expect(many.postRename).toBeNull()
+    } finally {
+      await ws.close()
+    }
+  })
+
+  it('moves a link below a renamed directory with it', async () => {
+    const ws = await makeWs()
+    try {
+      await ws.execute('mkdir -p /data/d; printf t > /data/t')
+      await ws.execute('ln -s /data/t /data/d/link')
+      expect((await ws.execute('mv /data/d /data/moved')).exitCode).toBe(0)
+      const told = await ws.execute('readlink /data/moved/link')
+      expect([told.exitCode, DEC.decode(told.stdout)]).toEqual([0, '/data/t\n'])
+      expect((await ws.execute('readlink /data/d/link')).exitCode).not.toBe(0)
     } finally {
       await ws.close()
     }

--- a/typescript/packages/core/src/workspace/executor/builtins/links/links.ts
+++ b/typescript/packages/core/src/workspace/executor/builtins/links/links.ts
@@ -12,7 +12,8 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { SPECS, parseCommand } from '../../../../commands/spec/index.ts'
+import { FlagView, SPECS, parseCommand } from '../../../../commands/spec/index.ts'
+import { parseToKwargs } from '../../../../commands/spec/parser.ts'
 import type { FileStat } from '../../../../types.ts'
 import { FileType, PathSpec } from '../../../../types.ts'
 import { blamedPath, fsStrerror, isEacces, isEnoent, isErofs } from '../../../../utils/errors.ts'
@@ -251,18 +252,39 @@ export interface PreparedMv {
 // the link entry itself. A destination that is (a link to) a directory
 // receives the move inside it (rename(2) preceded by mv's dst stat); any
 // other destination is replaced, so its node entry, link or overlay attrs
-// alike, drops once the backend move succeeds. A plain source that carries
-// overlay attributes has its meta travel with the file once the backend
-// move succeeds.
+// alike, drops once the backend move succeeds. A plain source hands back the
+// pair to re-anchor once the backend move succeeds, so whatever the node table
+// holds at it and below it travels with the bytes.
+//
+// The pair is where this can be done at all: a single-mount `mv` renames
+// through the backend op bound to the accessor rather than through the
+// dispatcher, so the re-anchoring the dispatcher does for every other caller
+// has to be repeated here. Only a two-operand line qualifies, because a
+// path-shaped word is classified into a PathSpec whether it filled an operand
+// slot or a flag's value, and nothing here can tell `mv a b dst` from
+// `mv -t dst a b`.
 export async function prepareMv(
   namespace: Namespace,
   dispatch: DispatchFn,
   items: (string | PathSpec)[],
+  args: readonly string[],
+  cwd: string,
 ): Promise<PreparedMv> {
   const paths = items.filter((p): p is PathSpec => p instanceof PathSpec)
   const src = paths[0]
   const dst = paths[1]
   if (paths.length !== 2 || src === undefined || dst === undefined) {
+    return { items, postUnlink: null, postRename: null, early: null }
+  }
+  // `-t` makes every positional a source and the flag's value the destination,
+  // which is the many-source shape above; `-T` names the destination outright,
+  // so no basename is appended to it. Both are read off the parsed line rather
+  // than guessed from the parts, since a path-shaped flag value is classified
+  // into a PathSpec there exactly as an operand is.
+  const spec = SPECS.mv
+  if (spec === undefined) return { items, postUnlink: null, postRename: null, early: null }
+  const fl = new FlagView(parseToKwargs(parseCommand(spec, [...args], cwd)), spec)
+  if (fl.raw('target_directory') !== undefined) {
     return { items, postUnlink: null, postRename: null, early: null }
   }
 
@@ -271,7 +293,8 @@ export async function prepareMv(
   // the destination itself, replaced like rename(2).
   const followed = namespace.follow(dst.virtual)
   const stat = await statOrNull(dispatch, PathSpec.fromStrPath(followed))
-  const intoDir = stat !== null && stat.type === FileType.DIRECTORY
+  const intoDir =
+    !fl.asBool('no_target_directory') && stat !== null && stat.type === FileType.DIRECTORY
   let targetDst = dst.virtual
   if (intoDir) {
     const name = src.virtual.slice(src.virtual.lastIndexOf('/') + 1)
@@ -311,10 +334,11 @@ export async function prepareMv(
     return { items, postUnlink: null, postRename: null, early }
   }
 
-  let postRename: [string, string] | null = null
-  if (namespace.metaFor(src.virtual) !== null) {
-    postRename = [src.virtual, targetDst]
-  }
+  // Unconditional: a directory source carries a whole subtree of node entries
+  // that no exact-path lookup at the source can see, and a symlink below it is
+  // destroyed rather than merely forgotten when they are left behind. Both
+  // halves are no-ops when the table holds nothing there.
+  const postRename: [string, string] = [src.virtual, targetDst]
 
   const rewritten = intoDir && namespace.isLink(dst.virtual) ? followPaths(namespace, items) : items
   return { items: rewritten, postUnlink: targetDst, postRename, early: null }

--- a/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
+++ b/typescript/packages/core/src/workspace/mount/namespace/namespace.ts
@@ -409,6 +409,32 @@ export class Namespace {
     return out
   }
 
+  /**
+   * Re-anchor every node below one directory onto another.
+   *
+   * A rename moves a whole subtree, and the node table addresses its entries by
+   * absolute path, so a link or an attr overlay below the source names a path
+   * that no longer exists once the backend has moved the bytes. No backend can
+   * report those entries, which is why nothing below the dispatcher can do this.
+   */
+  async renameUnder(src: string, dst: string): Promise<number> {
+    const base = rstripSlash(src) + '/'
+    const moved: [string, NodeMeta][] = []
+    for (const [path, meta] of this.nodeTable) {
+      if (path.startsWith(base)) moved.push([path, meta])
+    }
+    if (moved.length === 0) return 0
+    const landing = rstripSlash(dst)
+    for (const [path] of moved) this.nodeTable.delete(path)
+    for (const [path, meta] of moved) {
+      const target = `${landing}/${path.slice(base.length)}`
+      this.nodeTable.set(target, meta)
+      await this.store.set(target, metaToFields(meta))
+    }
+    await this.store.delete(moved.map(([path]) => path))
+    return moved.length
+  }
+
   // Drop every node entry under a directory (`rm -r` semantics).
   async purgeUnder(directory: string): Promise<number> {
     const base = rstripSlash(directory) + '/'

--- a/typescript/packages/core/src/workspace/node/command_dispatch.ts
+++ b/typescript/packages/core/src/workspace/node/command_dispatch.ts
@@ -780,7 +780,7 @@ async function routeArgv(
           ]
         }
       } else if (name === 'mv') {
-        const prepared = await prepareMv(namespace, dispatch, operands)
+        const prepared = await prepareMv(namespace, dispatch, operands, argv.args, session.cwd)
         operands = prepared.items
         postUnlink = prepared.postUnlink
         postRename = prepared.postRename
@@ -845,8 +845,18 @@ async function routeArgv(
         }
       }
     }
-    if (postUnlink !== null) await namespace.unlink(postUnlink)
-    if (postRename !== null) await namespace.rename(postRename[0], postRename[1])
+    if (postUnlink !== null) {
+      // The landing is replaced the way rename(2) replaces it, node and
+      // subtree alike, and then the source's own node and subtree land on it.
+      // The same four steps the dispatcher takes for a rename it forwards
+      // itself.
+      await namespace.unlink(postUnlink)
+      await namespace.purgeUnder(postUnlink)
+    }
+    if (postRename !== null) {
+      await namespace.rename(postRename[0], postRename[1])
+      await namespace.renameUnder(postRename[0], postRename[1])
+    }
   }
   if (linkErrors.length > 0) {
     // A refused link operand fails the line the way a refused backend

--- a/typescript/packages/node/src/ops/index_invalidation.test.ts
+++ b/typescript/packages/node/src/ops/index_invalidation.test.ts
@@ -15,7 +15,7 @@
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { MountMode } from '@struktoai/mirage-core/types'
+import { MountMode, PathSpec } from '@struktoai/mirage-core/types'
 import { DiskResource } from '../resource/disk/disk.ts'
 import { tmpRoot } from '../test-utils.ts'
 import { Workspace } from '../workspace.ts'
@@ -78,6 +78,26 @@ describe('dispatcher evicts the index after a write op', () => {
       expect(names(await ws.dispatch('readdir', '/d/'))).toEqual(['gone', 'seed'])
       await ws.dispatch('rmdir', '/d/gone')
       expect(names(await ws.dispatch('readdir', '/d/'))).toEqual(['seed'])
+    } finally {
+      await ws.close()
+      cleanup()
+    }
+  })
+})
+
+describe('dispatcher evicts both subtrees after a rename', () => {
+  it('the old name of a moved directory stops answering from its cached children', async () => {
+    // The old name kept answering from its cached children after the move,
+    // so a later rename onto that name saw a directory that was no longer
+    // there and landed the source inside it.
+    const { ws, cleanup } = diskWorkspace()
+    try {
+      await ws.dispatch('write', '/d/seed/readme.md', [new TextEncoder().encode('notes\n')])
+      expect(names(await ws.dispatch('readdir', '/d/seed'))).toEqual(['readme.md'])
+      await ws.dispatch('rename', '/d/seed', [PathSpec.fromStrPath('/d/moved')])
+      await expect(ws.dispatch('stat', '/d/seed')).rejects.toThrow()
+      await expect(ws.dispatch('readdir', '/d/seed')).rejects.toThrow()
+      expect(names(await ws.dispatch('readdir', '/d/moved'))).toEqual(['readme.md'])
     } finally {
       await ws.close()
       cleanup()


### PR DESCRIPTION
Part of #705 (local mutation and branching rows) and the #609 tracker work.

Adds `git switch`, `git restore`, `git rm`, `git mv` and `git tag` in both languages. `checkout` now shares `move_head` / `moveHead` with `switch`, and git's "Previous HEAD position was" line is printed on a detach. Every case is pinned against real git 2.50.1.

Also fixes the dispatcher's rename invalidation: it evicted only the two paths and their parents, so a renamed directory's old name kept answering `stat` and `ls` from cached children on the disk mount. Both dispatchers now evict the subtree on both ends.

Deliberate divergences, documented in `docs/*/cli/git.mdx`: `tag -a` without `-m` is a fatal (no editor); `mv` prints only its two usage lines; no `switch -`.

Tests: unit tests for each verb in both languages, dispatcher invalidation tests, and 58 new cases in `integ/cli/git.json` (py and ts batteries 302/302 on git-disk and git-ram).