### PR TITLE
Fix Pyodide capture cleanup when Python closes output streams

### DIFF
--- a/integ/runtime/local.json
+++ b/integ/runtime/local.json
@@ -22,6 +22,62 @@
           }
         }
       ]
+    },
+    {
+      "id": "closed_output_and_reuse",
+      "world": {
+        "runtimes": [
+          "local",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import sys; print('out'); sys.stderr.write('err'); sys.stdout.close(); sys.stderr.close(); assert sys.stdout.closed and sys.stderr.closed\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "out\n",
+            "stderr": "err"
+          }
+        },
+        {
+          "command": "python3 -c \"import sys; print('next'); sys.stderr.write('next err')\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "next\n",
+            "stderr": "next err"
+          }
+        },
+        {
+          "command": "python3 -c \"import sys; sys.stdout.buffer.write(b'binary'); sys.stdout.buffer.close()\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "binary",
+            "stderr": ""
+          }
+        },
+        {
+          "command": "python3 -c \"import sys; print('before exit'); sys.stdout.close(); sys.stderr.close(); sys.exit(7)\"",
+          "expect": {
+            "exit": 7,
+            "stdout": "before exit\n",
+            "stderr": ""
+          }
+        },
+        {
+          "command": "python3 -c \"print('after exit')\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "after exit\n",
+            "stderr": ""
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/runtime/monty.json
+++ b/integ/runtime/monty.json
@@ -808,6 +808,33 @@
           }
         }
       ]
+    },
+    {
+      "id": "output_survives_failure_and_reuse",
+      "world": {
+        "runtimes": [
+          "monty",
+          "vfs"
+        ]
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"print('before failure'); raise ValueError('original failure')\"",
+          "expect": {
+            "exit": 1,
+            "stdout": "before failure\n",
+            "stderr_contains": "original failure"
+          }
+        },
+        {
+          "command": "python3 -c \"print('next')\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "next\n",
+            "stderr": ""
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/runtime/pyodide.json
+++ b/integ/runtime/pyodide.json
@@ -1050,6 +1050,135 @@
           }
         }
       ]
+    },
+    {
+      "id": "closed_output_and_reuse",
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import sys; print('out'); sys.stderr.write('err'); sys.stdout.close(); sys.stderr.close(); assert sys.stdout.closed and sys.stderr.closed\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "out\n",
+            "stderr": "err"
+          }
+        },
+        {
+          "command": "python3 -c \"import sys; print('next'); sys.stderr.write('next err')\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "next\n",
+            "stderr": "next err"
+          }
+        },
+        {
+          "command": "python3 -c \"import sys; sys.stdout.buffer.write(b'binary'); sys.stdout.detach().close()\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "binary",
+            "stderr": ""
+          }
+        },
+        {
+          "command": "python3 -c \"import sys; print('before exit'); sys.stdout.close(); sys.stderr.close(); sys.exit(7)\"",
+          "expect": {
+            "exit": 7,
+            "stdout": "before exit\n",
+            "stderr": ""
+          }
+        },
+        {
+          "command": "python3 -c \"print('after exit')\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "after exit\n",
+            "stderr": ""
+          }
+        }
+      ],
+      "hosts": [
+        "typescript"
+      ]
+    },
+    {
+      "id": "json_tool_closes_output",
+      "hosts": [
+        "typescript"
+      ],
+      "world": {
+        "runtimes": [
+          "pyodide",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram",
+            "files": {
+              "input.json": "{\"value\":1}"
+            }
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -m json.tool /ram/input.json",
+          "expect": {
+            "exit": 0,
+            "stdout": "{\n    \"value\": 1\n}\n",
+            "stderr": ""
+          }
+        },
+        {
+          "command": "cat /ram/input.json | python3 -m json.tool",
+          "expect": {
+            "exit": 0,
+            "stdout": "{\n    \"value\": 1\n}\n",
+            "stderr": ""
+          }
+        },
+        {
+          "command": "python3 -m json.tool /ram/input.json > /ram/formatted.json",
+          "expect": {
+            "exit": 0,
+            "stdout": "",
+            "stderr": ""
+          }
+        },
+        {
+          "command": "cat /ram/formatted.json",
+          "expect": {
+            "exit": 0,
+            "stdout": "{\n    \"value\": 1\n}\n",
+            "stderr": ""
+          }
+        },
+        {
+          "command": "python3 -c \"import sys; sys.stdin.close(); print('still works')\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "still works\n",
+            "stderr": ""
+          }
+        },
+        {
+          "command": "echo reused | python3 -c \"import sys; print(sys.stdin.read(), end='')\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "reused\n",
+            "stderr": ""
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/runtime/quickjs.json
+++ b/integ/runtime/quickjs.json
@@ -636,6 +636,33 @@
           }
         }
       ]
