### PR TITLE
Fix large stdin uploads and CLI output truncation

### DIFF
--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -9,6 +9,7 @@ permissions:
     paths:
       - python/**
       - typescript/**
+      - integ/execute_stdin.py
       - .github/workflows/test_cli.yml
       - .github/actions/setup-node-pnpm/action.yml
   pull_request:
@@ -44,6 +45,7 @@ jobs:
               - 'integ/cross.sh'
               - 'integ/cross.yaml'
               - 'integ/parity.sh'
+              - 'integ/execute_stdin.py'
               - 'integ/fuse/cli_fuse.sh'
               - 'integ/cli_config.sh'
               - 'integ/cli_env.sh'
@@ -727,6 +729,9 @@ jobs:
           /tmp/mc alias set local http://localhost:9000 minio minio123
           /tmp/mc mb local/mirage-cross || true
           /tmp/mc mb local/mirage-state || true
+
+      - name: Run daemon large-stdin and grep round trips (both languages)
+        run: ./python/.venv/bin/python integ/execute_stdin.py
 
       - name: Run cross-language snapshot interop (both directions)
         run: |

--- a/docs/home/cli.mdx
+++ b/docs/home/cli.mdx
@@ -100,8 +100,8 @@ mirage execute --workspace_id demo --command "head -n 1 /s3/data/example.jsonl"
 
 ### 4. Pipe stdin
 
-When stdout isn't a TTY, the CLI forwards stdin to the command
-automatically.
+For foreground commands, piped stdin is uploaded as a binary multipart file.
+Empty input and arbitrary bytes are preserved; input is buffered before execution.
 
 ```bash
 echo -e "a\nb\nc" | mirage execute --workspace_id demo --command "wc -l"
@@ -306,7 +306,7 @@ mirage workspace clone demo --at <version> --id demo_at_v1
 | `mirage session create WS [--id NAME] [--profile NAME] [-m /prefix[:mode]]...` | Add a named session (own cwd + env), optionally under a [permission profile](/home/permissions) or restricted to mounts with a mode ceiling (`read`/`write`/`exec` or `r`/`rw`/`rwx`). |
 | `mirage session list WS` | List sessions for a workspace. |
 | `mirage session delete WS SESSION` | Close a session. |
-| `mirage execute --workspace_id WS [--session_id S] [--background] --command "..."` | Run a command. Pipes stdin automatically when stdout is not a TTY. |
+| `mirage execute --workspace_id WS [--session_id S] [--background] --command "..."` | Run a command. Uploads piped stdin for foreground execution. |
 | `mirage provision --workspace_id WS [--session_id S] --command "..."` | Dry-run / cost estimate -- returns a `ProvisionResult` shape (network bytes, cache hits, estimated cost) without running the command. |
 | `mirage job list [--workspace_id WS]` | List jobs the daemon has run, plus their status. |
 | `mirage job get JOB` | Detail for one job. |

--- a/docs/typescript/server-and-cli.mdx
+++ b/docs/typescript/server-and-cli.mdx
@@ -55,6 +55,17 @@ mirage execute --bg -w <workspace-id> -c "wc -l /large.csv"
 mirage job wait <job-id>
 ```
 
+Piped input is uploaded as a binary multipart `stdin` file, preserving empty
+input and arbitrary bytes. HTTP clients can send `request` (the JSON execute
+options) and `stdin` as multipart parts for synchronous or background execution.
+The JSON `stdinBase64` form remains available for small requests; multipart
+avoids its base64 expansion and the daemon's JSON request-size limit. Input is
+buffered before execution.
+
+```bash
+cat report.json | mirage execute -w <workspace-id> -c 'cat > /report.json'
+```
+
 ## Workspace lifecycle
 
 | Command | Purpose |

--- a/integ/execute_stdin.py
+++ b/integ/execute_stdin.py
@@ -1,0 +1,221 @@
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
+"""Live daemon stdin and large grep output, on both hosts and RAM/disk.
+
+Run from the repository root after building TypeScript packages:
+    ./python/.venv/bin/python integ/execute_stdin.py
+
+Uses HTTP directly: grep returns its full output, the caller sends those
+bytes back as stdin to save a file, and the saved hash must match. Covers
+output above 1 MiB and output below 1 MiB whose base64 exceeds that limit.
+Each daemon has a private home and port and is terminated in finally.
+"""
+import base64
+import hashlib
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import httpx
+
+ROOT = Path(__file__).resolve().parents[1]
+MIB = 1024 * 1024
+
+
+@contextmanager
+def daemon(host: str, root: Path):
+    with socket.socket() as listener:
+        listener.bind(('127.0.0.1', 0))
+        port = listener.getsockname()[1]
+    env = {
+        **os.environ,
+        'MIRAGE_HOME': str(root / 'home'),
+        'MIRAGE_DAEMON_PORT': str(port),
+        'MIRAGE_AUTH_MODE': 'token',
+        'MIRAGE_AUTH_TOKEN': 'stdin-integ',
+        'MIRAGE_IDLE_GRACE_SECONDS': '600',
+    }
+    command = ([
+        sys.executable, '-m', 'uvicorn', 'mirage.server.daemon:app', '--host',
+        '127.0.0.1', '--port',
+        str(port)
+    ] if host == 'python' else [
+        'node',
+        str(ROOT / 'typescript/packages/server/dist/bin/daemon.js')
+    ])
+    with (root / 'daemon.log').open('w+') as log:
+        process = subprocess.Popen(command,
+                                   cwd=ROOT,
+                                   env=env,
+                                   stdout=log,
+                                   stderr=log)
+        try:
+            with httpx.Client(base_url=f'http://127.0.0.1:{port}',
+                              headers={'Authorization': 'Bearer stdin-integ'},
+                              timeout=60) as client:
+                deadline = time.monotonic() + 30
+                ready = False
+                while time.monotonic() < deadline:
+                    if process.poll() is not None:
+                        break
+                    try:
+                        if client.get('/v1/workspaces',
+                                      timeout=1).status_code == 200:
+                            ready = True
+                            break
+                    except httpx.TransportError:
+                        pass
+                    time.sleep(0.05)
+                if not ready:
+                    log.seek(0)
+                    raise RuntimeError(
+                        f'{host} daemon did not start:\n{log.read()}')
+                yield client
+        finally:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+
+
+def execute(client: httpx.Client,
+            wid: str,
+            command: str,
+            stdin: bytes | None = None,
+            background: bool = False,
+            legacy: bool = False) -> dict:
+    body = {'command': command, 'record': False}
+    kwargs = {'json': body}
+    if stdin is not None:
+        if legacy:
+            body['stdinBase64'] = base64.b64encode(stdin).decode()
+        else:
+            kwargs = {
+                'files': {
+                    'request':
+                    ('request.json', json.dumps(body), 'application/json'),
+                    'stdin': ('stdin.bin', stdin, 'application/octet-stream'),
+                }
+            }
+    response = client.post(f'/v1/workspaces/{wid}/execute',
+                           params={'background': str(background).lower()},
+                           **kwargs)
+    response.raise_for_status()
+    result = response.json()
+    if background:
+        job_id = result.get('job_id', result.get('jobId'))
+        response = client.post(f'/v1/jobs/{job_id}/wait',
+                               json={'timeoutS': 60})
+        response.raise_for_status()
+        job = response.json()
+        assert job['status'] == 'done', job
+        result = job['result']
+    assert result.get('exit_code', result.get('exitCode')) == 0, result
+    assert not result['stderr'], result['stderr']
+    return result
+
+
+def check_workspace(client: httpx.Client, host: str, resource: str,
+                    root: Path) -> None:
+    mount = {'resource': resource}
+    if resource == 'disk':
+        mount['config'] = {'root': str(root)}
+    created = client.post('/v1/workspaces',
+                          json={
+                              'config': {
+                                  'mode': 'EXEC',
+                                  'mounts': {
+                                      '/work': mount
+                                  }
+                              },
+                          })
+    created.raise_for_status()
+    wid = created.json()['id']
+    try:
+        if host == 'typescript':
+            for legacy in (False, True):
+                for stdin in (b'', b'\x00\xff\r\n' + 'α'.encode()):
+                    result = execute(client,
+                                     wid, 'python3 -c "import sys; '
+                                     'print(sys.stdin.buffer.read().hex())"',
+                                     stdin,
+                                     legacy=legacy)
+                    assert result['stdout'] == stdin.hex() + '\n', result
+            print(
+                f'{host}/{resource}: Python stdin '
+                '(empty/binary, JSON/multipart) OK',
+                flush=True)
+        for background in (False, True):
+            for count in (400_000, 600_000):
+                expected = 'needle ' + 'α' * count + '\n'
+                source = ('unmatched\n' + expected).encode()
+                byte_count = len(expected.encode())
+                assert len(base64.b64encode(expected.encode())) > MIB
+                assert (byte_count > MIB) == (count == 600_000)
+                execute(client, wid, 'cat > /work/source.txt', source,
+                        background)
+                result = execute(client,
+                                 wid,
+                                 'grep needle /work/source.txt',
+                                 background=background)
+                assert result['stdout'] == expected
+                data = result['stdout'].encode()
+                if host == 'typescript':
+                    # Base64 JSON still fails at its intended limit.
+                    refused = client.post(f'/v1/workspaces/{wid}/execute',
+                                          json={
+                                              'command':
+                                              'cat > /work/saved.txt',
+                                              'stdinBase64':
+                                              base64.b64encode(data).decode(),
+                                          })
+                    assert refused.status_code == 413, refused.text[:200]
+                execute(client, wid, 'cat > /work/saved.txt', data, background)
+                saved = execute(client, wid, 'sha256sum /work/saved.txt')
+                assert saved['stdout'].split()[0] == hashlib.sha256(
+                    data).hexdigest()
+                piped = execute(client, wid, 'grep needle', source, background)
+                assert piped['stdout'] == expected
+                print(
+                    f'{host}/{resource}/background={background}: '
+                    f'grep + save + SHA256, {len(data)} bytes OK',
+                    flush=True)
+    finally:
+        deleted = client.delete(f'/v1/workspaces/{wid}')
+        deleted.raise_for_status()
+
+
+def main() -> None:
+    for host in ('python', 'typescript'):
+        with tempfile.TemporaryDirectory(
+                prefix=f'mirage-stdin-{host}-') as temporary:
+            root = Path(temporary)
+            with daemon(host, root) as client:
+                for resource in ('ram', 'disk'):
+                    files = root / resource
+                    files.mkdir()
+                    check_workspace(client, host, resource, files)
+    print('Live daemon stdin and grep round trips passed on both hosts.')
+
+
+if __name__ == '__main__':
+    main()

--- a/python/tests/server/test_execute_router.py
+++ b/python/tests/server/test_execute_router.py
@@ -13,6 +13,7 @@
 # ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import asyncio
+import base64
 import json
 
 import pytest
@@ -274,6 +275,60 @@ async def test_execute_with_stdin_multipart():
         body = r.json()
         assert body["exit_code"] == 0
         assert body["stdout"].strip().startswith("3")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("background", [False, True])
+@pytest.mark.parametrize("resource", ["ram", "disk"])
+async def test_large_multipart_stdin_roundtrip(tmp_path, resource, background):
+    app = build_app(idle_grace_seconds=10.0)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport,
+                           base_url="http://test") as client:
+        mount = {"resource": resource, "mode": "WRITE"}
+        if resource == "disk":
+            mount["config"] = {"root": str(tmp_path)}
+        created = await client.post(
+            "/v1/workspaces", json={"config": {
+                "mounts": {
+                    "/work": mount
+                }
+            }})
+        assert created.status_code == 201, created.text
+        wid = created.json()["id"]
+        try:
+            for stdin in [("α\0\r\n" * 240_000).encode(), b""]:
+                payload = json.dumps({
+                    "command": "cat > input.bin",
+                    "cwd": "/work",
+                    "record": False
+                })
+                result = await client.post(
+                    f"/v1/workspaces/{wid}/execute",
+                    params={"background": str(background).lower()},
+                    files={
+                        "request":
+                        ("request.json", payload, "application/json"),
+                        "stdin":
+                        ("stdin.bin", stdin, "application/octet-stream")
+                    },
+                )
+                assert result.status_code == (202 if background else
+                                              200), result.text
+                if background:
+                    job = result.json()["job_id"]
+                    waited = await client.post(f"/v1/jobs/{job}/wait", json={})
+                    assert waited.json()["status"] == "done", waited.text
+                else:
+                    assert result.json()["exit_code"] == 0, result.text
+                read = await client.post(
+                    f"/v1/workspaces/{wid}/execute",
+                    json={"command": "base64 /work/input.bin"})
+                assert read.status_code == 200, read.text
+                assert read.json()["exit_code"] == 0
+                assert base64.b64decode(read.json()["stdout"]) == stdin
+        finally:
+            await client.delete(f"/v1/workspaces/{wid}")
 
 
 @pytest.mark.asyncio

--- a/typescript/packages/cli/src/e2e.test.ts
+++ b/typescript/packages/cli/src/e2e.test.ts
@@ -279,6 +279,44 @@ describe('mirage CLI end-to-end', () => {
     await runCli(env, ['workspace', 'delete', 'stdin-ws'])
   }, 30000)
 
+  it('execute uploads large piped stdin without JSON size limits', async () => {
+    const cfgPath = writeRamConfig(tmp, 'large-stdin.yaml')
+    const created = (await runCli(env, ['workspace', 'create', cfgPath])) as { id: string }
+    try {
+      const input = Buffer.from('α\0\r\n'.repeat(240_000))
+      await runCli(env, ['execute', '-w', created.id, '-c', 'cat > /input.bin'], input)
+      const read = (await runCli(env, [
+        'execute',
+        '-w',
+        created.id,
+        '-c',
+        'base64 /input.bin',
+      ])) as { stdout: string }
+      expect(Buffer.from(read.stdout, 'base64')).toEqual(input)
+      const submitted = (await runCli(env, [
+        'execute',
+        '-w',
+        created.id,
+        '--bg',
+        '-c',
+        'base64 /input.bin; false',
+      ])) as { jobId: string }
+      for (const command of ['wait', 'get']) {
+        const job = await runCliRaw(env, ['job', command, submitted.jobId])
+        expect(job.status).toBe(1)
+        const result = (job.parsed as { result: { stdout: string } }).result
+        expect(Buffer.from(result.stdout, 'base64')).toEqual(input)
+      }
+      await runCli(env, ['execute', '-w', created.id, '-c', 'cat > /input.bin'], new Uint8Array())
+      const empty = (await runCli(env, ['execute', '-w', created.id, '-c', 'cat /input.bin'])) as {
+        stdout: string
+      }
+      expect(empty.stdout).toBe('')
+    } finally {
+      await runCli(env, ['workspace', 'delete', created.id])
+    }
+  }, 30000)
+
   it('execute propagates inner exit code to process exit', async () => {
     const cfgPath = writeRamConfig(tmp, 'exit-cfg.yaml')
     const created = (await runCli(env, ['workspace', 'create', cfgPath])) as { id: string }

--- a/typescript/packages/cli/src/execute.ts
+++ b/typescript/packages/cli/src/execute.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
-import { readFileSync } from 'node:fs'
+import { buffer } from 'node:stream/consumers'
 import type { Command } from 'commander'
 import { makeClient } from './client.ts'
 import { emit, exitCodeFromResponse, handleResponse } from './output.ts'
@@ -41,18 +41,30 @@ export function registerExecuteCommand(program: Command): void {
         if (opts.session !== undefined) body.sessionId = opts.session
         if (opts.cwd !== undefined) body.cwd = opts.cwd
         if (opts.runtime !== undefined) body.runtime = opts.runtime
-        if (opts.bg !== true && !process.stdin.isTTY) {
-          body.stdinBase64 = readFileSync(0).toString('base64')
-        }
         const path =
           `/v1/workspaces/${opts.workspace}/execute` + (opts.bg === true ? '?background=true' : '')
         const c = makeClient(loadDaemonSettings())
         await c.ensureRunning({ allowSpawn: false })
-        const response = await handleResponse(
-          await c.request('POST', path, { body: JSON.stringify(body) }),
-        )
+        let result: Response
+        if (opts.bg !== true && !process.stdin.isTTY) {
+          const form = new FormData()
+          form.set(
+            'request',
+            new Blob([JSON.stringify(body)], { type: 'application/json' }),
+            'request.json',
+          )
+          form.set(
+            'stdin',
+            new Blob([await buffer(process.stdin)], { type: 'application/octet-stream' }),
+            'stdin.bin',
+          )
+          result = await c.requestMultipart('POST', path, form)
+        } else {
+          result = await c.request('POST', path, { body: JSON.stringify(body) })
+        }
+        const response = await handleResponse(result)
         emit(response)
-        process.exit(exitCodeFromResponse(response))
+        process.exitCode = exitCodeFromResponse(response)
       },
     )
 }

--- a/typescript/packages/cli/src/job.ts
+++ b/typescript/packages/cli/src/job.ts
@@ -43,7 +43,7 @@ export function registerJobCommands(program: Command): void {
       await c.ensureRunning({ allowSpawn: false })
       const response = await handleResponse(await c.request('GET', `/v1/jobs/${id}`))
       emit(response)
-      process.exit(exitCodeFromResponse(response))
+      process.exitCode = exitCodeFromResponse(response)
     })
 
   job
@@ -59,7 +59,7 @@ export function registerJobCommands(program: Command): void {
         await c.request('POST', `/v1/jobs/${id}/wait`, { body: JSON.stringify(body) }),
       )
       emit(response)
-      process.exit(exitCodeFromResponse(response))
+      process.exitCode = exitCodeFromResponse(response)
     })
 
   job

--- a/typescript/packages/server/src/routers/execute.test.ts
+++ b/typescript/packages/server/src/routers/execute.test.ts
@@ -91,6 +91,8 @@ describe('execute router', () => {
         await rm(root, { recursive: true, force: true })
       }
     },
+    // Includes real filesystem IO and multi-megabyte command output on CI.
+    30_000,
   )
 
   it('preserves empty multipart stdin and rejects missing request metadata', async () => {

--- a/typescript/packages/server/src/routers/execute.test.ts
+++ b/typescript/packages/server/src/routers/execute.test.ts
@@ -12,6 +12,9 @@
 // limitations under the License.
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { buildApp } from '../app.ts'
 
@@ -24,6 +27,100 @@ async function createWs(app: ReturnType<typeof buildApp>, id: string): Promise<v
 }
 
 describe('execute router', () => {
+  it.each([
+    ['ram', false],
+    ['ram', true],
+    ['disk', false],
+    ['disk', true],
+  ] as const)(
+    'preserves large multipart stdin on %s (background=%s)',
+    async (resource, background) => {
+      const root = await mkdtemp(join(tmpdir(), 'execute-stdin-'))
+      const app = buildApp()
+      try {
+        const created = await app.inject({
+          method: 'POST',
+          url: '/v1/workspaces',
+          payload: {
+            id: 'large-stdin',
+            config: {
+              mounts: {
+                '/work': {
+                  resource,
+                  mode: 'write',
+                  ...(resource === 'disk' ? { config: { root } } : {}),
+                },
+              },
+            },
+          },
+        })
+        expect(created.statusCode).toBe(201)
+        const stdin = Buffer.from('α\0\r\n'.repeat(240_000))
+        expect(stdin.length).toBeGreaterThan(1024 * 1024)
+        const form = new FormData()
+        const request = JSON.stringify({ command: 'cat > input.bin', cwd: '/work', record: false })
+        form.set(
+          'request',
+          background ? new Blob([request], { type: 'application/json' }) : request,
+        )
+        form.set('stdin', new Blob([stdin]), 'stdin.bin')
+        const upload = new Request('http://localhost', { method: 'POST', body: form })
+        const result = await app.inject({
+          method: 'POST',
+          url: `/v1/workspaces/large-stdin/execute?background=${String(background)}`,
+          headers: { 'content-type': upload.headers.get('content-type') ?? '' },
+          payload: Buffer.from(await upload.arrayBuffer()),
+        })
+        expect(result.statusCode).toBe(background ? 202 : 200)
+        if (background) {
+          const job = result.json<{ jobId: string }>()
+          const waited = await app.inject({ method: 'POST', url: `/v1/jobs/${job.jobId}/wait` })
+          expect(waited.json<{ status: string }>().status).toBe('done')
+        } else {
+          expect(result.json<{ exitCode: number }>().exitCode).toBe(0)
+        }
+        const read = await app.inject({
+          method: 'POST',
+          url: '/v1/workspaces/large-stdin/execute',
+          payload: { command: 'base64 /work/input.bin' },
+        })
+        expect(read.json<{ exitCode: number }>().exitCode).toBe(0)
+        expect(Buffer.from(read.json<{ stdout: string }>().stdout, 'base64')).toEqual(stdin)
+      } finally {
+        await app.close()
+        await rm(root, { recursive: true, force: true })
+      }
+    },
+  )
+
+  it('preserves empty multipart stdin and rejects missing request metadata', async () => {
+    const app = buildApp()
+    try {
+      await createWs(app, 'multipart-empty')
+      for (const request of [undefined, '{broken', JSON.stringify({ command: 'wc -c' })]) {
+        const form = new FormData()
+        // File first also covers clients whose multipart fields arrive out of order.
+        form.set('stdin', new Blob([]), 'stdin.bin')
+        if (request !== undefined) form.set('request', request)
+        const upload = new Request('http://localhost', { method: 'POST', body: form })
+        const result = await app.inject({
+          method: 'POST',
+          url: '/v1/workspaces/multipart-empty/execute',
+          headers: { 'content-type': upload.headers.get('content-type') ?? '' },
+          payload: Buffer.from(await upload.arrayBuffer()),
+        })
+        expect(result.statusCode).toBe(request?.startsWith('{"command"') === true ? 200 : 400)
+        if (result.statusCode === 200) {
+          expect(result.json<{ stdout: string }>().stdout.trim()).toBe('0')
+        }
+      }
+      const jobs = await app.inject({ method: 'GET', url: '/v1/jobs?workspaceId=multipart-empty' })
+      expect(jobs.json<unknown[]>()).toHaveLength(1)
+    } finally {
+      await app.close()
+    }
+  })
+
   it('synchronously runs a command and returns IO result', async () => {
     const app = buildApp()
     await createWs(app, 'ew')

--- a/typescript/packages/server/src/routers/execute.ts
+++ b/typescript/packages/server/src/routers/execute.ts
@@ -100,7 +100,8 @@ export function registerExecuteRoutes(app: FastifyInstance, deps: ExecuteRoutesD
           ...(body.runtime !== undefined ? { runtime: body.runtime } : {}),
           ...(body.record !== undefined ? { record: body.record } : {}),
           ...(body.provision === true ? { provision: true as const } : {}),
-          ...(stdin !== undefined ? { stdin } : {}),
+          // Pyodide rejects Node Buffer even though it subclasses Uint8Array.
+          ...(stdin !== undefined ? { stdin: new Uint8Array(stdin) } : {}),
           signal,
         }),
       )

--- a/typescript/packages/server/src/routers/execute.ts
+++ b/typescript/packages/server/src/routers/execute.ts
@@ -13,7 +13,8 @@
 // ========= Copyright 2026 @ Strukto.AI All Rights Reserved. =========
 
 import { Buffer } from 'node:buffer'
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyRequest } from 'fastify'
+import { z } from '@struktoai/mirage-core/resource/secrets'
 import type { WorkspaceRegistry } from '../registry.ts'
 import { JobStatus, type JobTable } from '../jobs.ts'
 import { ioResultToDict } from '../io_serde.ts'
@@ -27,15 +28,44 @@ interface ExecuteParams {
   wsId: string
 }
 
-interface ExecuteBody {
-  command: string
-  sessionId?: string
-  provision?: boolean
-  agentId?: string
-  cwd?: string
-  runtime?: string
-  stdinBase64?: string
-  record?: boolean
+const ExecuteBodySchema = z.object({
+  command: z.string(),
+  sessionId: z.string().optional(),
+  provision: z.boolean().optional(),
+  agentId: z.string().optional(),
+  cwd: z.string().optional(),
+  runtime: z.string().optional(),
+  stdinBase64: z.string().optional(),
+  record: z.boolean().optional(),
+})
+
+type ExecuteBody = z.infer<typeof ExecuteBodySchema>
+
+async function parseExecuteBody(
+  req: FastifyRequest,
+): Promise<[ExecuteBody, Uint8Array | undefined]> {
+  if (!req.isMultipart()) {
+    const body = ExecuteBodySchema.parse(req.body)
+    return [
+      body,
+      body.stdinBase64 === undefined ? undefined : Buffer.from(body.stdinBase64, 'base64'),
+    ]
+  }
+  let request: unknown
+  let stdin: Uint8Array | undefined
+  for await (const part of req.parts({ limits: { parts: 2 } })) {
+    if (part.type === 'field' && part.valueTruncated) {
+      throw Object.assign(new Error('multipart field is too large'), { statusCode: 413 })
+    }
+    const value = part.type === 'file' ? await part.toBuffer() : part.value
+    if (part.fieldname === 'request') {
+      request =
+        typeof value === 'string' || Buffer.isBuffer(value) ? JSON.parse(value.toString()) : value
+    } else if (part.fieldname === 'stdin') {
+      stdin = Buffer.isBuffer(value) ? value : Buffer.from(String(value))
+    }
+  }
+  return [ExecuteBodySchema.parse(request), stdin]
 }
 
 interface ExecuteQuery {
@@ -50,7 +80,16 @@ export function registerExecuteRoutes(app: FastifyInstance, deps: ExecuteRoutesD
       if (!deps.registry.has(wsId)) {
         return reply.status(404).send({ detail: 'workspace not found' })
       }
-      const body = req.body
+      let body: ExecuteBody
+      let stdin: Uint8Array | undefined
+      try {
+        ;[body, stdin] = await parseExecuteBody(req)
+      } catch (error) {
+        if (error instanceof SyntaxError || error instanceof z.ZodError) {
+          return reply.status(400).send({ detail: `bad execute request: ${error.message}` })
+        }
+        throw error
+      }
       const background = req.query.background === 'true'
       const entry = deps.registry.get(wsId)
       const job = deps.jobs.submit(wsId, body.command, async (signal) =>
@@ -61,9 +100,7 @@ export function registerExecuteRoutes(app: FastifyInstance, deps: ExecuteRoutesD
           ...(body.runtime !== undefined ? { runtime: body.runtime } : {}),
           ...(body.record !== undefined ? { record: body.record } : {}),
           ...(body.provision === true ? { provision: true as const } : {}),
-          ...(body.stdinBase64 !== undefined
-            ? { stdin: new Uint8Array(Buffer.from(body.stdinBase64, 'base64')) }
-            : {}),
+          ...(stdin !== undefined ? { stdin } : {}),
           signal,
         }),
       )


### PR DESCRIPTION
Saving large command output through the daemon failed when base64-encoded stdin exceeded the JSON request limit. The TypeScript execute endpoint now accepts multipart `request` and binary `stdin` parts, matching the existing Python transport for foreground and background execution. The CLI uses this upload path; existing JSON requests retain their current limit.

The large-pipe regression also exposed synchronous stdin reads failing with `EAGAIN` and immediate process exits truncating stdout. The CLI now reads stdin asynchronously and lets execute/job output drain while preserving command exit codes.

The daemon converts decoded stdin to a plain `Uint8Array` before runtime dispatch. Pyodide rejects Node `Buffer` values, including empty input; preserving that boundary fixes the runtime and CLI parity regressions. The large-I/O router tests use an explicit 30-second test timeout.

Validation:

- Full Python suite: 19,815 passed, 694 skipped, 1 expected failure; one warning from the existing short-key JWT rejection test.
- TypeScript daemon: 207 tests passed; CLI: 96 tests passed, including real daemon/CLI integration.
- Full cross-language CLI feature parity passed, including sessions, execution modes, versioning, and FUSE.
- Existing runtime CLI integration battery: 181 passed, 0 failed, 63 skipped for unavailable services and SDK-only cases; all previously failing Pyodide cases passed.
- CI now runs `integ/execute_stdin.py` against real Python and TypeScript daemons over HTTP: 800,008-byte and 1,200,008-byte grep results, foreground/background execution, RAM/disk mounts, saved SHA-256 checks, and empty/binary Python stdin through multipart and legacy JSON. The new check reproduced the Pyodide failure before normalization and passed afterward.
- Large and empty stdin coverage in Python and TypeScript, with RAM/disk mounts and foreground/background requests; malformed metadata is rejected before creating a job.
- Original 790,475-byte failing output and a 3,161,900-byte replay round-trip exactly on RAM and disk. A separate 1,280,000-byte payload containing every byte value also round-trips exactly.
- Server, CLI, and integration harness TypeScript checks passed. The oversized-JSON control still returns HTTP 413.
- Repository-wide pre-commit passed with the documented Python extras and generated integration clients installed.
