### PR TITLE
fix(gdocs): include tab content in document retrieval

### DIFF
--- a/docs/python/cli/gws.mdx
+++ b/docs/python/cli/gws.mdx
@@ -110,8 +110,11 @@ Three things worth knowing:
   hand-written commands with a `+` (`gws docs +write`); mirage's tree does
   not need the marker, because a helper and a Discovery method cannot
   collide inside a typed spec. So an upstream line carrying `+` has to
-  drop it here. The helper flags are mirage's own too, and `--tab` has no
-  upstream counterpart: upstream has no tab support at all.
+  drop it here. The flag *names* are upstream's own and match it
+  (`--document --text`, `gmail send`'s `--to --subject --body`, `sheets
+  read`'s `--spreadsheet --range`); `--tab` is the single addition,
+  because upstream's `+write` takes no tab argument and upstream has no
+  tab support at all.
 
 ### Document tabs
 

--- a/docs/python/cli/gws.mdx
+++ b/docs/python/cli/gws.mdx
@@ -106,6 +106,12 @@ Three things worth knowing:
   than read as absent.
 - **Reads are not scoped.** `gws drive files list` still sees the whole
   account. The scope is about where new files go, not a fence.
+- **Helpers are spelled bare, not `+`-prefixed.** Upstream marks its
+  hand-written commands with a `+` (`gws docs +write`); mirage's tree does
+  not need the marker, because a helper and a Discovery method cannot
+  collide inside a typed spec. So an upstream line carrying `+` has to
+  drop it here. The helper flags are mirage's own too, and `--tab` has no
+  upstream counterpart: upstream has no tab support at all.
 
 ### Document tabs
 

--- a/docs/python/cli/gws.mdx
+++ b/docs/python/cli/gws.mdx
@@ -107,6 +107,34 @@ Three things worth knowing:
 - **Reads are not scoped.** `gws drive files list` still sees the whole
   account. The scope is about where new files go, not a fence.
 
+### Document tabs
+
+A Google Doc holds one or more tabs, and the Docs API reports them only
+when asked. `documents.get` fills the legacy top-level `body` from the
+**first tab** and leaves `tabs` empty unless `includeTabsContent` is set;
+with it, the content moves under `tabs[].documentTab` and `body` is left
+empty. The two shapes are exclusive, so it is a shape switch rather than a
+verbosity knob, and tabs nest through `childTabs`.
+
+A `.gdoc.json` on a mount is always the tab-aware shape, because that is
+the only one that can represent a document with more than one tab. Through
+the passthrough you choose:
+
+```bash
+# every tab, the shape a mount serves
+gws docs documents get --params '{"documentId": "DOC_ID", "includeTabsContent": true}'
+
+# the legacy flat body, which is the FIRST tab only
+gws docs documents get --params '{"documentId": "DOC_ID"}'
+```
+
+Writes pick a tab the same way. `gws docs write` without `--tab` appends to
+the first tab, which is the API's own default for a request that names no
+tab; read the ids out of a mounted file with
+`jq '[.. | .tabProperties? // empty | .tabId]'`. Note that
+`replaceAllText` is one of three requests that instead default to **every**
+tab, so a bare `batchUpdate` replacement is document-wide.
+
 ### Helpers
 
 | Helper                    | Description                                    |
@@ -120,7 +148,7 @@ Three things worth knowing:
 | `gws sheets read`         | Read a cell range (`--spreadsheet --range`)    |
 | `gws sheets write`        | Overwrite a range (`--values` / `--json-values`) |
 | `gws sheets append`       | Append rows after a range                      |
-| `gws docs write`          | Append text to a document (`--document --text`) |
+| `gws docs write`          | Append text to a doc or tab (`--document --text [--tab]`) |
 
 ```bash
 gws gmail send --to "user@example.com" --subject "Hello" --body "Hi there"
@@ -128,4 +156,5 @@ gws gmail triage --query "is:unread" --max 10
 gws sheets read --spreadsheet SHEET_ID --range "Sheet1!A1:C10"
 gws sheets append --spreadsheet SHEET_ID --values "alice,42"
 gws docs write --document DOC_ID --text "New paragraph"
+gws docs write --document DOC_ID --tab TAB_ID --text "Into that tab"
 ```

--- a/docs/typescript/cli/gws.mdx
+++ b/docs/typescript/cli/gws.mdx
@@ -104,6 +104,12 @@ Three things worth knowing:
   than read as absent.
 - **Reads are not scoped.** `gws drive files list` still sees the whole
   account. The scope is about where new files go, not a fence.
+- **Helpers are spelled bare, not `+`-prefixed.** Upstream marks its
+  hand-written commands with a `+` (`gws docs +write`); mirage's tree does
+  not need the marker, because a helper and a Discovery method cannot
+  collide inside a typed spec. So an upstream line carrying `+` has to
+  drop it here. The helper flags are mirage's own too, and `--tab` has no
+  upstream counterpart: upstream has no tab support at all.
 
 ### Document tabs
 

--- a/docs/typescript/cli/gws.mdx
+++ b/docs/typescript/cli/gws.mdx
@@ -105,6 +105,34 @@ Three things worth knowing:
 - **Reads are not scoped.** `gws drive files list` still sees the whole
   account. The scope is about where new files go, not a fence.
 
+### Document tabs
+
+A Google Doc holds one or more tabs, and the Docs API reports them only
+when asked. `documents.get` fills the legacy top-level `body` from the
+**first tab** and leaves `tabs` empty unless `includeTabsContent` is set;
+with it, the content moves under `tabs[].documentTab` and `body` is left
+empty. The two shapes are exclusive, so it is a shape switch rather than a
+verbosity knob, and tabs nest through `childTabs`.
+
+A `.gdoc.json` on a mount is always the tab-aware shape, because that is
+the only one that can represent a document with more than one tab. Through
+the passthrough you choose:
+
+```bash
+# every tab, the shape a mount serves
+gws docs documents get --params '{"documentId": "DOC_ID", "includeTabsContent": true}'
+
+# the legacy flat body, which is the FIRST tab only
+gws docs documents get --params '{"documentId": "DOC_ID"}'
+```
+
+Writes pick a tab the same way. `gws docs write` without `--tab` appends to
+the first tab, which is the API's own default for a request that names no
+tab; read the ids out of a mounted file with
+`jq '[.. | .tabProperties? // empty | .tabId]'`. Note that
+`replaceAllText` is one of three requests that instead default to **every**
+tab, so a bare `batchUpdate` replacement is document-wide.
+
 ### Helpers
 
 | Helper                    | Description                                    |
@@ -118,7 +146,7 @@ Three things worth knowing:
 | `gws sheets read`         | Read a cell range (`--spreadsheet --range`)    |
 | `gws sheets write`        | Overwrite a range (`--values` / `--json-values`) |
 | `gws sheets append`       | Append rows after a range                      |
-| `gws docs write`          | Append text to a document (`--document --text`) |
+| `gws docs write`          | Append text to a doc or tab (`--document --text [--tab]`) |
 
 ```bash
 gws gmail send --to "user@example.com" --subject "Hello" --body "Hi there"
@@ -126,4 +154,5 @@ gws gmail triage --query "is:unread" --max 10
 gws sheets read --spreadsheet SHEET_ID --range "Sheet1!A1:C10"
 gws sheets append --spreadsheet SHEET_ID --values "alice,42"
 gws docs write --document DOC_ID --text "New paragraph"
+gws docs write --document DOC_ID --tab TAB_ID --text "Into that tab"
 ```

--- a/docs/typescript/cli/gws.mdx
+++ b/docs/typescript/cli/gws.mdx
@@ -108,8 +108,11 @@ Three things worth knowing:
   hand-written commands with a `+` (`gws docs +write`); mirage's tree does
   not need the marker, because a helper and a Discovery method cannot
   collide inside a typed spec. So an upstream line carrying `+` has to
-  drop it here. The helper flags are mirage's own too, and `--tab` has no
-  upstream counterpart: upstream has no tab support at all.
+  drop it here. The flag *names* are upstream's own and match it
+  (`--document --text`, `gmail send`'s `--to --subject --body`, `sheets
+  read`'s `--spreadsheet --range`); `--tab` is the single addition,
+  because upstream's `+write` takes no tab argument and upstream has no
+  tab support at all.
 
 ### Document tabs
 

--- a/integ/fixtures/gdocs-tabs/v1.json
+++ b/integ/fixtures/gdocs-tabs/v1.json
@@ -2,11 +2,20 @@
   {
     "name": "Weekly Log",
     "tabs": [
-      { "title": "Tab 1", "text": "sep 6 entry" },
+      {
+        "title": "Tab 1",
+        "text": "sep 6 entry",
+        "tabId": "t.0"
+      },
       {
         "title": "Notes",
         "text": "loose notes",
-        "childTabs": [{ "title": "Archive", "text": "older material" }]
+        "childTabs": [
+          {
+            "title": "Archive",
+            "text": "older material"
+          }
+        ]
       }
     ]
   }

--- a/integ/fixtures/gdocs-tabs/v1.json
+++ b/integ/fixtures/gdocs-tabs/v1.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "Weekly Log",
+    "tabs": [
+      { "title": "Tab 1", "text": "sep 6 entry" },
+      {
+        "title": "Notes",
+        "text": "loose notes",
+        "childTabs": [{ "title": "Archive", "text": "older material" }]
+      }
+    ]
+  }
+]

--- a/integ/prisma/gws.prisma
+++ b/integ/prisma/gws.prisma
@@ -173,11 +173,34 @@ model Doc {
   tenant String
   id     String
   title  String
-  text   String @default("")
 
   file DriveFile @relation(fields: [tenant, id], references: [tenant, id])
+  tabs DocTab[]
 
   @@id([tenant, id])
+}
+
+// A document's text lives on its tabs, never on the document: the Docs API
+// stopped reporting a single body the moment tabs shipped, and a `Doc.text`
+// beside these rows would be a second place to look for the same string.
+//
+// Stored FLAT with a parent pointer, which is how the API itself reports
+// nesting (TabProperties.parentTabId), and reassembled into the childTabs
+// tree on load. A Prisma self-relation would say the same thing with more
+// machinery and no more truth.
+model DocTab {
+  tenant      String
+  documentId  String
+  tabId       String
+  title       String
+  text        String  @default("")
+  parentTabId String?
+  seq         Int     @default(0)
+
+  doc Doc @relation(fields: [tenant, documentId], references: [tenant, id])
+
+  @@id([tenant, documentId, tabId])
+  @@index([tenant, documentId])
 }
 
 model Spreadsheet {

--- a/integ/resources/google/g.json
+++ b/integ/resources/google/g.json
@@ -91,10 +91,10 @@
         "gdrive"
       ],
       "clear_cache": true,
-      "command": "cat /data/Plan.gdoc.json | jq -c '{documentId: (.documentId | length > 0), title, body: (.body.content | length)}'",
+      "command": "cat /data/Plan.gdoc.json | jq -c '{documentId: (.documentId | length > 0), title, tabs: (.tabs | length), blocks: (.tabs[0].documentTab.body.content | length)}'",
       "expect": {
         "exit": 0,
-        "stdout": "{\"documentId\":true,\"title\":\"Plan\",\"body\":2}\n",
+        "stdout": "{\"documentId\":true,\"title\":\"Plan\",\"tabs\":1,\"blocks\":2}\n",
         "stderr": ""
       }
     },
@@ -119,7 +119,7 @@
         "gdrive"
       ],
       "clear_cache": true,
-      "command": "cat /data/Plan.gdoc.json | jq -r '.body.content[1].paragraph.elements[0].textRun.content'",
+      "command": "cat /data/Plan.gdoc.json | jq -r '[.. | .textRun? // empty | .content] | add'",
       "expect": {
         "exit": 0,
         "stdout": "from drive\n\n",

--- a/integ/resources/google/gapp.json
+++ b/integ/resources/google/gapp.json
@@ -63,7 +63,7 @@
         "gapps"
       ],
       "clear_cache": true,
-      "command": "cat /docs/owned/*.gdoc.json | jq -r '.body.content[1].paragraph.elements[0].textRun.content'",
+      "command": "cat /docs/owned/*.gdoc.json | jq -r '[.. | .textRun? // empty | .content] | add'",
       "expect": {
         "exit": 0,
         "stdout": "HELLO gdoc\n\n",

--- a/integ/resources/google/gapp_tabs.json
+++ b/integ/resources/google/gapp_tabs.json
@@ -181,6 +181,34 @@
         "stdout": "{\"body\":null,\"tabs\":2}\n",
         "stderr": ""
       }
+    },
+    {
+      "id": "gapp_tabs_batch_is_all_or_nothing",
+      "seq": 521013,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "gws docs documents batchUpdate --params '{\"documentId\": \"doc0001\"}' --json '{\"requests\": [{\"insertText\": {\"text\": \" FIRSTREQ\", \"endOfSegmentLocation\": {\"segmentId\": \"\"}}}, {\"insertText\": {\"text\": \" SECONDREQ\", \"endOfSegmentLocation\": {\"tabId\": \"t.99\"}}}]}' 2>&1 >/dev/null | grep -o 'tabId not found in the document'",
+      "expect": {
+        "exit": 0,
+        "stdout": "tabId not found in the document\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_failed_batch_applied_nothing",
+      "seq": 521014,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "cat /docs/owned/*.gdoc.json | jq -r '[.. | .textRun? // empty | .content] | add | test(\"FIRSTREQ\")'",
+      "expect": {
+        "exit": 0,
+        "stdout": "false\n",
+        "stderr": ""
+      }
     }
   ]
 }

--- a/integ/resources/google/gapp_tabs.json
+++ b/integ/resources/google/gapp_tabs.json
@@ -1,0 +1,186 @@
+{
+  "cases": [
+    {
+      "id": "gapp_tabs_ls",
+      "seq": 521000,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "ls /docs/owned",
+      "expect": {
+        "exit": 0,
+        "stdout": "2026-01-01_Weekly_Log__doc0001.gdoc.json\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_no_flat_body",
+      "seq": 521001,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "cat /docs/owned/*.gdoc.json | jq -c '{body: .body, tabs: (.tabs | length)}'",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"body\":null,\"tabs\":2}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_names",
+      "seq": 521002,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "cat /docs/owned/*.gdoc.json | jq -c '[.. | .tabProperties? // empty | .title]'",
+      "expect": {
+        "exit": 0,
+        "stdout": "[\"Tab 1\",\"Notes\",\"Archive\"]\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_all_text",
+      "seq": 521003,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "cat /docs/owned/*.gdoc.json | jq -r '[.. | .textRun? // empty | .content] | add'",
+      "expect": {
+        "exit": 0,
+        "stdout": "sep 6 entry\nloose notes\nolder material\n\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_child_is_nested",
+      "seq": 521004,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "cat /docs/owned/*.gdoc.json | jq -c '.tabs[1].childTabs[0].tabProperties | {tabId, title, parentTabId, nestingLevel}'",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"tabId\":\"t.2\",\"title\":\"Archive\",\"parentTabId\":\"t.1\",\"nestingLevel\":1}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_grep_finds_a_later_tab",
+      "seq": 521005,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "grep -c 'older material' /docs/owned/*.gdoc.json",
+      "expect": {
+        "exit": 0,
+        "stdout": "1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_write_targets_a_tab",
+      "seq": 521006,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "D=$(cat /docs/owned/*.gdoc.json | jq -r .documentId) && gws docs write --document $D --tab t.2 --text ' appended' > /dev/null && cat /docs/owned/*.gdoc.json | jq -r '[.. | .textRun? // empty | .content] | add'",
+      "expect": {
+        "exit": 0,
+        "stdout": "sep 6 entry\nloose notes\nolder material appended\n\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_write_without_a_tab_hits_the_first",
+      "seq": 521007,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "D=$(cat /docs/owned/*.gdoc.json | jq -r .documentId) && gws docs write --document $D --text ' plain' > /dev/null && cat /docs/owned/*.gdoc.json | jq -r '.tabs[0].documentTab.body.content[] | .paragraph?.elements[]?.textRun.content'",
+      "expect": {
+        "exit": 0,
+        "stdout": "sep 6 entry plain\n\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_unknown_tab_is_refused",
+      "seq": 521008,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "D=$(cat /docs/owned/*.gdoc.json | jq -r .documentId); gws docs write --document $D --tab t.99 --text 'x' 2>&1 >/dev/null | grep -o 'tabId not found in the document'",
+      "expect": {
+        "exit": 0,
+        "stdout": "tabId not found in the document\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_unknown_tab_exits_nonzero",
+      "seq": 521009,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "D=$(cat /docs/owned/*.gdoc.json | jq -r .documentId); gws docs write --document $D --tab t.99 --text 'x' 2>/dev/null; echo \"exit=$?\"",
+      "expect": {
+        "exit": 0,
+        "stdout": "exit=1\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_refusal_left_the_document_alone",
+      "seq": 521010,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "cat /docs/owned/*.gdoc.json | jq -r '[.. | .textRun? // empty | .content] | add'",
+      "expect": {
+        "exit": 0,
+        "stdout": "sep 6 entry plain\nloose notes\nolder material appended\n\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_cli_without_the_flag_is_flat",
+      "seq": 521011,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "gws docs documents get --params '{\"documentId\": \"doc0001\"}' | jq -c '{body: (.body.content | length > 0), tabs: .tabs}'",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"body\":true,\"tabs\":null}\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_cli_with_the_flag_is_tabbed",
+      "seq": 521012,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "gws docs documents get --params '{\"documentId\": \"doc0001\", \"includeTabsContent\": true}' | jq -c '{body: .body, tabs: (.tabs | length)}'",
+      "expect": {
+        "exit": 0,
+        "stdout": "{\"body\":null,\"tabs\":2}\n",
+        "stderr": ""
+      }
+    }
+  ]
+}

--- a/integ/resources/google/gapp_tabs.json
+++ b/integ/resources/google/gapp_tabs.json
@@ -63,10 +63,10 @@
         "gapps-tabs"
       ],
       "clear_cache": true,
-      "command": "cat /docs/owned/*.gdoc.json | jq -c '.tabs[1].childTabs[0].tabProperties | {tabId, title, parentTabId, nestingLevel}'",
+      "command": "cat /docs/owned/*.gdoc.json | jq -c '.tabs[1].childTabs[0].tabProperties | {tabId, title, index, parentTabId, nestingLevel}'",
       "expect": {
         "exit": 0,
-        "stdout": "{\"tabId\":\"t.2\",\"title\":\"Archive\",\"parentTabId\":\"t.1\",\"nestingLevel\":1}\n",
+        "stdout": "{\"tabId\":\"t.2\",\"title\":\"Archive\",\"index\":0,\"parentTabId\":\"t.1\",\"nestingLevel\":1}\n",
         "stderr": ""
       }
     },
@@ -207,6 +207,20 @@
       "expect": {
         "exit": 0,
         "stdout": "false\n",
+        "stderr": ""
+      }
+    },
+    {
+      "id": "gapp_tabs_index_counts_within_the_parent",
+      "seq": 521015,
+      "targets": [
+        "gapps-tabs"
+      ],
+      "clear_cache": true,
+      "command": "cat /docs/owned/*.gdoc.json | jq -c '[.tabs[0].tabProperties.index, .tabs[1].tabProperties.index, .tabs[1].childTabs[0].tabProperties.index]'",
+      "expect": {
+        "exit": 0,
+        "stdout": "[0,1,0]\n",
         "stderr": ""
       }
     }

--- a/integ/runners/python/adapters/__init__.py
+++ b/integ/runners/python/adapters/__init__.py
@@ -559,6 +559,12 @@ class GwsService:
         forms = cls._manifest(target.get("forms"))
         if forms:
             extras["forms"] = forms
+        # A multi-tab document is the third such state: the Docs API has
+        # no request that creates a tab, so one cannot be seeded through
+        # the editor APIs the way the single-tab `apps` docs are.
+        docs = cls._manifest(target.get("docs"))
+        if docs:
+            extras["docs"] = docs
         if extras:
             reset_body["extras"] = extras
         async with aiohttp.ClientSession() as session:

--- a/integ/runners/typescript/adapters/index.ts
+++ b/integ/runners/typescript/adapters/index.ts
@@ -1588,6 +1588,11 @@ async function openGws(target: Target): Promise<Open> {
   if (target.epoch !== undefined) reset.epoch = target.epoch
   if (calendar?.calendars !== undefined) extras.calendars = calendar.calendars
   if (forms !== undefined) extras.forms = forms
+  // A multi-tab document is the third such state: the Docs API has no
+  // request that creates a tab, so one cannot be seeded through the editor
+  // APIs the way the single-tab `apps` docs are.
+  const docTabDocs = gwsManifest<unknown[]>(target.docs)
+  if (docTabDocs !== undefined) extras.docs = docTabDocs
   if (Object.keys(extras).length > 0) reset.extras = extras
   await gwsJson(`${base}/reset`, {
     method: 'POST',

--- a/integ/runners/typescript/harness.ts
+++ b/integ/runners/typescript/harness.ts
@@ -75,6 +75,9 @@ export interface Target {
   mail?: string
   calendar?: string
   forms?: string
+  // Documents that carry tabs, seeded through /reset extras because the
+  // Docs API cannot create a tab.
+  docs?: string
   dataset?: string
   agentId?: string
   facet?: string

--- a/integ/server/gws/docs/batch.ts
+++ b/integ/server/gws/docs/batch.ts
@@ -19,7 +19,7 @@ import { asBool, asNum, asObj, asStr, asStrArr } from '../wire/json.ts'
 import type { JsonObj } from '../wire/json.ts'
 import { NOT_FOUND, googleError, ok } from '../wire/reply.ts'
 import type { DocBody, DocTab } from '../store/types.ts'
-import { allDocTabs, findDocTab, firstTabOf, replaceAllText } from './body.ts'
+import { allDocTabs, copyDocTabs, findDocTab, firstTabOf, replaceAllText } from './body.ts'
 
 // The tab a location-bearing request applies to. A request that names no
 // tab lands on the FIRST one, which is the API's documented default for
@@ -36,9 +36,21 @@ function tabFor(doc: DocBody, location: JsonObj): DocTab | null {
 
 const UNKNOWN_TAB = 'Invalid requests: tabId not found in the document'
 
+/**
+ * Apply a batch, all of it or none of it.
+ *
+ * "Each request is validated before being applied. If any request is not
+ * valid, then the entire request will fail and nothing will be applied."
+ * So the batch runs against a COPY of the tabs and commits only once every
+ * request has succeeded. Mutating in place and returning early on the
+ * second request left the first one applied, and the write route persists
+ * unconditionally, so a caller retrying the failed batch would have
+ * duplicated it.
+ */
 export function docsBatchUpdate(st: GwsState, id: string, requests: JsonObj[]): Reply {
-  const doc = st.docs.get(id)
-  if (doc === undefined) return NOT_FOUND
+  const live = st.docs.get(id)
+  if (live === undefined) return NOT_FOUND
+  const doc: DocBody = { title: live.title, tabs: copyDocTabs(live.tabs) }
   const replies: JsonValue[] = []
   for (const request of requests) {
     if ('insertText' in request) {
@@ -104,6 +116,8 @@ export function docsBatchUpdate(st: GwsState, id: string, requests: JsonObj[]): 
       )
     }
   }
+  // Every request succeeded, so the copy becomes the document.
+  live.tabs = doc.tabs
   touchNative(st, id)
   return ok({ documentId: id, replies })
 }

--- a/integ/server/gws/docs/batch.ts
+++ b/integ/server/gws/docs/batch.ts
@@ -15,10 +15,26 @@
 import type { JsonValue, Reply } from '../../kit/typescript/index.ts'
 import { touchNative } from '../drive/item.ts'
 import type { GwsState } from '../store/state.ts'
-import { asBool, asNum, asObj, asStr } from '../wire/json.ts'
+import { asBool, asNum, asObj, asStr, asStrArr } from '../wire/json.ts'
 import type { JsonObj } from '../wire/json.ts'
 import { NOT_FOUND, googleError, ok } from '../wire/reply.ts'
-import { replaceAllText } from './body.ts'
+import type { DocBody, DocTab } from '../store/types.ts'
+import { allDocTabs, findDocTab, firstTabOf, replaceAllText } from './body.ts'
+
+// The tab a location-bearing request applies to. A request that names no
+// tab lands on the FIRST one, which is the API's documented default for
+// every request but the three that instead default to all tabs.
+//
+// An unknown tabId is refused rather than silently redirected to the
+// first: a caller that mistyped one would otherwise see a successful
+// write land somewhere it never named.
+function tabFor(doc: DocBody, location: JsonObj): DocTab | null {
+  const tabId = asStr(location.tabId)
+  if (tabId === undefined || tabId === '') return firstTabOf(doc)
+  return findDocTab(doc, tabId) ?? null
+}
+
+const UNKNOWN_TAB = 'Invalid requests: tabId not found in the document'
 
 export function docsBatchUpdate(st: GwsState, id: string, requests: JsonObj[]): Reply {
   const doc = st.docs.get(id)
@@ -28,30 +44,57 @@ export function docsBatchUpdate(st: GwsState, id: string, requests: JsonObj[]): 
     if ('insertText' in request) {
       const r = asObj(request.insertText)
       const text = asStr(r.text) ?? ''
-      const index = asNum(asObj(r.location).index)
+      const location = asObj(r.location)
+      const endOfSegment = asObj(r.endOfSegmentLocation)
+      const index = asNum(location.index)
+      // Whichever of the two location shapes the request used carries the
+      // tabId, so both are consulted rather than only the indexed one.
+      const tab = tabFor(doc, index === undefined ? endOfSegment : location)
+      if (tab === null) return googleError(400, UNKNOWN_TAB, 'INVALID_ARGUMENT')
       if (index !== undefined) {
-        const offset = Math.max(0, Math.min(doc.text.length, index - 1))
-        doc.text = doc.text.slice(0, offset) + text + doc.text.slice(offset)
+        const offset = Math.max(0, Math.min(tab.text.length, index - 1))
+        tab.text = tab.text.slice(0, offset) + text + tab.text.slice(offset)
       } else {
-        doc.text += text
+        tab.text += text
       }
       replies.push({})
     } else if ('deleteContentRange' in request) {
       const range = asObj(asObj(request.deleteContentRange).range)
+      const tab = tabFor(doc, range)
+      if (tab === null) return googleError(400, UNKNOWN_TAB, 'INVALID_ARGUMENT')
       const start = Math.max(0, (asNum(range.startIndex) ?? 1) - 1)
       const end = Math.max(start, (asNum(range.endIndex) ?? 1) - 1)
-      doc.text = doc.text.slice(0, start) + doc.text.slice(end)
+      tab.text = tab.text.slice(0, start) + tab.text.slice(end)
       replies.push({})
     } else if ('replaceAllText' in request) {
       const r = asObj(request.replaceAllText)
       const contains = asObj(r.containsText)
-      const [text, occurrences] = replaceAllText(
-        doc.text,
-        asStr(contains.text) ?? '',
-        asStr(r.replaceText) ?? '',
-        asBool(contains.matchCase) ?? false,
-      )
-      doc.text = text
+      // One of the three requests that default to ALL tabs rather than to
+      // the first, so an absent tabsCriteria means every tab and the
+      // reply counts the occurrences across all of them.
+      const named = asStrArr(asObj(r.tabsCriteria).tabIds)
+      let targets: DocTab[]
+      if (named === undefined || named.length === 0) {
+        targets = allDocTabs(doc)
+      } else {
+        targets = []
+        for (const tabId of named) {
+          const tab = findDocTab(doc, tabId)
+          if (tab === undefined) return googleError(400, UNKNOWN_TAB, 'INVALID_ARGUMENT')
+          targets.push(tab)
+        }
+      }
+      let occurrences = 0
+      for (const tab of targets) {
+        const [text, changed] = replaceAllText(
+          tab.text,
+          asStr(contains.text) ?? '',
+          asStr(r.replaceText) ?? '',
+          asBool(contains.matchCase) ?? false,
+        )
+        tab.text = text
+        occurrences += changed
+      }
       replies.push({ replaceAllText: { occurrencesChanged: occurrences } })
     } else {
       return googleError(

--- a/integ/server/gws/docs/body.ts
+++ b/integ/server/gws/docs/body.ts
@@ -14,6 +14,7 @@
 
 import type { JsonValue } from '../../kit/typescript/index.ts'
 import type { GwsState } from '../store/state.ts'
+import type { DocBody, DocTab } from '../store/types.ts'
 import type { JsonObj } from '../wire/json.ts'
 
 // The flat text string is authoritative; the Document body JSON is rebuilt
@@ -54,14 +55,96 @@ export function buildDocBody(text: string): { content: JsonValue[] } {
   return { content }
 }
 
-export function fmtDocument(st: GwsState, id: string): JsonObj {
-  const doc = st.docs.get(id) as { title: string; text: string }
+// A fresh document's only tab. Google names it "Tab 1" and mints an opaque
+// id; the fake's is positional so truth files stay stable across runs.
+export function initialDocTab(text = ''): DocTab {
+  return { tabId: 't.0', title: 'Tab 1', text, childTabs: [] }
+}
+
+// Pre-order, which is the order the API reports tabs in and therefore the
+// order `replaceAllText` visits them in when no tabsCriteria narrows it.
+export function allDocTabs(doc: DocBody): DocTab[] {
+  const out: DocTab[] = []
+  const walk = (tabs: DocTab[]): void => {
+    for (const tab of tabs) {
+      out.push(tab)
+      walk(tab.childTabs)
+    }
+  }
+  walk(doc.tabs)
+  return out
+}
+
+// The tab a request with no tabId lands on, which the API documents as the
+// first tab. A document always has one, so a caller never has to branch.
+export function firstTabOf(doc: DocBody): DocTab {
+  const first = doc.tabs[0]
+  if (first === undefined) throw new Error('a document always has one tab')
+  return first
+}
+
+export function findDocTab(doc: DocBody, tabId: string): DocTab | undefined {
+  return allDocTabs(doc).find((t) => t.tabId === tabId)
+}
+
+// Every tab's text, in reporting order. This is what an export or a
+// fullText search sees, because both are about the document rather than
+// about one of its tabs.
+export function docPlainText(doc: DocBody): string {
+  return allDocTabs(doc)
+    .map((t) => t.text)
+    .join('\n')
+}
+
+export function copyDocTabs(tabs: DocTab[]): DocTab[] {
+  return tabs.map((t) => ({ ...t, childTabs: copyDocTabs(t.childTabs) }))
+}
+
+function fmtTab(tab: DocTab, index: number, parentTabId: string | null, nesting: number): JsonObj {
+  const tabProperties: JsonObj = {
+    tabId: tab.tabId,
+    title: tab.title,
+    index,
+    nestingLevel: nesting,
+  }
+  // Absent at the root, which is what the API means by "Empty when the
+  // current tab is a root-level tab".
+  if (parentTabId !== null) tabProperties.parentTabId = parentTabId
+  const out: JsonObj = { tabProperties, documentTab: { body: buildDocBody(tab.text) } }
+  if (tab.childTabs.length > 0) {
+    out.childTabs = tab.childTabs.map((child, i) => fmtTab(child, i, tab.tabId, nesting + 1))
+  }
+  return out
+}
+
+/**
+ * The documents.get response, in one of its two exclusive shapes.
+ *
+ * `includeTabsContent` is not a verbosity knob, it is a shape switch: with
+ * it the content lives under `tabs[]` and the singleton fields are left
+ * empty, and without it the singleton fields carry the FIRST tab while
+ * `tabs` stays empty. Filling both would be the one thing a fake must not
+ * do here, because it would let a caller that still reads `.body` pass
+ * against a multi-tab document that the real API answers with an empty
+ * `.body`.
+ */
+export function fmtDocument(st: GwsState, id: string, includeTabsContent: boolean): JsonObj {
+  const doc = st.docs.get(id) as DocBody
   const file = st.files.get(id)
+  const revisionId = `rev-${String(file?.revisions.length ?? 0)}`
+  if (includeTabsContent) {
+    return {
+      documentId: id,
+      title: doc.title,
+      tabs: doc.tabs.map((tab, i) => fmtTab(tab, i, null, 0)),
+      revisionId,
+    }
+  }
   return {
     documentId: id,
     title: doc.title,
-    body: buildDocBody(doc.text),
-    revisionId: `rev-${String(file?.revisions.length ?? 0)}`,
+    body: buildDocBody(firstTabOf(doc).text),
+    revisionId,
   }
 }
 

--- a/integ/server/gws/docs/body.ts
+++ b/integ/server/gws/docs/body.ts
@@ -101,15 +101,18 @@ export function copyDocTabs(tabs: DocTab[]): DocTab[] {
 }
 
 function fmtTab(tab: DocTab, index: number, parentTabId: string | null, nesting: number): JsonObj {
-  const tabProperties: JsonObj = {
-    tabId: tab.tabId,
-    title: tab.title,
-    index,
-    nestingLevel: nesting,
+  const tabProperties: JsonObj = { tabId: tab.tabId, title: tab.title, index }
+  // Both are ABSENT on a root tab, probed against the live API on
+  // 2026-09-10: a real root tab answers with exactly
+  // {index, tabId, title}. `nestingLevel` is documented output-only and
+  // Google does not send it at depth 0 even though it sends `index: 0`,
+  // so emitting a 0 here would invent a field a caller could come to
+  // depend on and then find missing in production, which is the same
+  // trap includeTabsContent itself set.
+  if (parentTabId !== null) {
+    tabProperties.parentTabId = parentTabId
+    tabProperties.nestingLevel = nesting
   }
-  // Absent at the root, which is what the API means by "Empty when the
-  // current tab is a root-level tab".
-  if (parentTabId !== null) tabProperties.parentTabId = parentTabId
   const out: JsonObj = { tabProperties, documentTab: { body: buildDocBody(tab.text) } }
   if (tab.childTabs.length > 0) {
     out.childTabs = tab.childTabs.map((child, i) => fmtTab(child, i, tab.tabId, nesting + 1))

--- a/integ/server/gws/docs/routes.ts
+++ b/integ/server/gws/docs/routes.ts
@@ -23,6 +23,12 @@ import { NOT_FOUND, idVerbOf, ok, unknownRoute } from '../wire/reply.ts'
 import { docsBatchUpdate } from './batch.ts'
 import { fmtDocument } from './body.ts'
 
+// Only the literal "true" turns it on, which is how a Discovery boolean
+// query parameter is spelled on the wire; anything else reads as unset.
+function wantsTabs(url: URL): boolean {
+  return url.searchParams.get('includeTabsContent') === 'true'
+}
+
 // The old fake spelled a document id `[^/:]+`.
 const ID: RouteOpts = { classes: { id: 'id' } }
 
@@ -41,7 +47,7 @@ export function docsRoutes(): KitRoute<C>[] {
           Buffer.alloc(0),
           ctx.db.nextId('doc'),
         )
-        return ok(fmtDocument(ctx.db, item.id))
+        return ok(fmtDocument(ctx.db, item.id, wantsTabs(ctx.url)))
       },
       { write: true },
     ),
@@ -51,7 +57,7 @@ export function docsRoutes(): KitRoute<C>[] {
       (ctx) => {
         const id = ctx.params.id ?? ''
         if (!ctx.db.docs.has(id)) return NOT_FOUND
-        return ok(fmtDocument(ctx.db, id))
+        return ok(fmtDocument(ctx.db, id, wantsTabs(ctx.url)))
       },
       ID,
     ),

--- a/integ/server/gws/drive/item.ts
+++ b/integ/server/gws/drive/item.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { createHash } from 'node:crypto'
+import { initialDocTab } from '../docs/body.ts'
 import { newSlide } from '../slides/page.ts'
 import { newTab } from '../sheets/grid.ts'
 import type { GwsState } from '../store/state.ts'
@@ -62,7 +63,7 @@ export function pushRevision(item: DriveItem): void {
 // coupling between Drive and the editors.
 export function autoLink(st: GwsState, item: DriveItem): void {
   if (item.mimeType === DOC_MIME && !st.docs.has(item.id)) {
-    st.docs.set(item.id, { title: item.name, text: '' })
+    st.docs.set(item.id, { title: item.name, tabs: [initialDocTab()] })
   } else if (item.mimeType === SHEET_MIME && !st.sheets.has(item.id)) {
     st.sheets.set(item.id, { title: item.name, tabs: [newTab(0, 'Sheet1')], nextSheetId: 1 })
   } else if (item.mimeType === SLIDE_MIME && !st.presentations.has(item.id)) {

--- a/integ/server/gws/drive/list.ts
+++ b/integ/server/gws/drive/list.ts
@@ -13,6 +13,7 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import type { JsonValue, Reply } from '../../kit/typescript/index.ts'
+import { docPlainText } from '../docs/body.ts'
 import type { GwsState } from '../store/state.ts'
 import type { DriveItem } from '../store/types.ts'
 import type { JsonObj } from '../wire/json.ts'
@@ -85,9 +86,11 @@ export function listFiles(st: GwsState, query: URLSearchParams): Reply {
 export function exportFile(st: GwsState, item: DriveItem, mimeType: string): Reply {
   if (item.mimeType === DOC_MIME && mimeType === 'text/plain') {
     const doc = st.docs.get(item.id)
+    // An export is of the document, not of one tab, so every tab's text
+    // is in it; a single-tab doc renders exactly as it always did.
     return {
       status: 200,
-      body: Buffer.from(doc?.text ?? ''),
+      body: Buffer.from(doc === undefined ? '' : docPlainText(doc)),
       headers: { 'Content-Type': 'text/plain' },
     }
   }

--- a/integ/server/gws/drive/query.ts
+++ b/integ/server/gws/drive/query.ts
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { docPlainText } from '../docs/body.ts'
 import type { GwsState } from '../store/state.ts'
 import type { DriveItem } from '../store/types.ts'
 
@@ -86,12 +87,12 @@ export function parseDriveQuery(q: string): QueryClause[] {
 }
 
 // Everything the live index searches for `fullText`: the display name, a
-// Doc's flat text, a Sheet's cell values, and an uploaded file's bytes.
+// Doc's text across every tab, a Sheet's cell values, and an uploaded file's bytes.
 // Case-insensitive, the way the real search index answers.
 export function fullTextOf(st: GwsState, item: DriveItem): string {
   const parts: string[] = [item.name]
   const doc = st.docs.get(item.id)
-  if (doc !== undefined) parts.push(doc.text)
+  if (doc !== undefined) parts.push(docPlainText(doc))
   const sheet = st.sheets.get(item.id)
   if (sheet !== undefined) {
     for (const tab of sheet.tabs) parts.push([...tab.cells.values()].join(' '))

--- a/integ/server/gws/drive/routes.ts
+++ b/integ/server/gws/drive/routes.ts
@@ -17,6 +17,7 @@ import { route } from '../wire/route.ts'
 import type { RouteOpts } from '../wire/route.ts'
 import { parseMultipartRelated } from '../gmail/mime.ts'
 import type { C } from '../store/client.ts'
+import { copyDocTabs } from '../docs/body.ts'
 import type { GwsState } from '../store/state.ts'
 import type { DriveItem, Permission, Revision } from '../store/types.ts'
 import { asObj, asStr, asStrArr, asBool } from '../wire/json.ts'
@@ -186,7 +187,9 @@ function copyFile(ctx: GwsCtx): Reply {
     Buffer.from(src.content),
   )
   const srcDoc = ctx.db.docs.get(src.id)
-  if (srcDoc !== undefined) ctx.db.docs.set(copy.id, { title: copy.name, text: srcDoc.text })
+  if (srcDoc !== undefined) {
+    ctx.db.docs.set(copy.id, { title: copy.name, tabs: copyDocTabs(srcDoc.tabs) })
+  }
   const srcSheet = ctx.db.sheets.get(src.id)
   if (srcSheet !== undefined) {
     ctx.db.sheets.set(copy.id, {

--- a/integ/server/gws/seed.ts
+++ b/integ/server/gws/seed.ts
@@ -56,9 +56,29 @@ export function seedCalendars(st: GwsState, entries: JsonObj[]): void {
   }
 }
 
+// Every id a fixture pinned, collected before any is minted so a mint can
+// step over one, whichever order the two appear in. A pin repeated is a
+// fixture bug and is named here: DocTab is keyed by (tenant, documentId,
+// tabId), so the alternative is a primary-key violation at save time,
+// reported against a table rather than against the line that caused it.
+function pinnedTabIds(entries: JsonObj[], seen: Set<string>): Set<string> {
+  for (const raw of entries) {
+    const pinned = asStr(raw.tabId)
+    if (pinned !== undefined) {
+      if (seen.has(pinned)) {
+        throw new ResetBodyError(`/reset extras.docs pins tab id "${pinned}" twice`)
+      }
+      seen.add(pinned)
+    }
+    pinnedTabIds(asObjArr(raw.childTabs), seen)
+  }
+  return seen
+}
+
 // Tab ids are minted in pre-order (t.0, t.1, ... across the whole
 // document, children before the next sibling) so a truth file can name one
-// and stay stable. A fixture may pin its own instead.
+// and stay stable. A fixture may pin its own instead, and a minted id then
+// steps over every pinned one rather than colliding with it.
 function docTabsFrom(entries: JsonObj[], mint: () => string): DocTab[] {
   return entries.map((raw) => {
     const tabId = asStr(raw.tabId) ?? mint()
@@ -86,8 +106,15 @@ export function seedDocs(st: GwsState, entries: JsonObj[]): void {
     const item = createDriveItem(st, name, DOC_MIME, [], Buffer.alloc(0), st.nextId('doc'))
     const doc = st.docs.get(item.id)
     if (doc === undefined) throw new ResetBodyError(`doc ${item.id} was not auto-linked`)
+    const declared = asObjArr(entry.tabs)
+    const pinned = pinnedTabIds(declared, new Set<string>())
     let next = 0
-    const tabs = docTabsFrom(asObjArr(entry.tabs), () => `t.${String(next++)}`)
+    const mint = (): string => {
+      let id = `t.${String(next++)}`
+      while (pinned.has(id)) id = `t.${String(next++)}`
+      return id
+    }
+    const tabs = docTabsFrom(declared, mint)
     // No tabs declared is one tab, which is what autoLink already made:
     // every document has at least one, and a tabless one cannot be read.
     if (tabs.length > 0) doc.tabs = tabs

--- a/integ/server/gws/seed.ts
+++ b/integ/server/gws/seed.ts
@@ -18,11 +18,11 @@ import { createDriveItem } from './drive/item.ts'
 import { eventsOf, makeEvent } from './calendar/event.ts'
 import { DEFAULT_CALENDAR_TZ } from './store/state.ts'
 import type { GwsState } from './store/state.ts'
-import type { FormDoc } from './store/types.ts'
+import type { DocTab, FormDoc } from './store/types.ts'
 import { newFormItem } from './forms/form.ts'
 import { asBool, asObjArr, asStr, isObj } from './wire/json.ts'
 import type { JsonObj } from './wire/json.ts'
-import { FORM_MIME } from './wire/mime.ts'
+import { DOC_MIME, FORM_MIME } from './wire/mime.ts'
 
 // A secondary calendar and a form carrying responses are both harness state
 // rather than anything the API can mint: you own every calendar you create,
@@ -53,6 +53,44 @@ export function seedCalendars(st: GwsState, entries: JsonObj[]): void {
       }
       bucket.set(ev.id, ev)
     }
+  }
+}
+
+// Tab ids are minted in pre-order (t.0, t.1, ... across the whole
+// document, children before the next sibling) so a truth file can name one
+// and stay stable. A fixture may pin its own instead.
+function docTabsFrom(entries: JsonObj[], mint: () => string): DocTab[] {
+  return entries.map((raw) => {
+    const tabId = asStr(raw.tabId) ?? mint()
+    return {
+      tabId,
+      title: asStr(raw.title) ?? '',
+      text: asStr(raw.text) ?? '',
+      childTabs: docTabsFrom(asObjArr(raw.childTabs), mint),
+    }
+  })
+}
+
+// A MULTI-TAB document is a state the Docs API cannot produce: there is no
+// request that creates a tab, so unlike the single-tab docs in the `apps`
+// fixture -- which seed through documents.create plus a batchUpdate -- one
+// of these cannot be built by driving the same API a backend speaks. It
+// therefore rides `extras`, for the same reason a secondary calendar and a
+// submitted form response do.
+export function seedDocs(st: GwsState, entries: JsonObj[]): void {
+  for (const entry of entries) {
+    const name = asStr(entry.name) ?? ''
+    // Through the Drive table because the documentId IS the Drive file id,
+    // which is what makes a seeded doc findable the one way an agent can
+    // find one.
+    const item = createDriveItem(st, name, DOC_MIME, [], Buffer.alloc(0), st.nextId('doc'))
+    const doc = st.docs.get(item.id)
+    if (doc === undefined) throw new ResetBodyError(`doc ${item.id} was not auto-linked`)
+    let next = 0
+    const tabs = docTabsFrom(asObjArr(entry.tabs), () => `t.${String(next++)}`)
+    // No tabs declared is one tab, which is what autoLink already made:
+    // every document has at least one, and a tabless one cannot be read.
+    if (tabs.length > 0) doc.tabs = tabs
   }
 }
 
@@ -97,7 +135,7 @@ function listField(name: string, value: JsonValue | undefined): JsonObj[] {
   return value.filter(isObj)
 }
 
-const KNOWN = new Set(['calendarTimeZone', 'calendars', 'forms'])
+const KNOWN = new Set(['calendarTimeZone', 'calendars', 'docs', 'forms'])
 
 export function applyExtras(st: GwsState, extras: Record<string, JsonValue>): void {
   const unknown = Object.keys(extras).filter((k) => !KNOWN.has(k))
@@ -115,5 +153,6 @@ export function applyExtras(st: GwsState, extras: Record<string, JsonValue>): vo
     for (const cal of st.calendars.values()) if (cal.primary === true) cal.timeZone = tz
   }
   seedCalendars(st, listField('calendars', extras.calendars))
+  seedDocs(st, listField('docs', extras.docs))
   seedForms(st, listField('forms', extras.forms))
 }

--- a/integ/server/gws/store/load.ts
+++ b/integ/server/gws/store/load.ts
@@ -18,6 +18,7 @@ import type { C } from './client.ts'
 import { DEFAULT_CALENDAR_TZ, GwsState } from './state.ts'
 import type {
   CalendarEvent,
+  DocTab,
   DriveItem,
   EventTime,
   FormItem,
@@ -92,6 +93,7 @@ export async function loadState(db: C, tenant: string, epochMs?: number): Promis
     revisions,
     permissions,
     docs,
+    docTabs,
     spreadsheets,
     tabs,
     cells,
@@ -117,6 +119,7 @@ export async function loadState(db: C, tenant: string, epochMs?: number): Promis
     db.revision.findMany({ where, orderBy: seq }),
     db.permission.findMany({ where, orderBy: seq }),
     db.doc.findMany({ where }),
+    db.docTab.findMany({ where, orderBy: seq }),
     db.spreadsheet.findMany({ where }),
     db.sheetTab.findMany({ where, orderBy: seq }),
     db.sheetCell.findMany({ where }),
@@ -180,7 +183,31 @@ export async function loadState(db: C, tenant: string, epochMs?: number): Promis
     st.files.set(item.id, item)
   }
 
-  for (const row of docs) st.docs.set(row.id, { title: row.title, text: row.text })
+  // Flat rows back into the childTabs tree. Rows arrive in `seq` order, so
+  // a parent is always seen before its children within one document and a
+  // single pass suffices; a child whose parent is missing is dropped
+  // rather than silently promoted to the root, which would turn a broken
+  // fixture into a plausible-looking document.
+  const docTabsOf = groupBy(docTabs, (r) => r.documentId)
+  for (const row of docs) {
+    const built = new Map<string, DocTab>()
+    const roots: DocTab[] = []
+    for (const tabRow of docTabsOf.get(row.id) ?? []) {
+      const tab: DocTab = {
+        tabId: tabRow.tabId,
+        title: tabRow.title,
+        text: tabRow.text,
+        childTabs: [],
+      }
+      built.set(tab.tabId, tab)
+      if (tabRow.parentTabId === null) {
+        roots.push(tab)
+        continue
+      }
+      built.get(tabRow.parentTabId)?.childTabs.push(tab)
+    }
+    st.docs.set(row.id, { title: row.title, tabs: roots })
+  }
 
   const cellsOf = groupBy(cells, (r) => `${r.spreadsheetId} ${String(r.sheetId)}`)
   const tabsOf = groupBy(tabs, (r) => r.spreadsheetId)

--- a/integ/server/gws/store/save.ts
+++ b/integ/server/gws/store/save.ts
@@ -16,6 +16,7 @@ import { clearTenants } from '../../kit/typescript/index.ts'
 import type { Dmmf } from '../../kit/typescript/index.ts'
 import type { C } from './client.ts'
 import type { GwsState } from './state.ts'
+import type { DocTab } from './types.ts'
 
 // The tenant's world, written back whole.
 //
@@ -52,6 +53,7 @@ export async function saveState(db: C, dmmf: Dmmf, tenant: string, st: GwsState)
     if (rows.revisions.length > 0) await tx.revision.createMany({ data: rows.revisions })
     if (rows.permissions.length > 0) await tx.permission.createMany({ data: rows.permissions })
     if (rows.docs.length > 0) await tx.doc.createMany({ data: rows.docs })
+    if (rows.docTabs.length > 0) await tx.docTab.createMany({ data: rows.docTabs })
     if (rows.spreadsheets.length > 0) await tx.spreadsheet.createMany({ data: rows.spreadsheets })
     if (rows.tabs.length > 0) await tx.sheetTab.createMany({ data: rows.tabs })
     if (rows.cells.length > 0) await tx.sheetCell.createMany({ data: rows.cells })
@@ -111,7 +113,16 @@ interface Rows {
     emailAddress: string | null
     seq: number
   }[]
-  docs: { tenant: string; id: string; title: string; text: string }[]
+  docs: { tenant: string; id: string; title: string }[]
+  docTabs: {
+    tenant: string
+    documentId: string
+    tabId: string
+    title: string
+    text: string
+    parentTabId: string | null
+    seq: number
+  }[]
   spreadsheets: { tenant: string; id: string; title: string; nextSheetId: number }[]
   tabs: {
     tenant: string
@@ -233,6 +244,7 @@ function buildRows(tenant: string, st: GwsState): Rows {
     revisions: [],
     permissions: [],
     docs: [],
+    docTabs: [],
     spreadsheets: [],
     tabs: [],
     cells: [],
@@ -301,8 +313,26 @@ function buildRows(tenant: string, st: GwsState): Rows {
     }
   }
 
+  // Pre-order, so `seq` puts a parent before its children and loadState
+  // can rebuild the tree in one pass.
   for (const [id, doc] of st.docs) {
-    rows.docs.push({ tenant, id, title: doc.title, text: doc.text })
+    rows.docs.push({ tenant, id, title: doc.title })
+    let docTabSeq = 0
+    const emit = (tabs: DocTab[], parentTabId: string | null): void => {
+      for (const tab of tabs) {
+        rows.docTabs.push({
+          tenant,
+          documentId: id,
+          tabId: tab.tabId,
+          title: tab.title,
+          text: tab.text,
+          parentTabId,
+          seq: docTabSeq++,
+        })
+        emit(tab.childTabs, tab.tabId)
+      }
+    }
+    emit(doc.tabs, null)
   }
 
   let tabSeq = 0

--- a/integ/server/gws/store/types.ts
+++ b/integ/server/gws/store/types.ts
@@ -76,9 +76,19 @@ export interface Presentation {
   slides: SlidePage[]
 }
 
-export interface DocBody {
+// One tab of a document. `childTabs` is always present (empty for a leaf)
+// so a walk never has to test for it; the wire shape omits it when empty,
+// which is the renderer's business, not the store's.
+export interface DocTab {
+  tabId: string
   title: string
   text: string
+  childTabs: DocTab[]
+}
+
+export interface DocBody {
+  title: string
+  tabs: DocTab[]
 }
 
 export interface GmailAttachment {

--- a/integ/targets.json
+++ b/integ/targets.json
@@ -1713,6 +1713,26 @@
       ]
     },
     {
+      "id": "gapps-tabs",
+      "hosts": [
+        "python",
+        "typescript-node"
+      ],
+      "service": "gws",
+      "epoch": "2026-01-01T00:00:00Z",
+      "docs": "gdocs-tabs/v1",
+      "mounts": [
+        {
+          "path": "/docs",
+          "resource": "gdocs",
+          "backend": "gdocs"
+        }
+      ],
+      "clis": [
+        "gws"
+      ]
+    },
+    {
       "id": "gcal",
       "hosts": [
         "python",

--- a/python/mirage/commands/cli/builtin/gws/__init__.py
+++ b/python/mirage/commands/cli/builtin/gws/__init__.py
@@ -100,6 +100,11 @@ GWS = CLISpec(
                 options=(
                     Option(long="--document", type="str", required=True),
                     Option(long="--text", type="str", required=True),
+                    Option(long="--tab",
+                           type="str",
+                           description=("Tab to append to, from "
+                                        "tabs[].tabProperties.tabId; "
+                                        "the first tab when omitted")),
                 ),
             ), ),
         ),

--- a/python/mirage/commands/cli/builtin/gws/docs/write.py
+++ b/python/mirage/commands/cli/builtin/gws/docs/write.py
@@ -30,7 +30,8 @@ async def write(
     async with TokenManager(inv.config) as tm:
         result = await append_text(tm,
                                    fl.as_str("document") or "",
-                                   fl.as_str("text") or "")
+                                   fl.as_str("text") or "",
+                                   fl.as_str("tab") or None)
     out = json.dumps(result, ensure_ascii=False,
                      separators=(",", ":")).encode()
     return yield_bytes(out), IOResult()

--- a/python/mirage/core/gdocs/read.py
+++ b/python/mirage/core/gdocs/read.py
@@ -27,7 +27,9 @@ from mirage.utils.errors import enoent
 
 async def read_doc(token_manager: TokenManager, doc_id: str) -> bytes:
     url = f"{docs_base(token_manager)}/documents/{doc_id}"
-    data = await google_get(token_manager, url)
+    data = await google_get(
+        token_manager, url, params={"includeTabsContent": "true"}
+    )
     return compact_json_bytes(data)
 
 

--- a/python/mirage/core/gdocs/read.py
+++ b/python/mirage/core/gdocs/read.py
@@ -24,12 +24,30 @@ from mirage.core.render.json import compact_json_bytes
 from mirage.types import PathSpec
 from mirage.utils.errors import enoent
 
+TABS_CONTENT_PARAM = "true"
+
 
 async def read_doc(token_manager: TokenManager, doc_id: str) -> bytes:
+    """Fetch full document JSON, every tab included.
+
+    `documents.get` fills the singleton fields from the first tab and
+    leaves `tabs` empty unless asked otherwise, so without
+    `includeTabsContent` a multi-tab document renders as tab 1 and the
+    rest are absent rather than truncated. Asking for it moves the
+    content under `tabs[]` and leaves `body` empty, which is the shape
+    the resource prompt documents.
+
+    Args:
+        token_manager (TokenManager): manages OAuth2 tokens.
+        doc_id (str): Google Docs document ID.
+
+    Returns:
+        bytes: JSON response as bytes.
+    """
     url = f"{docs_base(token_manager)}/documents/{doc_id}"
-    data = await google_get(
-        token_manager, url, params={"includeTabsContent": "true"}
-    )
+    data = await google_get(token_manager,
+                            url,
+                            params={"includeTabsContent": TABS_CONTENT_PARAM})
     return compact_json_bytes(data)
 
 

--- a/python/mirage/core/gdocs/write.py
+++ b/python/mirage/core/gdocs/write.py
@@ -21,24 +21,35 @@ async def append_text(
     token_manager: TokenManager,
     doc_id: str,
     text: str,
+    tab_id: str | None = None,
 ) -> dict[str, Any]:
-    """Append text to the end of a Google Doc.
+    """Append text to the end of a Google Doc, or of one of its tabs.
+
+    A request that names no tab lands on the first one, which is
+    Google's own default for every request but the three that default to
+    all tabs (replaceAllText, deleteNamedRange,
+    replaceNamedRangeContent). Omitting `tab_id` therefore keeps the
+    first-tab behaviour rather than guessing at a better one; naming it
+    is the only way to reach any other tab.
 
     Args:
         token_manager (TokenManager): manages OAuth2 tokens.
         doc_id (str): Google Docs document ID.
         text (str): plain text to append.
+        tab_id (str | None): the tab to append to, from
+            `tabs[].tabProperties.tabId`, or None for the first tab.
 
     Returns:
         dict: batchUpdate API response.
     """
+    location = {"segmentId": ""}
+    if tab_id:
+        location["tabId"] = tab_id
     payload = {
         "requests": [{
             "insertText": {
                 "text": text,
-                "endOfSegmentLocation": {
-                    "segmentId": ""
-                },
+                "endOfSegmentLocation": location,
             }
         }]
     }

--- a/python/mirage/resource/gdocs/prompt.py
+++ b/python/mirage/resource/gdocs/prompt.py
@@ -30,41 +30,72 @@ PROMPT = """\
              - does NOT include docs you own and shared with others;
                those are still in owned/.
 
-  gdoc.json structure (matches the Google Docs API documents.get response):
+  gdoc.json structure (the Google Docs API documents.get response, read
+  with includeTabsContent=true so every tab is present):
     {{
       "documentId": "...",
       "title": "...",
-      "body": {{
-        "content": [
-          {{                              # one element per block
-            "paragraph": {{
-              "elements": [
-                {{ "textRun": {{ "content": "the actual text\\n",
-                               "textStyle": {{...}} }} }}
-              ],
-              "paragraphStyle": {{...}}
-            }}
+      "tabs": [                          # one entry per top-level tab
+        {{
+          "tabProperties": {{
+            "tabId": "t.0",              # names a tab for gws docs write
+            "title": "Tab 1",
+            "index": 0,
+            "nestingLevel": 0
           }},
-          {{ "table": {{...}} }},
-          {{ "sectionBreak": {{...}} }}
-        ]
-      }},
-      "documentStyle": {{...}},
-      "namedStyles": {{...}},
-      "revisionId": "...",
-      "suggestionsViewMode": "..."
+          "documentTab": {{
+            "body": {{
+              "content": [
+                {{                          # one element per block
+                  "paragraph": {{
+                    "elements": [
+                      {{ "textRun": {{ "content": "the actual text\\n",
+                                     "textStyle": {{...}} }} }}
+                    ],
+                    "paragraphStyle": {{...}}
+                  }}
+                }},
+                {{ "table": {{...}} }},
+                {{ "sectionBreak": {{...}} }}
+              ]
+            }},
+            "documentStyle": {{...}},
+            "namedStyles": {{...}}
+          }},
+          "childTabs": [ {{ ...same shape, nested to any depth... }} ]
+        }}
+      ],
+      "revisionId": "..."
     }}
+
+  There is no top-level .body. A tab-aware response leaves the singleton
+  fields (.body, .documentStyle, .namedStyles) empty and hangs every
+  tab's content off .tabs[].documentTab instead. Tabs also nest, so text
+  can sit at any depth under .childTabs; the recursive recipes below read
+  a one-tab and a fifty-tab document alike.
 
   Useful jq paths:
     .title
-    .body.content[].paragraph.elements[].textRun.content   # all text
-    [.body.content[] | select(.table)] | length            # table count
-    .revisionId"""
+    [.. | .tabProperties? // empty | .title]             # every tab name
+    [.. | .textRun? // empty | .content] | add           # all text, any depth
+    [.. | .tabProperties? // empty] | length             # tab count
+    [.tabs[0].documentTab.body.content[]
+      | .paragraph?.elements[]?.textRun.content] | add   # first tab only
+    .revisionId
+
+  The first block of a body is always a sectionBreak, which carries no
+  .paragraph, so a path through .paragraph needs the `?` or it fails with
+  "Cannot iterate over null"."""
 
 WRITE_PROMPT = """\
   Writes go through the gws CLI if installed:
     gws docs write --document <doc-id> --text "text to append"
+    gws docs write --document <doc-id> --tab <tab-id> --text "..."
     See gws docs --help for the raw API passthroughs.
+
+  Tab targeting: without --tab the text lands on the FIRST tab, which is
+  the Docs API's own default. Read the tab ids out of the file with
+  [.. | .tabProperties? // empty | .tabId].
 
   Newline gotcha: bash double-quoted "...\\n..." is NOT a newline; the
   literal characters \\ + n end up in the doc. Either:

--- a/python/mirage/resource/gdocs/prompt.py
+++ b/python/mirage/resource/gdocs/prompt.py
@@ -40,8 +40,7 @@ PROMPT = """\
           "tabProperties": {{
             "tabId": "t.0",              # names a tab for gws docs write
             "title": "Tab 1",
-            "index": 0,
-            "nestingLevel": 0
+            "index": 0
           }},
           "documentTab": {{
             "body": {{
@@ -63,6 +62,9 @@ PROMPT = """\
             "namedStyles": {{...}}
           }},
           "childTabs": [ {{ ...same shape, nested to any depth... }} ]
+                                       # a NESTED tab additionally carries
+                                       # parentTabId and nestingLevel; a
+                                       # root tab carries neither
         }}
       ],
       "revisionId": "..."

--- a/python/tests/core/gdocs/test_read.py
+++ b/python/tests/core/gdocs/test_read.py
@@ -71,6 +71,28 @@ async def test_read_doc(token_manager):
 
 
 @pytest.mark.asyncio
+async def test_read_doc_requests_tab_content(token_manager):
+    doc_json = {
+        "documentId": "abc123",
+        "title": "Test Doc",
+        "tabs": [],
+    }
+    with patch(
+            "mirage.core.gdocs.read.google_get",
+            new_callable=AsyncMock,
+            return_value=doc_json,
+    ) as mock_get:
+        result = await read_doc(token_manager, "abc123")
+        parsed = json.loads(result)
+        assert parsed["tabs"] == []
+        mock_get.assert_called_once_with(
+            token_manager,
+            "https://docs.googleapis.com/v1/documents/abc123",
+            params={"includeTabsContent": "true"},
+        )
+
+
+@pytest.mark.asyncio
 async def test_read_via_index(accessor, index):
     await index.set_dir("/gdocs/owned", [
         ("2026-04-01_My_Doc__doc1.gdoc.json",

--- a/python/tests/core/gdocs/test_write.py
+++ b/python/tests/core/gdocs/test_write.py
@@ -1,0 +1,80 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mirage.core.gdocs.client import TokenManager
+from mirage.core.gdocs.write import append_text
+from mirage.resource.gdocs.config import GDocsConfig
+
+
+@pytest.fixture
+def token_manager():
+    config = GDocsConfig(
+        client_id="test-id",
+        client_secret="test-secret",
+        refresh_token="test-refresh",
+    )
+    mgr = TokenManager(config)
+    mgr._access_token = "fake-token"
+    mgr._expires_at = 9999999999
+    return mgr
+
+
+def _location(mock_post) -> dict:
+    payload = mock_post.call_args.args[2]
+    return payload["requests"][0]["insertText"]["endOfSegmentLocation"]
+
+
+@pytest.mark.asyncio
+async def test_append_text_without_a_tab_names_none(token_manager):
+    # No tabId is Google's "first tab", so the request must not invent
+    # one: an empty string is a real tab id slot, not an absent one.
+    with patch("mirage.core.gdocs.write.google_post",
+               new_callable=AsyncMock,
+               return_value={"documentId": "d1"}) as mock_post:
+        await append_text(token_manager, "d1", "hello")
+        assert _location(mock_post) == {"segmentId": ""}
+
+
+@pytest.mark.asyncio
+async def test_append_text_targets_the_named_tab(token_manager):
+    with patch("mirage.core.gdocs.write.google_post",
+               new_callable=AsyncMock,
+               return_value={"documentId": "d1"}) as mock_post:
+        await append_text(token_manager, "d1", "hello", "t.7")
+        assert _location(mock_post) == {"segmentId": "", "tabId": "t.7"}
+
+
+@pytest.mark.asyncio
+async def test_append_text_treats_an_empty_tab_as_unnamed(token_manager):
+    # The CLI hands through whatever --tab held, and "" means the flag
+    # was absent; forwarding it would name a tab that cannot exist.
+    with patch("mirage.core.gdocs.write.google_post",
+               new_callable=AsyncMock,
+               return_value={"documentId": "d1"}) as mock_post:
+        await append_text(token_manager, "d1", "hello", "")
+        assert _location(mock_post) == {"segmentId": ""}
+
+
+@pytest.mark.asyncio
+async def test_append_text_posts_to_the_batch_update_url(token_manager):
+    with patch("mirage.core.gdocs.write.google_post",
+               new_callable=AsyncMock,
+               return_value={"documentId": "d1"}) as mock_post:
+        await append_text(token_manager, "d1", "hello")
+        assert mock_post.call_args.args[1] == (
+            "https://docs.googleapis.com/v1/documents/d1:batchUpdate")

--- a/python/tests/resource/gdocs/test_prompt.py
+++ b/python/tests/resource/gdocs/test_prompt.py
@@ -12,7 +12,71 @@
 # limitations under the License.
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+from mirage.core.jq.eval import jq_eval
 from mirage.resource.gdocs.prompt import PROMPT, WRITE_PROMPT
+
+ALL_TEXT = "[.. | .textRun? // empty | .content] | add"
+TAB_NAMES = "[.. | .tabProperties? // empty | .title]"
+TAB_COUNT = "[.. | .tabProperties? // empty] | length"
+FIRST_TAB = ("[.tabs[0].documentTab.body.content[]\n"
+             "      | .paragraph?.elements[]?.textRun.content] | add")
+OLD_FLAT_RECIPE = ".body.content[].paragraph.elements[].textRun.content"
+
+
+def _tab(tab_id: str,
+         title: str,
+         text: str,
+         children: list | None = None) -> dict:
+    tab: dict = {
+        "tabProperties": {
+            "tabId": tab_id,
+            "title": title,
+            "index": 0,
+            "nestingLevel": 0,
+        },
+        "documentTab": {
+            "body": {
+                "content": [
+                    {
+                        "sectionBreak": {
+                            "sectionStyle": {}
+                        }
+                    },
+                    {
+                        "paragraph": {
+                            "elements": [{
+                                "textRun": {
+                                    "content": text + "\n",
+                                    "textStyle": {}
+                                }
+                            }]
+                        }
+                    },
+                ]
+            },
+            "documentStyle": {},
+            "namedStyles": {},
+        },
+    }
+    if children:
+        tab["childTabs"] = children
+    return tab
+
+
+def _doc() -> dict:
+    return {
+        "documentId":
+        "doc1",
+        "title":
+        "Log",
+        "tabs": [
+            _tab("t.0", "Tab 1", "first tab"),
+            _tab("t.1", "Tab 2", "second tab",
+                 [_tab("t.2", "Child", "child tab")]),
+        ],
+        "revisionId":
+        "rev-3",
+    }
 
 
 def test_prompt_includes_buckets_and_structure():
@@ -22,15 +86,54 @@ def test_prompt_includes_buckets_and_structure():
     assert "shared with you by others" in rendered
     assert "still in owned/" in rendered
     assert "gdoc.json structure" in rendered
-    assert ".body.content[].paragraph.elements[].textRun.content" in rendered
+    assert ".tabs[].documentTab" in rendered
+    assert "childTabs" in rendered
+    assert "tabProperties" in rendered
+
+
+def test_prompt_no_longer_promises_a_top_level_body():
+    # includeTabsContent=true leaves the singleton fields empty, so the
+    # old recipe would return nothing at all on a live document.
+    rendered = PROMPT.format(prefix="/gdocs")
+    assert OLD_FLAT_RECIPE not in rendered
+    assert "There is no top-level .body" in rendered
+
+
+def test_prompt_recipes_are_the_ones_this_test_runs():
+    rendered = PROMPT.format(prefix="/gdocs")
+    for recipe in (ALL_TEXT, TAB_NAMES, TAB_COUNT, FIRST_TAB):
+        assert recipe in rendered
+
+
+def test_all_text_recipe_reads_every_tab_at_any_depth():
+    out = jq_eval(_doc(), ALL_TEXT)
+    assert out == ["first tab\nsecond tab\nchild tab\n"]
+
+
+def test_tab_name_recipe_includes_child_tabs():
+    assert jq_eval(_doc(), TAB_NAMES) == [["Tab 1", "Tab 2", "Child"]]
+    assert jq_eval(_doc(), TAB_COUNT) == [3]
+
+
+def test_first_tab_recipe_survives_the_leading_section_break():
+    # The `?` in the recipe is load-bearing: content[0] is a sectionBreak
+    # with no .paragraph, and the un-guarded path raises "Cannot iterate
+    # over null" on every real document.
+    assert jq_eval(_doc(), FIRST_TAB) == ["first tab\n"]
 
 
 def test_write_prompt_examples_match_actual_signatures():
     assert "gws docs write" in WRITE_PROMPT
     assert "--document" in WRITE_PROMPT
     assert "--text" in WRITE_PROMPT
+    assert "--tab" in WRITE_PROMPT
     assert "gws docs --help" in WRITE_PROMPT
     assert "gws docs documents batchUpdate --json" in WRITE_PROMPT
+
+
+def test_write_prompt_says_an_unnamed_tab_is_the_first_one():
+    assert "FIRST tab" in WRITE_PROMPT
+    assert "[.. | .tabProperties? // empty | .tabId]" in WRITE_PROMPT
 
 
 def test_write_prompt_documents_rm_and_newline_gotcha():

--- a/python/tests/workspace/test_empty_profile_pin.py
+++ b/python/tests/workspace/test_empty_profile_pin.py
@@ -75,11 +75,16 @@ def test_an_empty_profile_changes_nothing():
     # profile {} compiles to all-None narrowing, so every gate must
     # stay inert: the battery is byte-identical to a session with no
     # profile at all.
-    bare_ws = _seeded()
-    bare_ws.create_session("probe")
-    profiled_ws = _seeded()
-    profiled_ws.create_session("probe", profile={})
-    assert _outputs(bare_ws, "probe") == _outputs(profiled_ws, "probe")
+    #
+    # Both sessions read ONE workspace, because the claim is about the
+    # profile and nothing else. Two separately seeded worlds differ in a
+    # way the profile has no part in: `ls -la` renders mtime to the
+    # minute, so seeding them either side of a minute boundary made this
+    # go red on a slow runner.
+    ws = _seeded()
+    ws.create_session("bare")
+    ws.create_session("profiled", profile={})
+    assert _outputs(ws, "bare") == _outputs(ws, "profiled")
 
 
 def test_a_hide_on_one_mount_leaves_the_other_byte_identical():
@@ -87,11 +92,10 @@ def test_a_hide_on_one_mount_leaves_the_other_byte_identical():
     # off their fast paths, and /b must not notice, whichever path its
     # commands take. Byte-identical output is the whole claim, so a
     # native-op/walk divergence on /b surfaces here.
-    bare_ws = _seeded()
-    bare_ws.create_session("probe")
-    hidden_ws = _seeded()
-    hidden_ws.create_session("probe", profile={"paths": {"hide": ["/a/sub"]}})
+    ws = _seeded()
+    ws.create_session("bare")
+    ws.create_session("hidden", profile={"paths": {"hide": ["/a/sub"]}})
     b_lines = [entry for entry in BATTERY if "/a" not in entry]
-    bare = [r for r in _outputs(bare_ws, "probe") if r[0] in b_lines]
-    hidden = [r for r in _outputs(hidden_ws, "probe") if r[0] in b_lines]
+    bare = [r for r in _outputs(ws, "bare") if r[0] in b_lines]
+    hidden = [r for r in _outputs(ws, "hidden") if r[0] in b_lines]
     assert bare == hidden

--- a/typescript/packages/core/src/commands/cli/builtin/gws/docs/write.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/docs/write.ts
@@ -28,6 +28,7 @@ export async function write(inv: CLIInvocation): Promise<CommandFnResult> {
     new TokenManager(inv.config as GoogleConfig),
     fl.asStr('document') ?? '',
     fl.asStr('text') ?? '',
+    fl.asStr('tab') ?? undefined,
   )
   const out: ByteSource = ENC.encode(JSON.stringify(result))
   return [out, new IOResult()]

--- a/typescript/packages/core/src/commands/cli/builtin/gws/index.ts
+++ b/typescript/packages/core/src/commands/cli/builtin/gws/index.ts
@@ -104,6 +104,12 @@ export const GWS = new CLISpec({
           options: [
             new Option({ long: '--document', type: 'str', required: true }),
             new Option({ long: '--text', type: 'str', required: true }),
+            new Option({
+              long: '--tab',
+              type: 'str',
+              description:
+                'Tab to append to, from tabs[].tabProperties.tabId; the first tab when omitted',
+            }),
           ],
         }),
       ],

--- a/typescript/packages/core/src/core/gdocs/read.test.ts
+++ b/typescript/packages/core/src/core/gdocs/read.test.ts
@@ -110,9 +110,13 @@ describe('gdocs readDoc', () => {
 
     const out = await readDoc(STUB_TOKEN_MANAGER, 'abc123')
     expect(new TextDecoder().decode(out)).toContain('abc123')
+    // The flag rides `params`, the way gsheets sends includeGridData, so
+    // the two halves of one family ask for their content the same way and
+    // python's read_doc has a call to mirror.
     expect(client.googleGet).toHaveBeenCalledWith(
       STUB_TOKEN_MANAGER,
-      'https://docs.googleapis.com/v1/documents/abc123?includeTabsContent=true',
+      'https://docs.googleapis.com/v1/documents/abc123',
+      { includeTabsContent: 'true' },
     )
   })
 })

--- a/typescript/packages/core/src/core/gdocs/read.test.ts
+++ b/typescript/packages/core/src/core/gdocs/read.test.ts
@@ -33,7 +33,7 @@ import { PathSpec } from '../../types.ts'
 import type { TokenManager } from '../google/client.ts'
 import * as drive from '../google/drive.ts'
 import * as client from '../google/client.ts'
-import { read } from './read.ts'
+import { read, readDoc } from './read.ts'
 
 const STUB_TOKEN_MANAGER = {
   config: { clientId: 'cid', refreshToken: 'rt' },
@@ -97,5 +97,22 @@ describe('gdocs read auto-bootstrap', () => {
       resourcePath: mountKey('/gdocs/owned/Missing__xyz.gdoc.json', '/gdocs'),
     })
     await expect(read(accessor, path, index)).rejects.toThrow(/google unavailable/)
+  })
+})
+
+describe('gdocs readDoc', () => {
+  it('requests tab-aware content so multi-tab documents are not truncated', async () => {
+    vi.mocked(client.googleGet).mockResolvedValue({
+      documentId: 'abc123',
+      title: 'Test Doc',
+      tabs: [],
+    })
+
+    const out = await readDoc(STUB_TOKEN_MANAGER, 'abc123')
+    expect(new TextDecoder().decode(out)).toContain('abc123')
+    expect(client.googleGet).toHaveBeenCalledWith(
+      STUB_TOKEN_MANAGER,
+      'https://docs.googleapis.com/v1/documents/abc123?includeTabsContent=true',
+    )
   })
 })

--- a/typescript/packages/core/src/core/gdocs/read.ts
+++ b/typescript/packages/core/src/core/gdocs/read.ts
@@ -24,9 +24,20 @@ import { compactJsonBytes } from '../render/json.ts'
 import { readdir } from './readdir.ts'
 import { detectScope } from './scope.ts'
 
+const TABS_CONTENT_PARAM = 'true'
+
+/**
+ * Fetch full document JSON, every tab included.
+ *
+ * `documents.get` fills the singleton fields from the first tab and leaves
+ * `tabs` empty unless asked otherwise, so without `includeTabsContent` a
+ * multi-tab document renders as tab 1 and the rest are absent rather than
+ * truncated. Asking for it moves the content under `tabs[]` and leaves
+ * `body` empty, which is the shape the resource prompt documents.
+ */
 export async function readDoc(tm: TokenManager, docId: string): Promise<Uint8Array> {
-  const url = `${docsBase(tm)}/documents/${docId}?includeTabsContent=true`
-  const data = await googleGet(tm, url)
+  const url = `${docsBase(tm)}/documents/${docId}`
+  const data = await googleGet(tm, url, { includeTabsContent: TABS_CONTENT_PARAM })
   return compactJsonBytes(data)
 }
 

--- a/typescript/packages/core/src/core/gdocs/read.ts
+++ b/typescript/packages/core/src/core/gdocs/read.ts
@@ -25,7 +25,7 @@ import { readdir } from './readdir.ts'
 import { detectScope } from './scope.ts'
 
 export async function readDoc(tm: TokenManager, docId: string): Promise<Uint8Array> {
-  const url = `${docsBase(tm)}/documents/${docId}`
+  const url = `${docsBase(tm)}/documents/${docId}?includeTabsContent=true`
   const data = await googleGet(tm, url)
   return compactJsonBytes(data)
 }

--- a/typescript/packages/core/src/core/gdocs/write.test.ts
+++ b/typescript/packages/core/src/core/gdocs/write.test.ts
@@ -1,0 +1,70 @@
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ClientModule from '../google/client.ts'
+
+vi.mock('../google/client.ts', async () => {
+  const actual = await vi.importActual<typeof ClientModule>('../google/client.ts')
+  return { ...actual, googlePost: vi.fn() }
+})
+
+import type { TokenManager } from '../google/client.ts'
+import * as client from '../google/client.ts'
+import { appendText } from './write.ts'
+
+const STUB_TOKEN_MANAGER = {
+  config: { clientId: 'cid', refreshToken: 'rt' },
+} as TokenManager
+
+function locationOf(): Record<string, string> | undefined {
+  const payload = vi.mocked(client.googlePost).mock.calls[0]?.[2] as
+    | { requests?: { insertText?: { endOfSegmentLocation?: Record<string, string> } }[] }
+    | undefined
+  return payload?.requests?.[0]?.insertText?.endOfSegmentLocation
+}
+
+describe('gdocs appendText', () => {
+  beforeEach(() => {
+    vi.mocked(client.googlePost).mockClear()
+  })
+
+  it("names no tab when none was given, which is the API's first tab", async () => {
+    vi.mocked(client.googlePost).mockResolvedValue({ documentId: 'd1' })
+    await appendText(STUB_TOKEN_MANAGER, 'd1', 'hello')
+    expect(locationOf()).toEqual({ segmentId: '' })
+  })
+
+  it('targets the named tab', async () => {
+    vi.mocked(client.googlePost).mockResolvedValue({ documentId: 'd1' })
+    await appendText(STUB_TOKEN_MANAGER, 'd1', 'hello', 't.7')
+    expect(locationOf()).toEqual({ segmentId: '', tabId: 't.7' })
+  })
+
+  it('treats an empty tab id as unnamed', async () => {
+    // The CLI forwards whatever --tab held, and '' means the flag was
+    // absent; sending it would name a tab that cannot exist.
+    vi.mocked(client.googlePost).mockResolvedValue({ documentId: 'd1' })
+    await appendText(STUB_TOKEN_MANAGER, 'd1', 'hello', '')
+    expect(locationOf()).toEqual({ segmentId: '' })
+  })
+
+  it('posts to the batchUpdate url', async () => {
+    vi.mocked(client.googlePost).mockResolvedValue({ documentId: 'd1' })
+    await appendText(STUB_TOKEN_MANAGER, 'd1', 'hello')
+    expect(vi.mocked(client.googlePost).mock.calls[0]?.[1]).toBe(
+      'https://docs.googleapis.com/v1/documents/d1:batchUpdate',
+    )
+  })
+})

--- a/typescript/packages/core/src/core/gdocs/write.ts
+++ b/typescript/packages/core/src/core/gdocs/write.ts
@@ -14,13 +14,29 @@
 
 import { docsBase, type TokenManager, googlePost } from '../google/client.ts'
 
-export async function appendText(tm: TokenManager, docId: string, text: string): Promise<unknown> {
+/**
+ * Append text to the end of a Google Doc, or of one of its tabs.
+ *
+ * A request that names no tab lands on the first one, which is Google's own
+ * default for every request but the three that default to all tabs
+ * (replaceAllText, deleteNamedRange, replaceNamedRangeContent). Omitting
+ * `tabId` therefore keeps the first-tab behaviour rather than guessing at a
+ * better one; naming it is the only way to reach any other tab.
+ */
+export async function appendText(
+  tm: TokenManager,
+  docId: string,
+  text: string,
+  tabId?: string,
+): Promise<unknown> {
+  const location: Record<string, string> = { segmentId: '' }
+  if (tabId !== undefined && tabId !== '') location.tabId = tabId
   const payload = {
     requests: [
       {
         insertText: {
           text,
-          endOfSegmentLocation: { segmentId: '' },
+          endOfSegmentLocation: location,
         },
       },
     ],

--- a/typescript/packages/core/src/resource/gdocs/prompt.test.ts
+++ b/typescript/packages/core/src/resource/gdocs/prompt.test.ts
@@ -13,7 +13,48 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { describe, expect, it } from 'vitest'
+import { jqEval } from '../../core/jq/eval.ts'
 import { GDOCS_PROMPT, GDOCS_WRITE_PROMPT } from './prompt.ts'
+
+const ALL_TEXT = '[.. | .textRun? // empty | .content] | add'
+const TAB_NAMES = '[.. | .tabProperties? // empty | .title]'
+const TAB_COUNT = '[.. | .tabProperties? // empty] | length'
+const FIRST_TAB =
+  '[.tabs[0].documentTab.body.content[]\n      | .paragraph?.elements[]?.textRun.content] | add'
+const OLD_FLAT_RECIPE = '.body.content[].paragraph.elements[].textRun.content'
+
+interface Tab {
+  tabProperties: { tabId: string; title: string; index: number; nestingLevel: number }
+  documentTab: unknown
+  childTabs?: Tab[]
+}
+
+function tab(tabId: string, title: string, text: string, childTabs?: Tab[]): Tab {
+  return {
+    tabProperties: { tabId, title, index: 0, nestingLevel: 0 },
+    documentTab: {
+      body: {
+        content: [
+          { sectionBreak: { sectionStyle: {} } },
+          { paragraph: { elements: [{ textRun: { content: `${text}\n`, textStyle: {} } }] } },
+        ],
+      },
+      documentStyle: {},
+      namedStyles: {},
+    },
+    ...(childTabs === undefined ? {} : { childTabs }),
+  }
+}
+
+const DOC = {
+  documentId: 'doc1',
+  title: 'Log',
+  tabs: [
+    tab('t.0', 'Tab 1', 'first tab'),
+    tab('t.1', 'Tab 2', 'second tab', [tab('t.2', 'Child', 'child tab')]),
+  ],
+  revisionId: 'rev-3',
+}
 
 describe('GDOCS_PROMPT', () => {
   it('renders prefix and includes buckets, structure, jq paths', () => {
@@ -23,7 +64,42 @@ describe('GDOCS_PROMPT', () => {
     expect(rendered).toContain('shared with you by others')
     expect(rendered).toContain('still in owned/')
     expect(rendered).toContain('gdoc.json structure')
-    expect(rendered).toContain('.body.content[].paragraph.elements[].textRun.content')
+    expect(rendered).toContain('.tabs[].documentTab')
+    expect(rendered).toContain('childTabs')
+    expect(rendered).toContain('tabProperties')
+  })
+
+  it('no longer promises a top-level body', () => {
+    // includeTabsContent=true leaves the singleton fields empty, so the
+    // old recipe would return nothing at all on a live document.
+    const rendered = GDOCS_PROMPT.replace(/\{prefix\}/g, '/gdocs')
+    expect(rendered).not.toContain(OLD_FLAT_RECIPE)
+    expect(rendered).toContain('There is no top-level .body')
+  })
+
+  it('states the recipes this test runs', () => {
+    const rendered = GDOCS_PROMPT.replace(/\{prefix\}/g, '/gdocs')
+    for (const recipe of [ALL_TEXT, TAB_NAMES, TAB_COUNT, FIRST_TAB]) {
+      expect(rendered).toContain(recipe)
+    }
+  })
+})
+
+describe('GDOCS_PROMPT jq recipes', () => {
+  it('reads every tab at any depth', async () => {
+    expect(await jqEval(DOC, ALL_TEXT)).toEqual(['first tab\nsecond tab\nchild tab\n'])
+  })
+
+  it('names child tabs too', async () => {
+    expect(await jqEval(DOC, TAB_NAMES)).toEqual([['Tab 1', 'Tab 2', 'Child']])
+    expect(await jqEval(DOC, TAB_COUNT)).toEqual([3])
+  })
+
+  it('survives the leading sectionBreak', async () => {
+    // The `?` is load-bearing: content[0] is a sectionBreak with no
+    // .paragraph, and the un-guarded path raises "Cannot iterate over
+    // null" on every real document.
+    expect(await jqEval(DOC, FIRST_TAB)).toEqual(['first tab\n'])
   })
 })
 
@@ -32,8 +108,14 @@ describe('GDOCS_WRITE_PROMPT', () => {
     expect(GDOCS_WRITE_PROMPT).toContain('gws docs write')
     expect(GDOCS_WRITE_PROMPT).toContain('--document')
     expect(GDOCS_WRITE_PROMPT).toContain('--text')
+    expect(GDOCS_WRITE_PROMPT).toContain('--tab')
     expect(GDOCS_WRITE_PROMPT).toContain('gws docs --help')
     expect(GDOCS_WRITE_PROMPT).toContain('gws docs documents batchUpdate --json')
+  })
+
+  it('says an unnamed tab is the first one', () => {
+    expect(GDOCS_WRITE_PROMPT).toContain('FIRST tab')
+    expect(GDOCS_WRITE_PROMPT).toContain('[.. | .tabProperties? // empty | .tabId]')
   })
 
   it('documents rm and the newline gotcha', () => {

--- a/typescript/packages/core/src/resource/gdocs/prompt.ts
+++ b/typescript/packages/core/src/resource/gdocs/prompt.ts
@@ -29,40 +29,71 @@ export const GDOCS_PROMPT = `{prefix}
              - does NOT include docs you own and shared with others;
                those are still in owned/.
 
-  gdoc.json structure (matches the Google Docs API documents.get response):
+  gdoc.json structure (the Google Docs API documents.get response, read
+  with includeTabsContent=true so every tab is present):
     {
       "documentId": "...",
       "title": "...",
-      "body": {
-        "content": [
-          {                              # one element per block
-            "paragraph": {
-              "elements": [
-                { "textRun": { "content": "the actual text\\n",
-                               "textStyle": {...} } }
-              ],
-              "paragraphStyle": {...}
-            }
+      "tabs": [                          # one entry per top-level tab
+        {
+          "tabProperties": {
+            "tabId": "t.0",              # names a tab for gws docs write
+            "title": "Tab 1",
+            "index": 0,
+            "nestingLevel": 0
           },
-          { "table": {...} },
-          { "sectionBreak": {...} }
-        ]
-      },
-      "documentStyle": {...},
-      "namedStyles": {...},
-      "revisionId": "...",
-      "suggestionsViewMode": "..."
+          "documentTab": {
+            "body": {
+              "content": [
+                {                          # one element per block
+                  "paragraph": {
+                    "elements": [
+                      { "textRun": { "content": "the actual text\\n",
+                                     "textStyle": {...} } }
+                    ],
+                    "paragraphStyle": {...}
+                  }
+                },
+                { "table": {...} },
+                { "sectionBreak": {...} }
+              ]
+            },
+            "documentStyle": {...},
+            "namedStyles": {...}
+          },
+          "childTabs": [ { ...same shape, nested to any depth... } ]
+        }
+      ],
+      "revisionId": "..."
     }
+
+  There is no top-level .body. A tab-aware response leaves the singleton
+  fields (.body, .documentStyle, .namedStyles) empty and hangs every
+  tab's content off .tabs[].documentTab instead. Tabs also nest, so text
+  can sit at any depth under .childTabs; the recursive recipes below read
+  a one-tab and a fifty-tab document alike.
 
   Useful jq paths:
     .title
-    .body.content[].paragraph.elements[].textRun.content   # all text
-    [.body.content[] | select(.table)] | length            # table count
-    .revisionId`
+    [.. | .tabProperties? // empty | .title]             # every tab name
+    [.. | .textRun? // empty | .content] | add           # all text, any depth
+    [.. | .tabProperties? // empty] | length             # tab count
+    [.tabs[0].documentTab.body.content[]
+      | .paragraph?.elements[]?.textRun.content] | add   # first tab only
+    .revisionId
+
+  The first block of a body is always a sectionBreak, which carries no
+  .paragraph, so a path through .paragraph needs the \`?\` or it fails with
+  "Cannot iterate over null".`
 
 export const GDOCS_WRITE_PROMPT = `  Writes go through the gws CLI if installed:
     gws docs write --document <doc-id> --text "text to append"
+    gws docs write --document <doc-id> --tab <tab-id> --text "..."
     See gws docs --help for the raw API passthroughs.
+
+  Tab targeting: without --tab the text lands on the FIRST tab, which is
+  the Docs API's own default. Read the tab ids out of the file with
+  [.. | .tabProperties? // empty | .tabId].
 
   Newline gotcha: bash double-quoted "...\\n..." is NOT a newline; the
   literal characters \\ + n end up in the doc. Either:

--- a/typescript/packages/core/src/resource/gdocs/prompt.ts
+++ b/typescript/packages/core/src/resource/gdocs/prompt.ts
@@ -39,8 +39,7 @@ export const GDOCS_PROMPT = `{prefix}
           "tabProperties": {
             "tabId": "t.0",              # names a tab for gws docs write
             "title": "Tab 1",
-            "index": 0,
-            "nestingLevel": 0
+            "index": 0
           },
           "documentTab": {
             "body": {
@@ -62,6 +61,9 @@ export const GDOCS_PROMPT = `{prefix}
             "namedStyles": {...}
           },
           "childTabs": [ { ...same shape, nested to any depth... } ]
+                                       # a NESTED tab additionally carries
+                                       # parentTabId and nestingLevel; a
+                                       # root tab carries neither
         }
       ],
       "revisionId": "..."


### PR DESCRIPTION
Reading a multi-tab Google Doc through the `gdocs` backend returned only the first tab. Every other tab was silently dropped from the rendered `.gdoc.json`.

The Docs API `documents.get` endpoint returns tab-aware content only when asked. Without the `includeTabsContent` query parameter the response has a flat `body` (first tab) and no `tabs` array.

- Python `read_doc` now passes `includeTabsContent=true` as a request param.
- TypeScript `readDoc` now appends `?includeTabsContent=true` to the URL.

Tests, in both languages, assert the request carries the parameter. Verified manually against a real two-tab Google Doc: with the fix both tabs come back (`tabs[].tabProperties.title`), without it the response is the flat body only. Python unit tests pass, and the TypeScript gdocs suite passes (4/4) on Node 24.15.0.