+    },
+    {
+      "id": "output_survives_failure_and_reuse",
+      "world": {
+        "runtimes": [
+          "quickjs",
+          "vfs"
+        ]
+      },
+      "steps": [
+        {
+          "command": "js -e \"console.log('before failure'); throw new Error('original failure')\"",
+          "expect": {
+            "exit": 1,
+            "stdout": "before failure\n",
+            "stderr_contains": "original failure"
+          }
+        },
+        {
+          "command": "js -e \"console.log('next')\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "next\n",
+            "stderr": ""
+          }
+        }
+      ]
     }
   ]
 }

--- a/integ/runtime/wasi.json
+++ b/integ/runtime/wasi.json
@@ -605,6 +605,65 @@
           }
         }
       ]
+    },
+    {
+      "id": "closed_output_and_reuse",
+      "world": {
+        "runtimes": [
+          "wasi",
+          "vfs"
+        ],
+        "mounts": {
+          "/ram": {
+            "resource": "ram"
+          }
+        }
+      },
+      "steps": [
+        {
+          "command": "python3 -c \"import sys; print('out'); sys.stderr.write('err'); sys.stdout.close(); sys.stderr.close(); assert sys.stdout.closed and sys.stderr.closed\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "out\n",
+            "stderr": "err"
+          }
+        },
+        {
+          "command": "python3 -c \"import sys; print('next'); sys.stderr.write('next err')\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "next\n",
+            "stderr": "next err"
+          }
+        },
+        {
+          "command": "python3 -c \"import sys; sys.stdout.buffer.write(b'binary'); sys.stdout.buffer.close()\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "binary",
+            "stderr": ""
+          }
+        },
+        {
+          "command": "python3 -c \"import sys; print('before exit'); sys.stdout.close(); sys.stderr.close(); sys.exit(7)\"",
+          "expect": {
+            "exit": 7,
+            "stdout": "before exit\n",
+            "stderr": ""
+          }
+        },
+        {
+          "command": "python3 -c \"print('after exit')\"",
+          "expect": {
+            "exit": 0,
+            "stdout": "after exit\n",
+            "stderr": ""
+          }
+        }
+      ],
+      "hosts": [
+        "python"
+      ]
     }
   ]
 }

--- a/typescript/packages/core/src/runtime/python/pyodide/execution.test.ts
+++ b/typescript/packages/core/src/runtime/python/pyodide/execution.test.ts
@@ -20,6 +20,105 @@ import { PrefixResolver } from '../../resolver.ts'
 import { loadPyodideRuntime } from './loader.ts'
 import { PyodideExecution } from './execution.ts'
 describe('Python guest module', { timeout: 120_000 }, () => {
+  it('restores process globals after closing output and reporting SystemExit', async () => {
+    const pyodide = await loadPyodideRuntime()
+    const guest = new PyodideExecution(pyodide)
+    pyodide.runPython(`
+import os, sys, warnings
+def process_state():
+    return (dict(os.environ), list(sys.path), list(sys.argv), os.getcwd(),
+            sys.dont_write_bytecode, dict(sys._xoptions), list(warnings.filters),
+            sys.stdin, sys.stdout, sys.stderr)
+saved_state = process_state()
+`)
+    try {
+      const result = guest.run(
+        {
+          code: "import os, sys; os.environ['CHANGED'] = '1'; sys.path.append('/changed'); os.chdir('/tmp'); print('saved'); sys.stdout.close(); sys.stderr.close(); sys.exit('original exit')",
+          argv: ['probe'],
+          cwd: '/',
+          flags: { B: true, X: ['probe=1'], W: ['ignore'] },
+          script_cli: false,
+          env: {},
+          stdin: null,
+        },
+        () => undefined,
+        () => undefined,
+      )
+      expect(result[2]).toBe(1)
+      expect(new TextDecoder().decode(result[0])).toBe('saved\n')
+      expect(new TextDecoder().decode(result[1])).toBe('original exit\n')
+      expect(pyodide.runPython('process_state() == saved_state')).toBe(true)
+    } finally {
+      guest.close()
+    }
+  })
+
+  it('preserves closed and detached output in run, eval and REPL and restores streams', async () => {
+    const pyodide = await loadPyodideRuntime()
+    const guest = new PyodideExecution(pyodide)
+    const decode = (data: Uint8Array) => new TextDecoder().decode(data)
+    pyodide.runPython('import sys; saved_streams = (sys.stdin, sys.stdout, sys.stderr)')
+    try {
+      for (const mode of ['run', 'eval', 'repl']) {
+        for (const operation of [
+          'sys.stdout.close(); sys.stderr.close()',
+          'sys.stdout.buffer.close(); sys.stderr.buffer.close()',
+          'sys.stdout.detach().close(); sys.stderr.detach().close()',
+          'sys.stdout = None; sys.stderr = None',
+          "sys.stdout.reconfigure(write_through=False, line_buffering=False); sys.stdout.write('buffered')",
+        ]) {
+          const code = `import sys; print('out'); sys.stderr.write('err'); ${operation}`
+          let stdout: Uint8Array
+          let stderr: Uint8Array
+          if (mode === 'run') {
+            const result = guest.run(
+              { code, argv: [], cwd: '', flags: {}, script_cli: false, env: {}, stdin: null },
+              () => undefined,
+              () => undefined,
+            )
+            expect(result[2]).toBe(0)
+            ;[stdout, stderr] = result
+          } else if (mode === 'eval') {
+            const result = guest.evaluate(`${code}; None`, {})
+            expect(result[3]).toBe(true)
+            ;[, stdout, stderr] = result
+          } else {
+            // An exec statement avoids REPL displayhook output for write()'s return value.
+            const result = guest.repl(`exec(${JSON.stringify(code)})`, 'streams', {})
+            expect(result[2]).toBe(0)
+            ;[stdout, stderr] = result
+          }
+          expect(decode(stdout)).toBe(`out\n${operation.includes('reconfigure') ? 'buffered' : ''}`)
+          expect(decode(stderr)).toBe('err')
+          expect(pyodide.runPython('saved_streams == (sys.stdin, sys.stdout, sys.stderr)')).toBe(
+            true,
+          )
+          expect(decode(guest.evaluate("print('next')", {})[1])).toBe('next\n')
+        }
+      }
+      for (const code of [
+        "import sys; sys.stderr.close(); raise ValueError('original failure')",
+        "import sys; sys.stderr.detach(); raise ValueError('original failure')",
+      ]) {
+        const result = guest.evaluate(code, {})
+        expect(result[3]).toBe(false)
+        expect(decode(result[2])).toContain('ValueError: original failure')
+      }
+      const binary = guest.evaluate(
+        'import sys; sys.stdout.buffer.write(bytes([0, 255])); sys.stdout.close()',
+        {},
+      )
+      expect([...binary[1]]).toEqual([0, 255])
+      expect(binary[3]).toBe(true)
+      const closed = guest.evaluate("import sys; sys.stdout.close(); print('refused')", {})
+      expect(closed[3]).toBe(false)
+      expect(decode(closed[2])).toContain('ValueError: I/O operation on closed file')
+    } finally {
+      guest.close()
+    }
+  })
+
   it('releases converted arguments and keeps helper globals outside guest programs', async () => {
     const pyodide = await loadPyodideRuntime()
     const toPy = pyodide.toPy

--- a/typescript/packages/core/src/runtime/python/pyodide/py/execution.py
+++ b/typescript/packages/core/src/runtime/python/pyodide/py/execution.py
@@ -10,6 +10,44 @@ import sys
 import traceback
 import warnings
 
+
+class OutputCapture(io.RawIOBase):
+
+    def __init__(self):
+        super().__init__()
+        self.data = bytearray()
+        self.text = io.TextIOWrapper(self,
+                                     encoding='utf-8',
+                                     errors='replace',
+                                     write_through=True,
+                                     line_buffering=True)
+
+    def writable(self):
+        return True
+
+    def write(self, data):
+        self._checkClosed()
+        self.data.extend(data)
+        return len(data)
+
+    def diagnostic(self, text):
+        # Host diagnostics remain available even after the guest closes stderr.
+        if self.text.buffer is not None and not self.text.closed:
+            self.text.flush()
+        self.data.extend(text.encode('utf-8', errors='replace'))
+
+    def __exit__(self, *exc):
+        try:
+            # A guest may reconfigure buffering, close, or detach the wrapper.
+            if self.text.buffer is not None and not self.text.closed:
+                self.text.close()
+        finally:
+            self.close()
+
+    def getvalue(self):
+        return bytes(self.data)
+
+
 repl_session_globals = {}
 
 
@@ -38,18 +76,10 @@ def run(request, arm_interrupt, disarm_interrupt):
     saved_stderr = sys.stderr
     saved_argv = sys.argv
 
-    out_bytes = io.BytesIO()
-    err_bytes = io.BytesIO()
-    out_text = io.TextIOWrapper(out_bytes,
-                                encoding='utf-8',
-                                errors='replace',
-                                write_through=True,
-                                line_buffering=True)
-    err_text = io.TextIOWrapper(err_bytes,
-                                encoding='utf-8',
-                                errors='replace',
-                                write_through=True,
-                                line_buffering=True)
+    out_bytes = OutputCapture()
+    err_bytes = OutputCapture()
+    out_text = out_bytes.text
+    err_text = err_bytes.text
 
     stdin_buf = io.BytesIO(
         bytes(stdin_bytes) if stdin_bytes is not None else b'')
@@ -64,128 +94,122 @@ def run(request, arm_interrupt, disarm_interrupt):
     saved_xop = dict(sys._xoptions)
     saved_filters = None
 
-    exit_code = 0
-    try:
-        os.environ.clear()
-        os.environ.update(merged_env)
-        if flags.get('B'):
-            sys.dont_write_bytecode = True
-        for xopt in flags.get('X') or []:
-            name, _, value = str(xopt).partition('=')
-            sys._xoptions[name] = value if value else True
-        if flags.get('W'):
-            saved_filters = warnings.filters[:]
-            for spec in flags.get('W') or []:
-                try:
-                    warnings._setoption(str(spec))
-                except warnings._OptionError as werr:
-                    err_text.write(f'Invalid -W option ignored: {werr}\n')
-        sys.stdin = stdin_text
-        sys.stdout = out_text
-        sys.stderr = err_text
-        sys.argv = list(argv)
-        user_globals = {}
-        if script_cli:
-            user_globals.update(
-                argv=list(argv),
-                stdin=bytes(stdin_bytes) if stdin_bytes is not None else None)
+    with out_bytes, err_bytes:
+        exit_code = 0
         try:
+            os.environ.clear()
+            os.environ.update(merged_env)
+            if flags.get('B'):
+                sys.dont_write_bytecode = True
+            for xopt in flags.get('X') or []:
+                name, _, value = str(xopt).partition('=')
+                sys._xoptions[name] = value if value else True
+            if flags.get('W'):
+                saved_filters = warnings.filters[:]
+                for spec in flags.get('W') or []:
+                    try:
+                        warnings._setoption(str(spec))
+                    except warnings._OptionError as werr:
+                        err_bytes.diagnostic(
+                            f'Invalid -W option ignored: {werr}\n')
+            sys.stdin = stdin_text
+            sys.stdout = out_text
+            sys.stderr = err_text
+            sys.argv = list(argv)
+            user_globals = {}
+            if script_cli:
+                user_globals.update(argv=list(argv),
+                                    stdin=bytes(stdin_bytes)
+                                    if stdin_bytes is not None else None)
             try:
-                arm_interrupt()
-                if cwd != '':
-                    saved_chdir(cwd)
-                exec(compile(user_code, '<string>', 'exec', optimize=optimize),
-                     user_globals)
-            finally:
-                disarm_interrupt()
-        except SystemExit as e:
-            code = e.code
-            if code is None:
-                exit_code = 0
-            elif isinstance(code, bool):
-                exit_code = int(code)
-            elif isinstance(code, int):
-                exit_code = code
-            else:
-                err_text.write(str(code) + '\n')
+                try:
+                    arm_interrupt()
+                    if cwd != '':
+                        saved_chdir(cwd)
+                    exec(
+                        compile(user_code,
+                                '<string>',
+                                'exec',
+                                optimize=optimize), user_globals)
+                finally:
+                    disarm_interrupt()
+            except SystemExit as e:
+                code = e.code
+                if code is None:
+                    exit_code = 0
+                elif isinstance(code, bool):
+                    exit_code = int(code)
+                elif isinstance(code, int):
+                    exit_code = code
+                else:
+                    err_bytes.diagnostic(str(code) + '\n')
+                    exit_code = 1
+            except BaseException:
+                err_bytes.diagnostic(traceback.format_exc())
                 exit_code = 1
-        except BaseException:
-            traceback.print_exc(file=err_text)
-            exit_code = 1
-    finally:
-        out_text.flush()
-        err_text.flush()
-        os.environ.clear()
-        os.environ.update(saved_env)
-        sys.path[:] = saved_path
-        sys.dont_write_bytecode = saved_dwb
-        sys._xoptions.clear()
-        sys._xoptions.update(saved_xop)
-        if saved_filters is not None:
-            warnings.filters[:] = saved_filters
-            warnings._filters_mutated()
-        sys.stdin = saved_stdin
-        sys.stdout = saved_stdout
-        sys.stderr = saved_stderr
-        sys.argv = saved_argv
-        os.chdir = saved_chdir
-        os.getcwd = saved_getcwd
-        saved_chdir(saved_cwd)
+        finally:
+            os.environ.clear()
+            os.environ.update(saved_env)
+            sys.path[:] = saved_path
+            sys.dont_write_bytecode = saved_dwb
+            sys._xoptions.clear()
+            sys._xoptions.update(saved_xop)
+            if saved_filters is not None:
+                warnings.filters[:] = saved_filters
+                warnings._filters_mutated()
+            sys.stdin = saved_stdin
+            sys.stdout = saved_stdout
+            sys.stderr = saved_stderr
+            sys.argv = saved_argv
+            os.chdir = saved_chdir
+            os.getcwd = saved_getcwd
+            saved_chdir(saved_cwd)
 
     return (out_bytes.getvalue(), err_bytes.getvalue(), exit_code)
 
 
 def evaluate(user_code, eval_inputs):
-    out_bytes = io.BytesIO()
-    err_bytes = io.BytesIO()
-    out_text = io.TextIOWrapper(out_bytes,
-                                encoding='utf-8',
-                                errors='replace',
-                                write_through=True,
-                                line_buffering=True)
-    err_text = io.TextIOWrapper(err_bytes,
-                                encoding='utf-8',
-                                errors='replace',
-                                write_through=True,
-                                line_buffering=True)
+    out_bytes = OutputCapture()
+    err_bytes = OutputCapture()
+    out_text = out_bytes.text
+    err_text = err_bytes.text
 
-    ok = True
-    syntax = False
-    value_json = 'null'
-    try:
-        tree = ast.parse(user_code)
-    except SyntaxError:
-        ok = False
-        syntax = True
-        traceback.print_exc(file=err_text)
-    else:
-        last = None
-        if tree.body and isinstance(tree.body[-1], ast.Expr):
-            last = ast.Expression(tree.body[-1].value)
-            tree.body = tree.body[:-1]
-        g = dict(eval_inputs)
-        g.setdefault('__builtins__', __builtins__)
-        saved_stdout, saved_stderr = sys.stdout, sys.stderr
-        sys.stdout, sys.stderr = out_text, err_text
+    with out_bytes, err_bytes:
+        ok = True
+        syntax = False
+        value_json = 'null'
         try:
-            exec(compile(tree, '<eval>', 'exec'), g)
-            value = None
-            if last is not None:
-                value = eval(compile(last, '<eval>', 'eval'), g)
-            try:
-                value_json = json.dumps(value, default=eval_enc)
-            except TypeError:
-                ok = False
-                err_text.write(
-                    'eval: result of type %s is not JSON-serializable\n' %
-                    type(value).__name__)
-        except BaseException:
+            tree = ast.parse(user_code)
+        except SyntaxError:
             ok = False
-            traceback.print_exc(file=err_text)
-        finally:
-            out_text.flush()
-            err_text.flush()
-            sys.stdout, sys.stderr = saved_stdout, saved_stderr
+            syntax = True
+            err_bytes.diagnostic(traceback.format_exc())
+        else:
+            last = None
+            if tree.body and isinstance(tree.body[-1], ast.Expr):
+                last = ast.Expression(tree.body[-1].value)
+                tree.body = tree.body[:-1]
+            g = dict(eval_inputs)
+            g.setdefault('__builtins__', __builtins__)
+            saved_stdout, saved_stderr = sys.stdout, sys.stderr
+            sys.stdout, sys.stderr = out_text, err_text
+            try:
+                exec(compile(tree, '<eval>', 'exec'), g)
+                value = None
+                if last is not None:
+                    value = eval(compile(last, '<eval>', 'eval'), g)
+                try:
+                    value_json = json.dumps(value, default=eval_enc)
+                except TypeError:
+                    ok = False
+                    err_bytes.diagnostic(
+                        'eval: result of type %s is not JSON-serializable\n' %
+                        type(value).__name__)
+            except BaseException:
+                ok = False
+                err_bytes.diagnostic(traceback.format_exc())
+            finally:
+                sys.stdout, sys.stderr = saved_stdout, saved_stderr
 
     return (value_json, out_bytes.getvalue(), err_bytes.getvalue(), ok, syntax)
 
@@ -205,64 +229,55 @@ def repl(user_code, repl_session_id, repl_inputs):
     repl_globals = repl_session_globals[sid]
     repl_globals.update(dict(repl_inputs))
 
-    out_bytes = io.BytesIO()
-    err_bytes = io.BytesIO()
-    out_text = io.TextIOWrapper(out_bytes,
-                                encoding='utf-8',
-                                errors='replace',
-                                write_through=True,
-                                line_buffering=True)
-    err_text = io.TextIOWrapper(err_bytes,
-                                encoding='utf-8',
-                                errors='replace',
-                                write_through=True,
-                                line_buffering=True)
+    out_bytes = OutputCapture()
+    err_bytes = OutputCapture()
+    out_text = out_bytes.text
+    err_text = err_bytes.text
 
-    status = 'complete'
-    exit_code = 0
-    codeobj = None
+    with out_bytes, err_bytes:
+        status = 'complete'
+        exit_code = 0
+        codeobj = None
 
-    try:
-        codeobj = codeop.compile_command(user_code, '<repl>', 'single')
-    except (SyntaxError, ValueError, OverflowError):
-        traceback.print_exc(file=err_text)
-        exit_code = 1
-        codeobj = False
-
-    if codeobj is None:
-        status = 'incomplete'
-    elif codeobj is not False:
-        saved_stdout = sys.stdout
-        saved_stderr = sys.stderr
-        saved_stdin = sys.stdin
-        sys.stdout = out_text
-        sys.stderr = err_text
-        sys.stdin = io.TextIOWrapper(io.BytesIO(b''),
-                                     encoding='utf-8',
-                                     errors='replace')
         try:
-            exec(codeobj, repl_globals)
-        except SystemExit as e:
-            code = e.code
-            if code is None:
-                exit_code = 0
-            elif isinstance(code, bool):
-                exit_code = int(code)
-            elif isinstance(code, int):
-                exit_code = code
-            else:
-                err_text.write(str(code) + '\n')
-                exit_code = 1
-            status = 'exit'
-        except BaseException:
-            traceback.print_exc(file=err_text)
+            codeobj = codeop.compile_command(user_code, '<repl>', 'single')
+        except (SyntaxError, ValueError, OverflowError):
+            err_bytes.diagnostic(traceback.format_exc())
             exit_code = 1
-        finally:
-            out_text.flush()
-            err_text.flush()
-            sys.stdout = saved_stdout
-            sys.stderr = saved_stderr
-            sys.stdin = saved_stdin
+            codeobj = False
+
+        if codeobj is None:
+            status = 'incomplete'
+        elif codeobj is not False:
+            saved_stdout = sys.stdout
+            saved_stderr = sys.stderr
+            saved_stdin = sys.stdin
+            sys.stdout = out_text
+            sys.stderr = err_text
+            sys.stdin = io.TextIOWrapper(io.BytesIO(b''),
+                                         encoding='utf-8',
+                                         errors='replace')
+            try:
+                exec(codeobj, repl_globals)
+            except SystemExit as e:
+                code = e.code
+                if code is None:
+                    exit_code = 0
+                elif isinstance(code, bool):
+                    exit_code = int(code)
+                elif isinstance(code, int):
+                    exit_code = code
+                else:
+                    err_bytes.diagnostic(str(code) + '\n')
+                    exit_code = 1
+                status = 'exit'
+            except BaseException:
+                err_bytes.diagnostic(traceback.format_exc())
+                exit_code = 1
+            finally:
+                sys.stdout = saved_stdout
+                sys.stderr = saved_stderr
+                sys.stdin = saved_stdin
 
     return (out_bytes.getvalue(), err_bytes.getvalue(), exit_code, status)
 

--- a/typescript/packages/node/src/workspace/pyodide_streams.test.ts
+++ b/typescript/packages/node/src/workspace/pyodide_streams.test.ts
@@ -1,0 +1,44 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { MountMode } from '@struktoai/mirage-core/types'
+import { RAMResource } from '@struktoai/mirage-core/resource/ram/ram'
+import { DiskResource } from '../resource/disk/disk.ts'
+import { Workspace } from '../workspace.ts'
+
+interface StreamCase {
+  id: string
+  world: { mounts: { '/ram': { files: Record<string, string> } } }
+  steps: { command: string; expect: { exit: number; stdout: string; stderr: string } }[]
+}
+
+describe('Pyodide captured streams', { timeout: 120_000 }, () => {
+  it.each(['ram', 'disk'])('runs the json.tool integration on a %s mount', async (kind) => {
+    const suite = JSON.parse(
+      await readFile(new URL('../../../../../integ/runtime/pyodide.json', import.meta.url), 'utf8'),
+    ) as { cases: StreamCase[] }
+    const fixture = suite.cases.find((testCase) => testCase.id === 'json_tool_closes_output')
+    if (fixture === undefined) throw new Error('Missing json.tool integration fixture')
+    const root = await mkdtemp(join(tmpdir(), 'mirage-streams-'))
+    const resource = kind === 'disk' ? new DiskResource({ root }) : new RAMResource()
+    const ws = new Workspace(
+      { '/ram': resource },
+      { mode: MountMode.EXEC, runtimes: ['pyodide', 'vfs'] },
+    )
+    try {
+      for (const [name, content] of Object.entries(fixture.world.mounts['/ram'].files)) {
+        await ws.dispatch('write', `/ram/${name}`, [new TextEncoder().encode(content)])
+      }
+      for (const step of fixture.steps) {
+        const result = await ws.execute(step.command)
+        expect(result.exitCode, step.command).toBe(step.expect.exit)
+        expect(new TextDecoder().decode(result.stdout), step.command).toBe(step.expect.stdout)
+        expect(new TextDecoder().decode(result.stderr), step.command).toBe(step.expect.stderr)
+      }
+    } finally {
+      await ws.close()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
Fixes #1057.

Preserve captured bytes when Python closes or detaches stdout/stderr. Run, eval, and REPL share the capture implementation; process globals restore before capture finalization, and closing stderr no longer hides the original exception or SystemExit message.

Integration coverage includes `json.tool` on RAM/disk, pipes, redirection, binary output, stream closing, and reuse. Native Python and WASI cover closing; Monty and QuickJS cover preserving output across failures.

Validation: 127 integration cases across Python/TypeScript; 157 Pyodide/workspace tests; Python runtime tests; core/node builds and typechecks; layout parity and pre-commit hooks passed.
